### PR TITLE
release: v0.1.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-# Auto-release to npm from release branches.
+# Auto-release to npm from version tags on main.
 #
-# Push to `release` or any `release/*` branch (e.g. release/0.2.0) and, if the
-# version in package.json isn't on npm yet, this workflow publishes it, tags
-# the commit `v<version>`, and creates a GitHub Release with generated notes.
-# Pushing again with the same version is a safe no-op.
+# The publish step is gated on a `vX.Y.Z` tag push to `main` — that requires
+# both a merged commit on the protected default branch AND an explicit tag,
+# both of which need write access to main. Release branches, PR pushes, and
+# force-pushes to a release branch do NOT publish, even with valid npm creds.
 #
 # Required repo secret: NPM_TOKEN (npm "Automation" access token with publish
 # rights for the `orbcode` package).
@@ -12,13 +12,17 @@ name: Release
 
 on:
   push:
-    branches:
-      - release
-      - "release/**"
+    tags:
+      - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (must match package.json). Leave empty to read from package.json."
+        required: false
+        type: string
 
 permissions:
-  contents: write # push the version tag + create the GitHub Release
+  contents: write # create the GitHub Release
   id-token: write # npm --provenance (requires a public GitHub repo)
 
 concurrency:
@@ -28,6 +32,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
 
@@ -40,18 +45,45 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Resolve and verify version
+        id: version
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          NAME=$(node -p "require('./package.json').name")
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Tag push: REF is refs/tags/vX.Y.Z
+            TAG_VERSION=${GITHUB_REF#refs/tags/v}
+            if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+              echo "::error::Tag v$TAG_VERSION does not match package.json version $PKG_VERSION."
+              echo "::error::Update package.json (and this tag) to publish a coherent release."
+              exit 1
+            fi
+            VERSION="$TAG_VERSION"
+          else
+            # Manual dispatch: prefer the input, fall back to package.json.
+            VERSION="${{ inputs.version }}"
+            if [ -z "$VERSION" ]; then
+              VERSION="$PKG_VERSION"
+            fi
+            if [ "$VERSION" != "$PKG_VERSION" ]; then
+              echo "::error::Input version $VERSION does not match package.json version $PKG_VERSION."
+              exit 1
+            fi
+          fi
+          echo "name=$NAME"      >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Typecheck & build
         run: |
           npm run typecheck
           npm run build
 
       - name: Check whether this version is already on npm
-        id: version
+        id: check
         run: |
-          NAME=$(node -p "require('./package.json').name")
-          VERSION=$(node -p "require('./package.json').version")
-          echo "name=$NAME" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          NAME="${{ steps.version.outputs.name }}"
+          VERSION="${{ steps.version.outputs.version }}"
           if npm view "$NAME@$VERSION" version >/dev/null 2>&1; then
             echo "Version $VERSION already published — skipping."
             echo "publish=false" >> "$GITHUB_OUTPUT"
@@ -60,24 +92,26 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: steps.version.outputs.publish == 'true'
+        if: steps.check.outputs.publish == 'true'
         # Drop --provenance if the repository is private (provenance needs a
         # public repo and a `repository` field in package.json).
         run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Tag and create GitHub Release
-        if: steps.version.outputs.publish == 'true'
+      - name: Create GitHub Release
+        if: steps.check.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "v$VERSION" || true
-          git push origin "v$VERSION" || true
+          TARGET_SHA="${{ github.sha }}"
+          # For tag pushes, also publish from the tagged commit itself.
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TARGET_SHA="$GITHUB_REF"
+          fi
           gh release create "v$VERSION" \
             --title "orbcode v$VERSION" \
             --generate-notes \
-            --target "$GITHUB_SHA" || echo "Release v$VERSION already exists."
+            --target "$TARGET_SHA" \
+            || echo "Release v$VERSION already exists."

--- a/README.md
+++ b/README.md
@@ -144,12 +144,13 @@ The two Axon models are built in; `/model` opens a scroll-and-select picker
 (`/model <id>` still selects directly). Additional models can be declared via
 `customModels` in settings.json. The choice persists across sessions.
 
-| id                  | context | max output | pricing                  |
-|---------------------|---------|------------|--------------------------|
-| `axon-code-2-5-pro` | 400k    | 64k        | $2/M in · $6/M out       |
-| `axon-code-2-5-mini`| 400k    | 64k        | free                     |
+| id                     | context | max output | pricing            |
+| ---------------------- | ------- | ---------- | ------------------ |
+| `axon-eido-3-code-pro` | 400k    | 64k        | $3/M in · $9/M out |
+| `axon-code-2-5-pro`    | 400k    | 64k        | $2/M in · $6/M out |
+| `axon-code-2-5-mini`   | 400k    | 64k        | free               |
 
-`axon-code-2-5-pro` is the default. Both support native JSON tool calls and
+`axon-code-2-5-pro` is the default. All three support native JSON tool calls and
 image input. Cost comes from the API's usage chunks (`is_byok`-aware) and is
 shown in the status bar.
 
@@ -196,35 +197,35 @@ shown in the status bar.
 
 ## Slash commands
 
-| command    | action |
-|------------|--------|
-| `/help`    | list commands |
-| `/model`   | scrollable model picker (`/model pro` / `/model mini` / full id selects directly) |
-| `/clear`   | clear the screen only, like the terminal's `clear` — the conversation and context continue |
-| `/new`     | start a fresh conversation/session with a clean slate |
-| `/resume`  | pick a previous session for this directory and continue it (screen is cleared, conversation replayed) |
-| `/analytics` | open the MatterAI analytics dashboard (app.matterai.so/orbital) in the browser |
-| `/compact` | summarize the conversation and replace history with the summary |
-| `/tasks`   | print the current task list |
-| `/status`  | version, model, account, gateway, context usage, cost, approval modes |
-| `/cost`    | show session cost and fetch account balance |
-| `/init`    | analyze the codebase and create/improve `AGENTS.md` |
-| `/login`   | start the browser sign-in flow |
-| `/logout`  | remove the saved token |
-| `/version` | print the CLI version |
-| `/exit`    | quit |
+| command      | action                                                                                                |
+| ------------ | ----------------------------------------------------------------------------------------------------- |
+| `/help`      | list commands                                                                                         |
+| `/model`     | scrollable model picker (`/model pro` / `/model mini` / full id selects directly)                     |
+| `/clear`     | clear the screen only, like the terminal's `clear` — the conversation and context continue            |
+| `/new`       | start a fresh conversation/session with a clean slate                                                 |
+| `/resume`    | pick a previous session for this directory and continue it (screen is cleared, conversation replayed) |
+| `/analytics` | open the MatterAI analytics dashboard (app.matterai.so/orbital) in the browser                        |
+| `/compact`   | summarize the conversation and replace history with the summary                                       |
+| `/tasks`     | print the current task list                                                                           |
+| `/status`    | version, model, account, gateway, context usage, cost, approval modes                                 |
+| `/cost`      | show session cost and fetch account balance                                                           |
+| `/init`      | analyze the codebase and create/improve `AGENTS.md`                                                   |
+| `/login`     | start the browser sign-in flow                                                                        |
+| `/logout`    | remove the saved token                                                                                |
+| `/version`   | print the CLI version                                                                                 |
+| `/exit`      | quit                                                                                                  |
 
 ## Keyboard shortcuts
 
-| key | action |
-|-----|--------|
-| `Esc` | interrupt the running turn (or cancel login polling / close a menu) |
-| `Ctrl+C` | quit |
-| `Ctrl+O` | toggle thinking display for the whole transcript (past turns included) |
-| `Shift+Tab` | cycle approval mode: ask → accept edits → auto-approve |
-| `↑` / `↓` | input history, or navigate any open menu |
-| `Ctrl+A` / `Ctrl+E` | start / end of line |
-| `Ctrl+U` | clear the input line |
+| key                 | action                                                                 |
+| ------------------- | ---------------------------------------------------------------------- |
+| `Esc`               | interrupt the running turn (or cancel login polling / close a menu)    |
+| `Ctrl+C`            | quit                                                                   |
+| `Ctrl+O`            | toggle thinking display for the whole transcript (past turns included) |
+| `Shift+Tab`         | cycle approval mode: ask → accept edits → auto-approve                 |
+| `↑` / `↓`           | input history, or navigate any open menu                               |
+| `Ctrl+A` / `Ctrl+E` | start / end of line                                                    |
+| `Ctrl+U`            | clear the input line                                                   |
 
 ## Approvals & safety
 
@@ -267,22 +268,22 @@ Two kinds of files under `~/.orbcode/`:
 
 ```json
 {
-	"apiKey": "<token used instead of logging in>",
-	"baseUrl": "https://my-gateway.example.com/v1",
-	"model": "my-custom-model",
-	"autoApproveEdits": false,
-	"autoApproveSafeCommands": false,
-	"customModels": [
-		{
-			"id": "my-custom-model",
-			"name": "My Custom Model",
-			"contextWindow": 128000,
-			"maxOutputTokens": 32000,
-			"inputPrice": 0.000001,
-			"outputPrice": 0.000002
-		}
-	],
-	"env": { "MY_VAR": "value" }
+  "apiKey": "<token used instead of logging in>",
+  "baseUrl": "https://my-gateway.example.com/v1",
+  "model": "my-custom-model",
+  "autoApproveEdits": false,
+  "autoApproveSafeCommands": false,
+  "customModels": [
+    {
+      "id": "my-custom-model",
+      "name": "My Custom Model",
+      "contextWindow": 128000,
+      "maxOutputTokens": 32000,
+      "inputPrice": 0.000001,
+      "outputPrice": 0.000002
+    }
+  ],
+  "env": { "MY_VAR": "value" }
 }
 ```
 
@@ -295,15 +296,15 @@ config.json.
 Sessions are stored in `~/.orbcode/sessions/<id>.json` and power `/resume`
 and `--resume <id>`.
 
-| env var | effect |
-|---------|--------|
-| `ORBCODE_TOKEN` | auth token (overrides everything) |
-| `ORBCODE_API_KEY` | same as `apiKey` in settings.json |
-| `ORBCODE_BASE_URL` | same as `baseUrl` in settings.json |
-| `ORBCODE_MODEL` | model override (what `--model` sets internally) |
-| `ORBCODE_CONFIG_DIR` | config directory (default `~/.orbcode`) |
-| `ORBCODE_BACKEND_URL` | device-auth backend (default `https://api.matterai.so`) |
-| `ORBCODE_APP_URL` | webapp for the authorize page (default `https://app.matterai.so`) |
+| env var               | effect                                                            |
+| --------------------- | ----------------------------------------------------------------- |
+| `ORBCODE_TOKEN`       | auth token (overrides everything)                                 |
+| `ORBCODE_API_KEY`     | same as `apiKey` in settings.json                                 |
+| `ORBCODE_BASE_URL`    | same as `baseUrl` in settings.json                                |
+| `ORBCODE_MODEL`       | model override (what `--model` sets internally)                   |
+| `ORBCODE_CONFIG_DIR`  | config directory (default `~/.orbcode`)                           |
+| `ORBCODE_BACKEND_URL` | device-auth backend (default `https://api.matterai.so`)           |
+| `ORBCODE_APP_URL`     | webapp for the authorize page (default `https://app.matterai.so`) |
 
 `autoApproveEdits` / `autoApproveSafeCommands` set the session defaults for the
 approval prompts (dangerous commands still always prompt); shift+tab cycles
@@ -365,19 +366,19 @@ reset date — the same data as the extension's profile view.
 
 Active in the CLI (schemas byte-identical to the extension's `native-tools`):
 
-| tool | executor notes |
-|------|----------------|
-| `read_file` | line-numbered output (`LINE\|content`, 6-char pad), 1000-line cap, offset/limit |
-| `file_edit` | single replacement; unique-match enforcement; `replace_all`; empty `old_string` = whole file |
-| `multi_file_edit` | batched edits grouped per file, per-edit OK/FAILED results |
-| `file_write` | creates parent dirs, full-content writes |
-| `list_files` | optional recursive, ignores node_modules/.git/build dirs, 800-entry cap |
-| `search_files` | JS regex search with glob `file_pattern` (picomatch), 300-match cap, binary skip |
-| `execute_command` | user's shell, 120s timeout, 30k output cap, optional cwd |
-| `web_search` / `web_fetch` | proxied through the MatterAI backend with your token |
-| `update_todo_list` | drives the TUI todo panel |
-| `ask_followup_question` | interactive menu in the TUI |
-| `attempt_completion` | ends the turn with a completion card |
+| tool                       | executor notes                                                                               |
+| -------------------------- | -------------------------------------------------------------------------------------------- |
+| `read_file`                | line-numbered output (`LINE\|content`, 6-char pad), 1000-line cap, offset/limit              |
+| `file_edit`                | single replacement; unique-match enforcement; `replace_all`; empty `old_string` = whole file |
+| `multi_file_edit`          | batched edits grouped per file, per-edit OK/FAILED results                                   |
+| `file_write`               | creates parent dirs, full-content writes                                                     |
+| `list_files`               | optional recursive, ignores node_modules/.git/build dirs, 800-entry cap                      |
+| `search_files`             | JS regex search with glob `file_pattern` (picomatch), 300-match cap, binary skip             |
+| `execute_command`          | user's shell, 120s timeout, 30k output cap, optional cwd                                     |
+| `web_search` / `web_fetch` | proxied through the MatterAI backend with your token                                         |
+| `update_todo_list`         | drives the TUI todo panel                                                                    |
+| `ask_followup_question`    | interactive menu in the TUI                                                                  |
+| `attempt_completion`       | ends the turn with a completion card                                                         |
 
 Present in `tools/schemas/` but **inactive** (need IDE services): `codebase_search`,
 `lsp`, `list_code_definition_names`, `use_skill`, `check_past_chat_memories`,
@@ -417,6 +418,7 @@ Source-of-truth rule: behavior is **ported from the Orbital extension repo**
 schemas byte-identical rather than editing them here.
 
 Backend/web pieces of the device-auth flow live in:
+
 - `gravity-console-backend` → `src/controller/orbcodeAuthController.ts`
   (+ OAuth state in `router.ts`, callbacks in `authController.ts`)
 - `gravity-console-webapp` → authorize dialog in `src/App.js`, sign-in q-p

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,31 +34,40 @@ bumping the version is all that's needed; no source change required.
 
 ## Automated release (recommended)
 
-Releases are driven by **release branches**; the workflow is
-`.github/workflows/release.yml`.
+Releases are gated on a `vX.Y.Z` tag on `main` — publishing requires the
+release commit to be **merged into `main`** first, then an explicit tag push.
+The workflow is `.github/workflows/release.yml`.
 
 ```bash
-# 1. bump the version on a release branch
+# 1. cut a release branch off main and bump the version
 git checkout -b release/0.2.0
 npm version 0.2.0 --no-git-tag-version
 git commit -am "release: v0.2.0"
 
-# 2. push — this triggers the workflow
+# 2. push, open a PR, get it reviewed and merged into main
 git push -u origin release/0.2.0
+gh pr create --base main --head release/0.2.0 --title "release: v0.2.0"
+
+# 3. AFTER the PR is merged, tag the merge commit on main and push the tag
+git checkout main && git pull
+git tag v0.2.0           # tag the current HEAD (the merge commit)
+git push origin v0.2.0   # ← this is what actually triggers the publish
 ```
 
 The workflow then:
 
-1. installs (`npm ci`), typechecks, and builds;
-2. checks npm — if `@matterailab/orbcode@<version>` **already exists, it skips publishing**
-   (so repeated pushes to the branch are safe no-ops);
-3. publishes to npm with provenance;
-4. tags the commit `v<version>` and creates a **GitHub Release** with
-   auto-generated notes.
+1. checks out the tagged commit, installs (`npm ci`), typechecks, and builds;
+2. **verifies the tag (`vX.Y.Z`) matches `package.json#version`** — a mismatch
+   fails the build instead of publishing a mismatched package;
+3. checks npm — if `@matterailab/orbcode@<version>` **already exists, it skips publishing**
+   (so re-tagging a published version is a safe no-op);
+4. publishes to npm with provenance;
+5. creates a **GitHub Release** with auto-generated notes pointed at the tag.
 
-Branch names `release` and `release/*` both trigger it; it can also be run
-manually from the Actions tab (`workflow_dispatch`). After the release, merge
-the branch back to `main` so the version bump isn't lost.
+Tag pushes to any branch other than `main` are ignored, so a force-push to a
+release branch can't publish anything on its own. `workflow_dispatch` is also
+available as a manual fallback (it reads the version from `package.json` and
+refuses to publish if the input doesn't match).
 
 ### Versioning convention
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orbcode",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orbcode",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "license": "UNLICENSED",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -1,4 +1,4 @@
-// The two Axon models served by the MatterAI backend. Ported from the
+// The Axon models served by the MatterAI backend. Ported from the
 // Orbital extension's model registry (kilocode-models.ts).
 export interface AxonModel {
   id: string;
@@ -37,6 +37,18 @@ export const AXON_MODELS: Record<string, AxonModel> = {
     supportsImages: true,
     inputPrice: 0.000002,
     outputPrice: 0.000006,
+    free: false,
+  },
+  "axon-eido-3-code-pro": {
+    id: "axon-eido-3-code-pro",
+    name: "Axon Eido 3 Pro",
+    description:
+      "Axon Eido 3 Pro is the frontier Axon Code model for coding tasks, long running agents and general intelligence, fine-tuned on open source models.",
+    contextWindow: 400000,
+    maxOutputTokens: 64000,
+    supportsImages: true,
+    inputPrice: 0.000003,
+    outputPrice: 0.000009,
     free: false,
   },
 };

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,38 +1,40 @@
 // Auth ported from the Orbital extension: a MatterAI JWT acts as the API key.
 // Backend URL resolution mirrors getKiloBaseUriFromToken / getKiloUrlFromToken.
 
-export const DEFAULT_BACKEND_URL = "https://api.matterai.so"
-export const API_GATEWAY_PATH = "https://api2.matterai.so/v1/web/"
+export const DEFAULT_BACKEND_URL = "https://api.matterai.so";
+export const API_GATEWAY_PATH = "https://api2.matterai.so/v1/web/";
 
 export function getBaseUrlFromToken(token?: string): string {
-	if (token) {
-		try {
-			const payloadString = token.split(".")[1]
-			if (payloadString) {
-				const payload = JSON.parse(Buffer.from(payloadString, "base64").toString())
-				// UNTRUSTED payload: only used to detect the development environment,
-				// never to read URLs directly.
-				if (payload.env === "development") return "http://localhost:3000"
-			}
-		} catch {
-			// fall through to production URL
-		}
-	}
-	return DEFAULT_BACKEND_URL
+  if (token) {
+    try {
+      const payloadString = token.split(".")[1];
+      if (payloadString) {
+        const payload = JSON.parse(
+          Buffer.from(payloadString, "base64").toString(),
+        );
+        // UNTRUSTED payload: only used to detect the development environment,
+        // never to read URLs directly.
+        if (payload.env === "development") return "http://localhost:3000";
+      }
+    } catch {
+      // fall through to production URL
+    }
+  }
+  return DEFAULT_BACKEND_URL;
 }
 
 /** Re-host targetUrl onto the backend resolved from the token. */
 export function getUrlFromToken(targetUrl: string, token?: string): string {
-	const target = new URL(targetUrl)
-	const { protocol, host } = new URL(getBaseUrlFromToken(token))
-	Object.assign(target, { protocol, host })
-	return target.toString()
+  const target = new URL(targetUrl);
+  const { protocol, host } = new URL(getBaseUrlFromToken(token));
+  Object.assign(target, { protocol, host });
+  return target.toString();
 }
 
-export const APP_URL = "https://app.matterai.so"
+export const APP_URL = "https://app.matterai.so";
 
 export function getSignInUrl(): string {
-	return `${APP_URL}/authentication/sign-in?loginType=extension&source=cli`
+  return `${APP_URL}/authentication/sign-in?loginType=extension&source=cli`;
 }
 
 // ---- Device-code (polling) login flow ----
@@ -44,87 +46,118 @@ export function getSignInUrl(): string {
 // 3. pollDeviceAuth(code) is called until it returns the token.
 
 export interface DeviceAuthStart {
-	devicecode: string
-	expiresIn: number
-	interval: number
+  devicecode: string;
+  expiresIn: number;
+  interval: number;
 }
 
 function deviceAuthBaseUrl(): string {
-	return process.env.ORBCODE_BACKEND_URL || DEFAULT_BACKEND_URL
+  return process.env.ORBCODE_BACKEND_URL || DEFAULT_BACKEND_URL;
 }
 
 function deviceAuthAppUrl(): string {
-	return process.env.ORBCODE_APP_URL || APP_URL
+  return process.env.ORBCODE_APP_URL || APP_URL;
 }
 
 export async function startDeviceAuth(): Promise<DeviceAuthStart> {
-	const response = await fetch(`${deviceAuthBaseUrl()}/orbcode/auth/start`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: "{}",
-	})
-	if (!response.ok) {
-		throw new Error(`Could not start sign-in (${response.status}). Try again or paste a token manually.`)
-	}
-	const data = (await response.json()) as Partial<DeviceAuthStart>
-	if (!data.devicecode) {
-		throw new Error("Sign-in service returned no device code.")
-	}
-	return {
-		devicecode: data.devicecode,
-		expiresIn: data.expiresIn ?? 600,
-		interval: data.interval ?? 3,
-	}
+  const response = await fetch(`${deviceAuthBaseUrl()}/orbcode/auth/start`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Could not start sign-in (${response.status}). Try again or paste a token manually.`,
+    );
+  }
+  const data = (await response.json()) as Partial<DeviceAuthStart>;
+  if (!data.devicecode) {
+    throw new Error("Sign-in service returned no device code.");
+  }
+  return {
+    devicecode: data.devicecode,
+    expiresIn: data.expiresIn ?? 600,
+    interval: data.interval ?? 3,
+  };
 }
 
 export function getAuthorizeUrl(devicecode: string): string {
-	return `${deviceAuthAppUrl()}/orbital?loginType=orbcode&devicecode=${encodeURIComponent(devicecode)}`
+  return `${deviceAuthAppUrl()}/orbital?loginType=orbcode&devicecode=${encodeURIComponent(devicecode)}`;
 }
 
 export type DeviceAuthPollResult =
-	| { status: "pending" }
-	| { status: "expired" }
-	| { status: "authorized"; token: string }
+  | { status: "pending" }
+  | { status: "expired" }
+  | { status: "authorized"; token: string };
 
-export async function pollDeviceAuth(devicecode: string): Promise<DeviceAuthPollResult> {
-	const response = await fetch(
-		`${deviceAuthBaseUrl()}/orbcode/auth/poll?devicecode=${encodeURIComponent(devicecode)}`,
-	)
-	if (!response.ok) {
-		// Transient server/network errors are treated as pending; the caller's
-		// overall deadline still bounds the wait.
-		return { status: "pending" }
-	}
-	const data = (await response.json()) as { status?: string; token?: string }
-	if (data.status === "authorized" && data.token) {
-		return { status: "authorized", token: data.token }
-	}
-	if (data.status === "expired") {
-		return { status: "expired" }
-	}
-	return { status: "pending" }
+export async function pollDeviceAuth(
+  devicecode: string,
+): Promise<DeviceAuthPollResult> {
+  const response = await fetch(
+    `${deviceAuthBaseUrl()}/orbcode/auth/poll?devicecode=${encodeURIComponent(devicecode)}`,
+  );
+  if (!response.ok) {
+    // Transient server/network errors are treated as pending; the caller's
+    // overall deadline still bounds the wait.
+    return { status: "pending" };
+  }
+  const data = (await response.json()) as { status?: string; token?: string };
+  if (data.status === "authorized" && data.token) {
+    return { status: "authorized", token: data.token };
+  }
+  if (data.status === "expired") {
+    return { status: "expired" };
+  }
+  return { status: "pending" };
+}
+
+export interface AxonCodeWindowUsage {
+  used: number;
+  limit: number;
+  remaining: number;
+  percentage: number;
+  resetsAt: string;
+  windowStart: string;
+}
+
+export interface AxonCodeTieredUsage {
+  plan: string;
+  monthlyLimit: number;
+  fiveHour: AxonCodeWindowUsage;
+  weekly: AxonCodeWindowUsage;
+  monthly: AxonCodeWindowUsage;
 }
 
 export interface ProfileData {
-	user?: { name?: string; email?: string; image?: string }
-	organizations?: Array<{ id: string; name: string; role?: string }>
-	// Usage fields from /axoncode/profile (same as the extension's profile view).
-	plan?: string
-	remainingReviews?: number
-	usagePercentage?: number
-	creditsResetDate?: string
-	[key: string]: unknown
+  user?: { name?: string; email?: string; image?: string };
+  organizations?: Array<{ id: string; name: string; role?: string }>;
+  // Usage fields from /axoncode/profile (same as the extension's profile view).
+  plan?: string;
+  remainingReviews?: number;
+  usagePercentage?: number;
+  creditsResetDate?: string;
+  // Tiered usage windows (5hr / weekly / monthly).
+  tieredUsage?: AxonCodeTieredUsage;
+  [key: string]: unknown;
 }
 
 export async function fetchProfile(token: string): Promise<ProfileData> {
-	const url = getUrlFromToken("https://api.matterai.so/axoncode/profile", token)
-	const response = await fetch(url, {
-		headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
-	})
-	if (!response.ok) {
-		throw new Error(`Profile request failed (${response.status}). Your token may be invalid or expired.`)
-	}
-	return (await response.json()) as ProfileData
+  const url = getUrlFromToken(
+    "https://api.matterai.so/axoncode/profile",
+    token,
+  );
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Profile request failed (${response.status}). Your token may be invalid or expired.`,
+    );
+  }
+  return (await response.json()) as ProfileData;
 }
 
 /**
@@ -133,25 +166,25 @@ export async function fetchProfile(token: string): Promise<ProfileData> {
  * Ported from the extension's taskMetadata sanitizeTitle.
  */
 function sanitizeTitle(raw: unknown): string | undefined {
-	if (raw == null) return undefined
-	if (typeof raw === "string") {
-		const trimmed = raw.trim()
-		if (!trimmed) return undefined
-		if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
-			try {
-				const extracted = sanitizeTitle(JSON.parse(trimmed))
-				if (extracted) return extracted
-			} catch {
-				// not JSON, use as plain string
-			}
-		}
-		return trimmed
-	}
-	if (typeof raw === "object") {
-		const maybe = (raw as Record<string, unknown>)["title"]
-		if (maybe != null) return sanitizeTitle(maybe)
-	}
-	return undefined
+  if (raw == null) return undefined;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) return undefined;
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        const extracted = sanitizeTitle(JSON.parse(trimmed));
+        if (extracted) return extracted;
+      } catch {
+        // not JSON, use as plain string
+      }
+    }
+    return trimmed;
+  }
+  if (typeof raw === "object") {
+    const maybe = (raw as Record<string, unknown>)["title"];
+    if (maybe != null) return sanitizeTitle(maybe);
+  }
+  return undefined;
 }
 
 /**
@@ -160,53 +193,64 @@ function sanitizeTitle(raw: unknown): string | undefined {
  * retries a few times. Ported from the extension's fetchTaskTitle.
  */
 export async function fetchTaskTitle(
-	taskId: string,
-	token: string,
-	maxRetries = 3,
-	retryDelayMs = 2000,
+  taskId: string,
+  token: string,
+  maxRetries = 3,
+  retryDelayMs = 2000,
 ): Promise<string | null> {
-	if (!token) return null
-	const url = getUrlFromToken(`https://api.matterai.so/axoncode/meta/${taskId}`, token)
+  if (!token) return null;
+  const url = getUrlFromToken(
+    `https://api.matterai.so/axoncode/meta/${taskId}`,
+    token,
+  );
 
-	for (let attempt = 1; attempt <= maxRetries; attempt++) {
-		try {
-			const response = await fetch(url, {
-				headers: { Authorization: `Bearer ${token}` },
-				signal: AbortSignal.timeout(5000),
-			})
-			if (response.ok) {
-				const data: unknown = await response.json().catch(() => undefined)
-				const title = sanitizeTitle(data)
-				if (title) return title
-			}
-		} catch {
-			// network/timeout: fall through to retry
-		}
-		if (attempt < maxRetries) {
-			await new Promise((resolve) => setTimeout(resolve, retryDelayMs))
-		}
-	}
-	return null
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (response.ok) {
+        const data: unknown = await response.json().catch(() => undefined);
+        const title = sanitizeTitle(data);
+        if (title) return title;
+      }
+    } catch {
+      // network/timeout: fall through to retry
+    }
+    if (attempt < maxRetries) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+    }
+  }
+  return null;
 }
 
-export async function fetchBalance(token: string, organizationId?: string): Promise<number | undefined> {
-	try {
-		const url = getUrlFromToken("https://api.matterai.so/api/profile/balance", token)
-		const headers: Record<string, string> = { Authorization: `Bearer ${token}` }
-		if (organizationId) headers["X-KiloCode-OrganizationId"] = organizationId
-		const response = await fetch(url, { headers })
-		if (!response.ok) return undefined
-		const data = (await response.json()) as { balance?: number }
-		return data.balance
-	} catch {
-		return undefined
-	}
+export async function fetchBalance(
+  token: string,
+  organizationId?: string,
+): Promise<number | undefined> {
+  try {
+    const url = getUrlFromToken(
+      "https://api.matterai.so/api/profile/balance",
+      token,
+    );
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    };
+    if (organizationId) headers["X-KiloCode-OrganizationId"] = organizationId;
+    const response = await fetch(url, { headers });
+    if (!response.ok) return undefined;
+    const data = (await response.json()) as { balance?: number };
+    return data.balance;
+  } catch {
+    return undefined;
+  }
 }
 
 /** Validate a pasted token: well-formed JWT + accepted by the profile endpoint. */
 export async function verifyToken(token: string): Promise<ProfileData> {
-	if (token.split(".").length !== 3) {
-		throw new Error("That doesn't look like a valid token (expected a JWT).")
-	}
-	return fetchProfile(token)
+  if (token.split(".").length !== 3) {
+    throw new Error("That doesn't look like a valid token (expected a JWT).");
+  }
+  return fetchProfile(token);
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -50,6 +50,23 @@ function setTerminalTitle(title: string): void {
 	}
 }
 
+function formatRelativeTime(isoStr?: string): string {
+	if (!isoStr) return "???"
+	const now = Date.now()
+	const target = new Date(isoStr).getTime()
+	if (Number.isNaN(target)) return "???"
+	const diff = target - now
+	if (diff <= 0) return "now"
+	const sec = Math.floor(diff / 1000)
+	const min = Math.floor(sec / 60)
+	const hrs = Math.floor(min / 60)
+	const days = Math.floor(hrs / 24)
+	if (days >= 1) return `in ${days} day${days > 1 ? "s" : ""}`
+	if (hrs >= 1) return `in ${hrs}h ${min % 60}m`
+	if (min >= 1) return `in ${min}m`
+	return "soon"
+}
+
 /** Human lines for the /status and /cost usage block (extension profile data). */
 function usageLines(profile: ProfileData): string[] {
 	const lines: string[] = []
@@ -62,7 +79,23 @@ function usageLines(profile: ProfileData): string[] {
 	if (typeof profile.remainingReviews === "number") {
 		lines.push(`Reviews     ${profile.remainingReviews} remaining`)
 	}
-	if (profile.creditsResetDate) lines.push(`Resets      ${profile.creditsResetDate}`)
+	if (profile.tieredUsage) {
+		const ws: [string, string, import("../auth/auth.js").AxonCodeWindowUsage][] = [
+			["5hr", "5-Hour", profile.tieredUsage.fiveHour],
+			["wk",  "Weekly", profile.tieredUsage.weekly],
+			["mo",  "Monthly", profile.tieredUsage.monthly],
+		]
+		for (const [short, label, w] of ws) {
+			const remaining = Math.max(0, w.remaining || 0)
+			const pct = Math.max(0, Math.min(100, w.percentage || 0))
+			const reset = formatRelativeTime(w.resetsAt)
+			lines.push(
+				`${label.padEnd(12)} ${remaining.toFixed(1)}/${w.limit.toFixed(1)} left (${pct}% used) · Resets ${reset}`,
+			)
+		}
+	} else if (profile.creditsResetDate) {
+		lines.push(`Resets      ${profile.creditsResetDate}`)
+	}
 	return lines
 }
 
@@ -177,14 +210,16 @@ export function App({
 	)
 
 	const [sessionTitle, setSessionTitle] = useState("")
-	const [usage, setUsage] = useState<{ plan?: string; usagePercentage?: number } | null>(null)
+	const [usage, setUsage] = useState<{ plan?: string; usagePercentage?: number; tieredUsage?: import("../auth/auth.js").AxonCodeTieredUsage } | null>(null)
 
 	// Refresh plan/usage from /axoncode/profile (shown below the chat box).
 	const refreshUsage = useCallback(() => {
 		const token = getAuthToken(loadSettings())
 		if (!token) return
 		fetchProfile(token)
-			.then((profile) => setUsage({ plan: profile.plan, usagePercentage: profile.usagePercentage }))
+			.then((profile) =>
+				setUsage({ plan: profile.plan, usagePercentage: profile.usagePercentage, tieredUsage: profile.tieredUsage }),
+			)
 			.catch(() => {})
 	}, [])
 
@@ -276,6 +311,10 @@ export function App({
 				case "usage":
 					setContextTokens(event.inputTokens + event.outputTokens)
 					setTotalCost(event.totalCost)
+					// A usage chunk arrives once per LLM response, so the plan/usage
+					// shown below the chat box stays current mid-turn, not only
+					// after the turn finishes.
+					refreshUsage()
 					break
 				case "completion":
 					pushRow({ kind: "completion", text: event.result })
@@ -389,10 +428,19 @@ export function App({
 					const ids = Object.keys(AXON_MODELS)
 					if (arg && isValidAxonModel(arg)) {
 						switchModel(arg)
-					} else if (arg && isValidAxonModel(`axon-code-2-5-${arg}`)) {
-						switchModel(`axon-code-2-5-${arg}`)
 					} else if (arg) {
-						pushRow({ kind: "error", text: `Unknown model "${arg}". Available: ${ids.join(", ")}` })
+						// Allow short suffixes like "pro" or "mini" to resolve to the
+						// latest matching registered id, so /model pro keeps working
+						// as new model generations are added.
+						const matches = ids
+							.filter((id) => id.endsWith(`-${arg}`))
+							.sort()
+							.reverse()
+						if (matches.length > 0) {
+							switchModel(matches[0])
+						} else {
+							pushRow({ kind: "error", text: `Unknown model "${arg}". Available: ${ids.join(", ")}` })
+						}
 					} else {
 						setModelPickerOpen(true)
 					}
@@ -607,7 +655,7 @@ export function App({
 			saveSettings(updated)
 			agentRef.current = null
 			setView("chat")
-			setUsage({ plan: profile.plan, usagePercentage: profile.usagePercentage })
+			setUsage({ plan: profile.plan, usagePercentage: profile.usagePercentage, tieredUsage: profile.tieredUsage })
 			const who = profile.user?.name || profile.user?.email
 			pushRow({ kind: "info", text: `Signed in${who ? ` as ${who}` : ""}. Ready when you are.` })
 		},
@@ -737,6 +785,7 @@ export function App({
 							title={sessionTitle}
 							plan={usage?.plan}
 							usagePercentage={usage?.usagePercentage}
+							tieredUsage={usage?.tieredUsage}
 						/>
 					</Box>
 				</Box>

--- a/src/ui/components/StatusBar.tsx
+++ b/src/ui/components/StatusBar.tsx
@@ -1,77 +1,115 @@
-import React from "react"
-import { Box, Text } from "ink"
+import React from "react";
+import { Box, Text } from "ink";
 
-import { COLORS } from "../../branding.js"
-import { getModel } from "../../api/models.js"
+import { COLORS } from "../../branding.js";
+import { getModel } from "../../api/models.js";
+import type { AxonCodeTieredUsage } from "../../auth/auth.js";
 
-export type ApprovalMode = "ask" | "edits" | "auto"
+export type ApprovalMode = "ask" | "edits" | "auto";
 
 const MODE_LABELS: Record<ApprovalMode, string> = {
-	ask: "⏵ ask before changes",
-	edits: "⏵⏵ accept edits on",
-	auto: "⏵⏵⏵ auto-approve on",
+  ask: "⏵ ask before changes",
+  edits: "⏵⏵ accept edits on",
+  auto: "⏵⏵⏵ auto-approve on",
+};
+
+function formatRelativeTime(isoStr?: string): string {
+  if (!isoStr) return "???";
+  const now = Date.now();
+  const target = new Date(isoStr).getTime();
+  if (Number.isNaN(target)) return "???";
+  const diff = target - now;
+  if (diff <= 0) return "now";
+  const sec = Math.floor(diff / 1000);
+  const min = Math.floor(sec / 60);
+  const hrs = Math.floor(min / 60);
+  const days = Math.floor(hrs / 24);
+  if (days >= 1) return `${days}d`;
+  if (hrs >= 1) return `${hrs}h${min % 60 > 0 ? ` ${min % 60}m` : ""}`;
+  if (min >= 1) return `${min}m`;
+  return "soon";
 }
 
 interface StatusBarProps {
-	modelId: string
-	contextTokens: number
-	totalCost: number
-	state: string
-	approvalMode: ApprovalMode
-	busy: boolean
-	/** backend-generated session title, once available */
-	title?: string
-	/** plan name from /axoncode/profile */
-	plan?: string
-	/** percent of the plan already used, from /axoncode/profile */
-	usagePercentage?: number
+  modelId: string;
+  contextTokens: number;
+  totalCost: number;
+  state: string;
+  approvalMode: ApprovalMode;
+  busy: boolean;
+  title?: string;
+  plan?: string;
+  usagePercentage?: number;
+  tieredUsage?: AxonCodeTieredUsage;
 }
 
 function truncate(text: string, max: number): string {
-	return text.length > max ? text.slice(0, max - 1) + "…" : text
+  return text.length > max ? text.slice(0, max - 1) + "…" : text;
+}
+
+/**
+ * Picks the most constrained window (highest percentage used) and returns a
+ * compact string like "5hr 12% · resets in 3h 15m".
+ */
+function mostConstrainedSummary(tu: AxonCodeTieredUsage): string {
+  const windows: [string, number, string][] = [
+    ["5hr", tu.fiveHour.percentage, tu.fiveHour.resetsAt],
+    ["wk", tu.weekly.percentage, tu.weekly.resetsAt],
+    ["mo", tu.monthly.percentage, tu.monthly.resetsAt],
+  ];
+  const [label, pct, resetsAt] = windows.reduce((best, cur) =>
+    cur[1] >= best[1] ? cur : best,
+  );
+  return `${label} ${Math.round(pct)}% · resets ${formatRelativeTime(resetsAt)}`;
 }
 
 export function StatusBar({
-	modelId,
-	contextTokens,
-	totalCost,
-	state,
-	approvalMode,
-	busy,
-	title,
-	plan,
-	usagePercentage,
+  modelId,
+  contextTokens,
+  totalCost,
+  state,
+  approvalMode,
+  busy,
+  title,
+  plan,
+  usagePercentage,
+  tieredUsage,
 }: StatusBarProps) {
-	const model = getModel(modelId)
-	const contextPct = Math.min(100, Math.round((contextTokens / model.contextWindow) * 100))
-	const remaining =
-		typeof usagePercentage === "number" ? Math.max(0, Math.round(100 - usagePercentage)) : undefined
-	return (
-		<Box flexDirection="column">
-			<Box justifyContent="space-between">
-				<Text dimColor>
-					<Text color={approvalMode === "ask" ? undefined : COLORS.warning}>{MODE_LABELS[approvalMode]}</Text>
-					{" (shift+tab to cycle)"}
-					{busy && " · esc to interrupt"}
-					{state ? <Text color={COLORS.thinking}> · {state}</Text> : null}
-				</Text>
-				<Text dimColor>
-					{title ? `${truncate(title, 32)} · ` : ""}
-					{model.name} · ctx {contextTokens.toLocaleString()} ({contextPct}%)
-					{model.free ? " · free" : ` · $${totalCost.toFixed(4)}`}
-				</Text>
-			</Box>
-			{(plan || remaining !== undefined) && (
-				<Box justifyContent="flex-end">
-					<Text dimColor>
-						{plan ? `${plan} plan` : ""}
-						{plan && remaining !== undefined ? " · " : ""}
-						{remaining !== undefined ? (
-							<Text color={remaining <= 10 ? COLORS.error : undefined}>{remaining}% usage remaining</Text>
-						) : null}
-					</Text>
-				</Box>
-			)}
-		</Box>
-	)
+  const model = getModel(modelId);
+  const contextPct = Math.min(
+    100,
+    Math.round((contextTokens / model.contextWindow) * 100),
+  );
+  const constrainedLine = tieredUsage
+    ? mostConstrainedSummary(tieredUsage)
+    : typeof usagePercentage === "number"
+      ? `${Math.round(usagePercentage)}% used`
+      : null;
+  return (
+    <Box flexDirection="column">
+      <Box justifyContent="space-between">
+        <Text dimColor>
+          <Text color={approvalMode === "ask" ? undefined : COLORS.warning}>
+            {MODE_LABELS[approvalMode]}
+          </Text>
+          {" (shift+tab to cycle)"}
+          {busy && " · esc to interrupt"}
+          {state ? <Text color={COLORS.thinking}> · {state}</Text> : null}
+        </Text>
+        <Text dimColor>
+          {title ? `${truncate(title, 32)} · ` : ""}
+          {model.name} · ctx {contextTokens.toLocaleString()} ({contextPct}%)
+          {model.free ? " · free" : ` · $${totalCost.toFixed(4)}`}
+        </Text>
+      </Box>
+      {(plan || constrainedLine) && (
+        <Box justifyContent="flex-end">
+          <Text dimColor>
+            {plan && constrainedLine ? " · " : ""}
+            {constrainedLine}
+          </Text>
+        </Box>
+      )}
+    </Box>
+  );
 }


### PR DESCRIPTION
Automated release of v0.1.4 plus a security fix to the release pipeline.

## Release contents
- `@matterailab/orbcode` v0.1.3 -> v0.1.4
- Add `axon-eido-3-code-pro` model to `src/api/models.ts`
- Reformat `src/auth/auth.ts`, `src/ui/App.tsx`, `src/ui/components/StatusBar.tsx`
- Refresh `README.md` (model table, slash-command and shortcut tables)

## Security: gate publish on a v* tag on `main`
The previous `Release` workflow triggered on any push to a `release/*` branch
and ran `npm publish` straight away — so any push (or force-push) to a release
branch could publish to npm with the repo's `NPM_TOKEN`, regardless of whether
the code was reviewed or merged.

The new workflow:
- only runs on push of a `vX.Y.Z` tag (or a matching `workflow_dispatch`);
- checks out the tagged commit, verifies the tag matches `package.json#version`
  (a mismatch fails the build), then publishes + creates the GitHub Release.

Publishing now requires the release commit to be merged into `main` AND an
explicit tag push by someone with main write access. Release branch pushes no
longer have publish power on their own.

`RELEASE.md` updated to document the new flow.

Verified: `npm run typecheck` passes.