### PR TITLE
chore(env): rename ORBCODE_* env vars to MATTERAI_* (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-06-17
+
+### Changed
+
+- **Breaking: all `ORBCODE_*` environment variables renamed to `MATTERAI_*`.**
+  This aligns the CLI's env-var namespace with the MatterAI brand. Update any
+  scripts, CI configs, or `.env` files that set these variables. The renamed
+  variables are: `ORBCODE_TOKEN` → `MATTERAI_TOKEN`,
+  `ORBCODE_API_KEY` → `MATTERAI_API_KEY`, `ORBCODE_BASE_URL` → `MATTERAI_BASE_URL`,
+  `ORBCODE_MODEL` → `MATTERAI_MODEL`, `ORBCODE_CONFIG_DIR` → `MATTERAI_CONFIG_DIR`,
+  `ORBCODE_BACKEND_URL` → `MATTERAI_BACKEND_URL`, `ORBCODE_APP_URL` → `MATTERAI_APP_URL`,
+  `ORBCODE_PROJECT_DIR` → `MATTERAI_PROJECT_DIR`, and
+  `ORBCODE_TRUST_PROJECT_HOOKS` → `MATTERAI_TRUST_PROJECT_HOOKS`.
+
 ## [0.1.14] - 2026-06-17
 
 ### Added
@@ -29,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `effort`); and Fable 5. Auth is `ANTHROPIC_API_KEY` (or a per-model `apiKey`).
 - **Axon Eido 3 Mini** model added to the Axon registry.
 - Headless mode (`-p`) now warns on stderr when an unknown `--model` /
-  `ORBCODE_MODEL` silently resolves to the default, instead of quietly running
+  `MATTERAI_MODEL` silently resolves to the default, instead of quietly running
   a different model than requested.
 
 ### Changed
@@ -53,13 +67,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Hooks no longer receive OrbCode credentials.** Hook commands now run with a
-  redacted environment: `ORBCODE_TOKEN`, `ORBCODE_API_KEY`,
-  `ORBCODE_CONFIG_DIR`, `ORBCODE_BACKEND_URL`, `ORBCODE_APP_URL`, and any
+  redacted environment: `MATTERAI_TOKEN`, `MATTERAI_API_KEY`,
+  `MATTERAI_CONFIG_DIR`, `MATTERAI_BACKEND_URL`, `MATTERAI_APP_URL`, and any
   variable whose name matches a credential pattern (`*TOKEN*`, `*KEY*`,
   `*SECRET*`, `*PASSWORD*`, `*CREDENTIAL*`, `*PRIVATE_KEY*`) is stripped. A
   hook can no longer exfiltrate your API token. Non-credential vars (`PATH`,
-  `HOME`, `ORBCODE_PROJECT_DIR`, …) are preserved.
-- **`ORBCODE_TRUST_PROJECT_HOOKS=1` is now only honored when stdin is not a
+  `HOME`, `MATTERAI_PROJECT_DIR`, …) are preserved.
+- **`MATTERAI_TRUST_PROJECT_HOOKS=1` is now only honored when stdin is not a
   TTY.** A stray `export` in a shell rc file can no longer silently disable the
   project-hook trust gate for interactive sessions; the escape hatch still
   works in CI/headless mode. Only the exact value `"1"` is honored (not
@@ -95,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test-hook-env.mjs`: verifies credential env vars are redacted from hooks.
 - New test cases: matcher auto-anchoring, alternation, SIGKILL escalation,
-  context cap, strict `ORBCODE_TRUST_PROJECT_HOOKS` value, PreToolUse
+  context cap, strict `MATTERAI_TRUST_PROJECT_HOOKS` value, PreToolUse
   `ask`/`allow` + `updatedInput` interactions.
 
 ## [0.1.12] - 2026-06-16
@@ -119,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hooks always run). Trust is content-hashed — editing a project's hooks
   re-prompts — and persisted to `~/.orbcode/hook-trust.json`. Non-interactive
   (`-p`) runs skip untrusted project hooks with a warning;
-  `ORBCODE_TRUST_PROJECT_HOOKS=1` opts in for CI.
+  `MATTERAI_TRUST_PROJECT_HOOKS=1` opts in for CI.
 
 ## [0.1.8] - 2026-06-12
 
@@ -209,11 +223,11 @@ non-interactive mode.
   the choice persists across sessions.
 - Browser-based device-flow authentication with polling (no copy/paste):
   `orbcode login` or `/login` opens the MatterAI authorize dialog, and the
-  token is handed out exactly once. `ORBCODE_TOKEN` and a settings.json
+  token is handed out exactly once. `MATTERAI_TOKEN` and a settings.json
   `apiKey` provide non-interactive overrides.
 - Token-based backend routing: a JWT whose payload has `env: "development"`
   automatically routes API calls to `http://localhost:3000`, matching the
-  extension's behavior. `ORBCODE_BACKEND_URL` / `ORBCODE_APP_URL` override
+  extension's behavior. `MATTERAI_BACKEND_URL` / `MATTERAI_APP_URL` override
   the defaults for local development.
 - Headless non-interactive mode (`-p` / `--prompt`) that prints only the
   final response, with `--yolo` to auto-approve edits and safe commands.

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ Fallbacks & overrides:
 - **settings.json key**: set `apiKey` in `~/.orbcode/settings.json` (or a
   project's `.orbcode/settings.json`) to skip login. The login screen itself is
   browser-redirect only.
-- **Env token**: set `ORBCODE_TOKEN` to skip login entirely (takes precedence
+- **Env token**: set `MATTERAI_TOKEN` to skip login entirely (takes precedence
   over everything).
-- **Dev endpoints**: `ORBCODE_BACKEND_URL` (default `https://api.matterai.so`)
-  and `ORBCODE_APP_URL` (default `https://app.matterai.so`) override where the
+- **Dev endpoints**: `MATTERAI_BACKEND_URL` (default `https://api.matterai.so`)
+  and `MATTERAI_APP_URL` (default `https://app.matterai.so`) override where the
   device flow points — useful against a local backend/webapp.
 - Tokens are MatterAI JWTs. A token whose payload has `env: "development"`
   automatically routes API calls to `http://localhost:3000`, matching the
@@ -346,13 +346,13 @@ and `--resume <id>`.
 
 | env var               | effect                                                            |
 | --------------------- | ----------------------------------------------------------------- |
-| `ORBCODE_TOKEN`       | auth token (overrides everything)                                 |
-| `ORBCODE_API_KEY`     | same as `apiKey` in settings.json                                 |
-| `ORBCODE_BASE_URL`    | same as `baseUrl` in settings.json                                |
-| `ORBCODE_MODEL`       | model override (what `--model` sets internally)                   |
-| `ORBCODE_CONFIG_DIR`  | config directory (default `~/.orbcode`)                           |
-| `ORBCODE_BACKEND_URL` | device-auth backend (default `https://api.matterai.so`)           |
-| `ORBCODE_APP_URL`     | webapp for the authorize page (default `https://app.matterai.so`) |
+| `MATTERAI_TOKEN`       | auth token (overrides everything)                                 |
+| `MATTERAI_API_KEY`     | same as `apiKey` in settings.json                                 |
+| `MATTERAI_BASE_URL`    | same as `baseUrl` in settings.json                                |
+| `MATTERAI_MODEL`       | model override (what `--model` sets internally)                   |
+| `MATTERAI_CONFIG_DIR`  | config directory (default `~/.orbcode`)                           |
+| `MATTERAI_BACKEND_URL` | device-auth backend (default `https://api.matterai.so`)           |
+| `MATTERAI_APP_URL`     | webapp for the authorize page (default `https://app.matterai.so`) |
 
 `autoApproveEdits` / `autoApproveSafeCommands` set the session defaults for the
 approval prompts (dangerous commands still always prompt); shift+tab cycles
@@ -365,7 +365,7 @@ them to **block** dangerous actions, **auto-approve** trusted ones, **rewrite**
 tool inputs, **inject context** into the model, **format code** after edits,
 **notify** you, or **keep the agent working** until a condition is met. They use
 the **same contract as Claude Code's hooks**, so scripts written for it work
-here (just use `$ORBCODE_PROJECT_DIR` and OrbCode's tool names).
+here (just use `$MATTERAI_PROJECT_DIR` and OrbCode's tool names).
 
 > 📖 **This is the overview. The complete, example-driven reference —
 > per-event input/output, a copy-paste cookbook, debugging, and security — is in
@@ -588,8 +588,8 @@ node test-device-auth.mjs  # device-auth polling flow against a local mock
   command runs `dist/`, and the version is read from `package.json` at runtime.
 - **Stale link after the rename** — `npm unlink -g orbitalcode && npm link`.
 - **Login times out** — the device code lives 10 minutes; press Enter to retry,
-  or paste a token manually. Against a local stack, set `ORBCODE_BACKEND_URL`
-  and `ORBCODE_APP_URL`.
+  or paste a token manually. Against a local stack, set `MATTERAI_BACKEND_URL`
+  and `MATTERAI_APP_URL`.
 - **401 on chat** — token expired: `/logout` then `/login`.
 - **Keyboard input does nothing** — OrbCode needs a real TTY (raw mode); it
   won't accept piped stdin. Use `-p` for non-interactive runs.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -7,7 +7,7 @@ after edits, **notify** yourself, or **keep the agent working** until a
 condition is met.
 
 OrbCode's hooks follow the **same contract as Claude Code's hooks**, so scripts
-written for Claude Code work here with two tweaks: use `$ORBCODE_PROJECT_DIR`
+written for Claude Code work here with two tweaks: use `$MATTERAI_PROJECT_DIR`
 (not `$CLAUDE_PROJECT_DIR`) and use OrbCode's tool names (`execute_command`,
 `file_edit`, …) in your matchers. See [Differences from Claude
 Code](#differences-from-claude-code).
@@ -104,7 +104,7 @@ User hooks always run. **Project hooks are disabled until you trust them** (they
 ship inside a repo and run shell commands — see [Security](#security)). Once
 trusted, a project can **add** hooks without clobbering your global ones — for a
 given event the user matchers come first, then the project matchers, and they
-all execute. (Override the config directory with `ORBCODE_CONFIG_DIR`.)
+all execute. (Override the config directory with `MATTERAI_CONFIG_DIR`.)
 
 Hooks are **not** written to `config.json` (the app's own state file) — they are
 configuration you own.
@@ -173,7 +173,7 @@ file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')
 ```
 
 You can also read fields straight from the environment where provided (e.g.
-`$ORBCODE_PROJECT_DIR`).
+`$MATTERAI_PROJECT_DIR`).
 
 ---
 
@@ -371,14 +371,14 @@ merged:
 
 | Variable | Value |
 | --- | --- |
-| `ORBCODE_PROJECT_DIR` | the workspace directory (same as `cwd` in the payload) |
+| `MATTERAI_PROJECT_DIR` | the workspace directory (same as `cwd` in the payload) |
 
 Hooks inherit a **redacted** copy of your environment: `$PATH`, `$HOME`,
 `$LANG`, `$SHELL`, etc. are available, but **credential-like variables are
 stripped** so a hook can never exfiltrate your API token. Specifically redacted:
 
-- `ORBCODE_TOKEN`, `ORBCODE_API_KEY`, `ORBCODE_CONFIG_DIR`,
-  `ORBCODE_BACKEND_URL`, `ORBCODE_APP_URL` (OrbCode's own vars).
+- `MATTERAI_TOKEN`, `MATTERAI_API_KEY`, `MATTERAI_CONFIG_DIR`,
+  `MATTERAI_BACKEND_URL`, `MATTERAI_APP_URL` (OrbCode's own vars).
 - Any variable whose name matches `/(?:^|_)(TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|PRIVATE_KEY)(?:$|_)/i`
   (so `GITHUB_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `DATABASE_PASSWORD`, … are
   redacted too).
@@ -566,7 +566,7 @@ exit 0
     "UserPromptSubmit": [
       { "hooks": [
         { "type": "command",
-          "command": "echo \"Repo: $(basename $ORBCODE_PROJECT_DIR) · branch $(git branch --show-current 2>/dev/null) · $(date '+%H:%M')\"" }
+          "command": "echo \"Repo: $(basename $MATTERAI_PROJECT_DIR) · branch $(git branch --show-current 2>/dev/null) · $(date '+%H:%M')\"" }
       ] }
     ]
   }
@@ -742,7 +742,7 @@ schema, matcher regexes, parallel execution, per-command timeout). Differences:
 | --- | --- | --- |
 | Settings file | `~/.claude/settings.json` | `~/.orbcode/settings.json` |
 | Project file | `.claude/settings.json` | `.orbcode/settings.json` |
-| Project dir env var | `$CLAUDE_PROJECT_DIR` | `$ORBCODE_PROJECT_DIR` |
+| Project dir env var | `$CLAUDE_PROJECT_DIR` | `$MATTERAI_PROJECT_DIR` |
 | Tool names in matchers | `Bash`, `Edit`, `Write`, `Read`, … | `execute_command`, `file_edit`, `file_write`, `read_file`, … |
 | Hook types | `command`, plus newer MCP/HTTP/prompt hooks | `command` only |
 | Events | full internal SDK set | the documented set: `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Notification`, `Stop`, `PreCompact`, `SessionEnd` (+ `SubagentStop`, reserved) |
@@ -778,7 +778,7 @@ cheque and then quietly swap in a different command.
 
 In **non-interactive** (`-p`) mode there is no prompt, so untrusted project
 hooks are **skipped** with a warning on stderr. Set
-`ORBCODE_TRUST_PROJECT_HOOKS=1` to trust project hooks in CI/automation where
+`MATTERAI_TRUST_PROJECT_HOOKS=1` to trust project hooks in CI/automation where
 you control the repository. **This env var is only honored when stdin is not a
 TTY** — a stray `export` in a shell rc file cannot silently disable the trust
 gate for interactive sessions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.1.14",
+  "version": "0.2.0",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -52,11 +52,11 @@ export interface DeviceAuthStart {
 }
 
 function deviceAuthBaseUrl(): string {
-  return process.env.ORBCODE_BACKEND_URL || DEFAULT_BACKEND_URL;
+  return process.env.MATTERAI_BACKEND_URL || DEFAULT_BACKEND_URL;
 }
 
 function deviceAuthAppUrl(): string {
-  return process.env.ORBCODE_APP_URL || APP_URL;
+  return process.env.MATTERAI_APP_URL || APP_URL;
 }
 
 export async function startDeviceAuth(): Promise<DeviceAuthStart> {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -46,7 +46,7 @@ const SETTINGS_KEYS = [
 ] as const
 
 export function getConfigDir(): string {
-	return process.env.ORBCODE_CONFIG_DIR || path.join(os.homedir(), ".orbcode")
+	return process.env.MATTERAI_CONFIG_DIR || path.join(os.homedir(), ".orbcode")
 }
 
 function getConfigPath(): string {
@@ -108,7 +108,7 @@ function isProjectHooksTrusted(cwd: string, hash: string): boolean {
 	// stdin is not a TTY (so a stray export in a shell rc file can't silently
 	// disable the trust gate for interactive sessions). A non-TTY check keeps
 	// the gate meaningful in the TUI while still letting CI opt in.
-	if (process.env.ORBCODE_TRUST_PROJECT_HOOKS === "1" && !process.stdin.isTTY) return true
+	if (process.env.MATTERAI_TRUST_PROJECT_HOOKS === "1" && !process.stdin.isTTY) return true
 	const store = readJson(getTrustStorePath())
 	return Boolean(store && store[cwd] === hash)
 }
@@ -208,9 +208,9 @@ export function loadSettings(): OrbCodeSettings {
 	}
 
 	// Environment variables take precedence over all files.
-	if (process.env.ORBCODE_BASE_URL) settings.baseUrl = process.env.ORBCODE_BASE_URL
-	if (process.env.ORBCODE_API_KEY) settings.apiKey = process.env.ORBCODE_API_KEY
-	if (process.env.ORBCODE_MODEL) settings.model = process.env.ORBCODE_MODEL
+	if (process.env.MATTERAI_BASE_URL) settings.baseUrl = process.env.MATTERAI_BASE_URL
+	if (process.env.MATTERAI_API_KEY) settings.apiKey = process.env.MATTERAI_API_KEY
+	if (process.env.MATTERAI_MODEL) settings.model = process.env.MATTERAI_MODEL
 
 	if (!isValidAxonModel(settings.model)) {
 		settings.model = DEFAULT_MODEL_ID
@@ -219,11 +219,11 @@ export function loadSettings(): OrbCodeSettings {
 }
 
 /**
- * Effective credential: ORBCODE_TOKEN env > apiKey (settings.json / env) >
+ * Effective credential: MATTERAI_TOKEN env > apiKey (settings.json / env) >
  * stored login token.
  */
 export function getAuthToken(settings: OrbCodeSettings): string | undefined {
-	return process.env.ORBCODE_TOKEN || settings.apiKey || settings.token
+	return process.env.MATTERAI_TOKEN || settings.apiKey || settings.token
 }
 
 /** Persist app state to config.json. settings.json-only fields are skipped. */

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -350,11 +350,11 @@ function capContext(text: string): string {
 
 /** Keys always stripped from the hook environment (OrbCode credentials/config). */
 const HOOK_ENV_REDACT_EXACT = new Set([
-	"ORBCODE_TOKEN",
-	"ORBCODE_API_KEY",
-	"ORBCODE_CONFIG_DIR",
-	"ORBCODE_BACKEND_URL",
-	"ORBCODE_APP_URL",
+	"MATTERAI_TOKEN",
+	"MATTERAI_API_KEY",
+	"MATTERAI_CONFIG_DIR",
+	"MATTERAI_BACKEND_URL",
+	"MATTERAI_APP_URL",
 ])
 
 /** Pattern for credential-like env var names (TOKEN, KEY, SECRET, …) so
@@ -366,7 +366,7 @@ const HOOK_ENV_REDACT_PATTERN = /(?:^|_)(TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDEN
  *  (so PATH, HOME, npx, git, … all work) minus anything that looks like a
  *  credential — hooks must never see the user's API token. */
 function buildHookEnv(cwd: string): NodeJS.ProcessEnv {
-	const env: NodeJS.ProcessEnv = { ORBCODE_PROJECT_DIR: cwd }
+	const env: NodeJS.ProcessEnv = { MATTERAI_PROJECT_DIR: cwd }
 	for (const [key, value] of Object.entries(process.env)) {
 		if (value === undefined) continue
 		if (HOOK_ENV_REDACT_EXACT.has(key)) continue

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -7,9 +7,9 @@ import type { AgentEvent } from "./core/events.js"
 export async function runHeadless(prompt: string, yolo: boolean): Promise<void> {
 	const settings = loadSettings()
 
-	// An unknown --model (or ORBCODE_MODEL) silently resolves to the default; say
+	// An unknown --model (or MATTERAI_MODEL) silently resolves to the default; say
 	// so on stderr instead of quietly running a different model than requested.
-	const requestedModel = process.env.ORBCODE_MODEL
+	const requestedModel = process.env.MATTERAI_MODEL
 	if (requestedModel && !isValidAxonModel(requestedModel)) {
 		process.stderr.write(
 			`warning: unknown model "${requestedModel}"; using "${settings.model}". ` +
@@ -24,7 +24,7 @@ export async function runHeadless(prompt: string, yolo: boolean): Promise<void> 
 	// so they don't need a MatterAI login. Only gate on the token when the
 	// selected model actually goes through the MatterAI gateway.
 	if (!token && !usesAiSdk(getModel(settings.model))) {
-		console.error("Not signed in. Run `orbcode login`, set ORBCODE_TOKEN, or put an apiKey in settings.json.")
+		console.error("Not signed in. Run `orbcode login`, set MATTERAI_TOKEN, or put an apiKey in settings.json.")
 		process.exit(1)
 	}
 
@@ -34,7 +34,7 @@ export async function runHeadless(prompt: string, yolo: boolean): Promise<void> 
 	if (pendingHooks) {
 		process.stderr.write(
 			`note: ${pendingHooks.commands.length} project hook(s) in .orbcode/settings.json are untrusted and were skipped. ` +
-				`Trust them in an interactive session, or set ORBCODE_TRUST_PROJECT_HOOKS=1.\n`,
+				`Trust them in an interactive session, or set MATTERAI_TRUST_PROJECT_HOOKS=1.\n`,
 		)
 	}
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -107,9 +107,9 @@ async function main(): Promise<void> {
 
 	const model = takeFlagValue(args, "model") ?? takeFlagValue(args, "m")
 	if (model) {
-		// loadSettings() treats ORBCODE_MODEL as the highest-precedence override,
+		// loadSettings() treats MATTERAI_MODEL as the highest-precedence override,
 		// so the flag reaches both the TUI and headless mode without plumbing.
-		process.env.ORBCODE_MODEL = model
+		process.env.MATTERAI_MODEL = model
 	}
 
 	let initialSession: SessionData | undefined

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -600,7 +600,7 @@ export function App({
 							`Version     ${VERSION}`,
 							`Model       ${model.name} (${model.id})`,
 							`Directory   ${process.cwd()}`,
-							`Account     ${getAuthToken(settings) ? (settings.apiKey || process.env.ORBCODE_TOKEN ? "API key" : "signed in") : "signed out"}${settings.organizationId ? ` · org ${settings.organizationId}` : ""}`,
+							`Account     ${getAuthToken(settings) ? (settings.apiKey || process.env.MATTERAI_TOKEN ? "API key" : "signed in") : "signed out"}${settings.organizationId ? ` · org ${settings.organizationId}` : ""}`,
 							`Gateway     ${settings.baseUrl ?? "MatterAI (default)"}`,
 							`Context     ${contextTokens.toLocaleString()} / ${model.contextWindow.toLocaleString()} tokens (${contextPct}%)`,
 							`Cost        $${totalCost.toFixed(4)} this session`,

--- a/src/ui/LoginView.tsx
+++ b/src/ui/LoginView.tsx
@@ -118,7 +118,7 @@ export function LoginView({ onLogin }: LoginViewProps) {
 			{phase === "verifying" && <Text color={COLORS.thinking}>Verifying…</Text>}
 			{error && <Text color={COLORS.error}>✗ {error}</Text>}
 			<Text dimColor>
-				To use a token instead, set apiKey in ~/.orbcode/settings.json or the ORBCODE_TOKEN env var.
+				To use a token instead, set apiKey in ~/.orbcode/settings.json or the MATTERAI_TOKEN env var.
 			</Text>
 		</Box>
 	)

--- a/test-device-auth.mjs
+++ b/test-device-auth.mjs
@@ -36,8 +36,8 @@ const server = http.createServer((req, res) => {
 })
 
 await new Promise((resolve) => server.listen(0, resolve))
-process.env.ORBCODE_BACKEND_URL = `http://localhost:${server.address().port}`
-process.env.ORBCODE_APP_URL = "http://localhost:9999"
+process.env.MATTERAI_BACKEND_URL = `http://localhost:${server.address().port}`
+process.env.MATTERAI_APP_URL = "http://localhost:9999"
 
 const { startDeviceAuth, pollDeviceAuth, getAuthorizeUrl } = await import("./dist/auth/auth.js")
 

--- a/test-hook-env.mjs
+++ b/test-hook-env.mjs
@@ -19,23 +19,23 @@ function makeRunner(config) {
 }
 
 // Set up credential-like env vars that must NEVER reach a hook.
-process.env.ORBCODE_TOKEN = "secret-orbcode-token"
-process.env.ORBCODE_API_KEY = "secret-api-key"
-process.env.ORBCODE_CONFIG_DIR = "/should/not/leak"
+process.env.MATTERAI_TOKEN = "secret-orbcode-token"
+process.env.MATTERAI_API_KEY = "secret-api-key"
+process.env.MATTERAI_CONFIG_DIR = "/should/not/leak"
 process.env.MY_GITHUB_TOKEN = "ghp_secret"
 process.env.AWS_SECRET_ACCESS_KEY = "aws-secret"
 process.env.DATABASE_PASSWORD = "db-pass"
 
-// 1. ORBCODE_TOKEN and ORBCODE_API_KEY are redacted from the hook env.
+// 1. MATTERAI_TOKEN and MATTERAI_API_KEY are redacted from the hook env.
 {
 	const { runner } = makeRunner({
 		SessionStart: [{ hooks: [{ type: "command", command: "env" }] }],
 	})
 	const r = await runner.run("SessionStart", { source: "startup" })
 	const envOutput = r.additionalContext || ""
-	assert.ok(!envOutput.includes("secret-orbcode-token"), "ORBCODE_TOKEN must not leak to hooks")
-	assert.ok(!envOutput.includes("secret-api-key"), "ORBCODE_API_KEY must not leak to hooks")
-	assert.ok(!envOutput.includes("/should/not/leak"), "ORBCODE_CONFIG_DIR must not leak to hooks")
+	assert.ok(!envOutput.includes("secret-orbcode-token"), "MATTERAI_TOKEN must not leak to hooks")
+	assert.ok(!envOutput.includes("secret-api-key"), "MATTERAI_API_KEY must not leak to hooks")
+	assert.ok(!envOutput.includes("/should/not/leak"), "MATTERAI_CONFIG_DIR must not leak to hooks")
 	ok("OrbCode credential env vars are redacted from hooks")
 }
 
@@ -52,22 +52,22 @@ process.env.DATABASE_PASSWORD = "db-pass"
 	ok("credential-pattern env vars (TOKEN/SECRET/PASSWORD) are redacted")
 }
 
-// 3. Non-credential env vars (PATH, HOME, ORBCODE_PROJECT_DIR) are preserved.
+// 3. Non-credential env vars (PATH, HOME, MATTERAI_PROJECT_DIR) are preserved.
 {
 	const { runner } = makeRunner({
 		SessionStart: [{ hooks: [{ type: "command", command: "env" }] }],
 	})
 	const r = await runner.run("SessionStart", { source: "startup" })
 	const envOutput = r.additionalContext || ""
-	assert.ok(envOutput.includes("ORBCODE_PROJECT_DIR"), "ORBCODE_PROJECT_DIR must be present")
+	assert.ok(envOutput.includes("MATTERAI_PROJECT_DIR"), "MATTERAI_PROJECT_DIR must be present")
 	assert.ok(envOutput.includes("PATH="), "PATH must be preserved")
-	ok("non-credential env vars (PATH, ORBCODE_PROJECT_DIR) are preserved")
+	ok("non-credential env vars (PATH, MATTERAI_PROJECT_DIR) are preserved")
 }
 
 // Cleanup
-delete process.env.ORBCODE_TOKEN
-delete process.env.ORBCODE_API_KEY
-delete process.env.ORBCODE_CONFIG_DIR
+delete process.env.MATTERAI_TOKEN
+delete process.env.MATTERAI_API_KEY
+delete process.env.MATTERAI_CONFIG_DIR
 delete process.env.MY_GITHUB_TOKEN
 delete process.env.AWS_SECRET_ACCESS_KEY
 delete process.env.DATABASE_PASSWORD

--- a/test-hook-trust.mjs
+++ b/test-hook-trust.mjs
@@ -19,8 +19,8 @@ const PROJECT_HOOKS = {
 function fresh() {
 	const cfg = mkdtempSync(join(tmpdir(), "orb-cfg-"))
 	const proj = mkdtempSync(join(tmpdir(), "orb-proj-"))
-	process.env.ORBCODE_CONFIG_DIR = cfg
-	delete process.env.ORBCODE_TRUST_PROJECT_HOOKS
+	process.env.MATTERAI_CONFIG_DIR = cfg
+	delete process.env.MATTERAI_TRUST_PROJECT_HOOKS
 	process.chdir(proj)
 	return { cfg, cwd: process.cwd() }
 }
@@ -71,15 +71,15 @@ function writeProjectHooks(cwd, obj) {
 	ok("editing project hooks re-prompts (trust is content-hashed)")
 }
 
-// 4. ORBCODE_TRUST_PROJECT_HOOKS=1 trusts project hooks without prompting (CI).
+// 4. MATTERAI_TRUST_PROJECT_HOOKS=1 trusts project hooks without prompting (CI).
 {
 	const { cwd } = fresh()
 	writeProjectHooks(cwd, PROJECT_HOOKS)
-	process.env.ORBCODE_TRUST_PROJECT_HOOKS = "1"
+	process.env.MATTERAI_TRUST_PROJECT_HOOKS = "1"
 	assert.strictEqual(getPendingProjectHooks(), null, "env override => nothing pending")
 	assert.ok(loadSettings().hooks?.PreToolUse, "env override => hooks active")
-	delete process.env.ORBCODE_TRUST_PROJECT_HOOKS
-	ok("ORBCODE_TRUST_PROJECT_HOOKS=1 enables project hooks (CI escape hatch)")
+	delete process.env.MATTERAI_TRUST_PROJECT_HOOKS
+	ok("MATTERAI_TRUST_PROJECT_HOOKS=1 enables project hooks (CI escape hatch)")
 }
 
 // 5. User-level hooks are ALWAYS active regardless of project trust.
@@ -111,16 +111,16 @@ function writeProjectHooks(cwd, obj) {
 	ok("trusted project hooks merge with (don't clobber) user hooks")
 }
 
-// 7. ORBCODE_TRUST_PROJECT_HOOKS only honors the exact value "1" (not "true").
+// 7. MATTERAI_TRUST_PROJECT_HOOKS only honors the exact value "1" (not "true").
 {
 	const { cwd } = fresh()
 	writeProjectHooks(cwd, PROJECT_HOOKS)
-	process.env.ORBCODE_TRUST_PROJECT_HOOKS = "true"
+	process.env.MATTERAI_TRUST_PROJECT_HOOKS = "true"
 	const pending = getPendingProjectHooks()
 	assert.ok(pending, '"true" must not be honored — only "1"')
 	assert.strictEqual(loadSettings().hooks, undefined, '"true" must not enable hooks')
-	delete process.env.ORBCODE_TRUST_PROJECT_HOOKS
-	ok('ORBCODE_TRUST_PROJECT_HOOKS="true" is not honored (strict "1" only)')
+	delete process.env.MATTERAI_TRUST_PROJECT_HOOKS
+	ok('MATTERAI_TRUST_PROJECT_HOOKS="true" is not honored (strict "1" only)')
 }
 
 console.log(`\n${passed} checks passed`)

--- a/test-hooks.mjs
+++ b/test-hooks.mjs
@@ -172,14 +172,14 @@ function makeRunner(config) {
 	ok("hook receives full JSON payload on stdin")
 }
 
-// 11. ORBCODE_PROJECT_DIR is exported to the hook
+// 11. MATTERAI_PROJECT_DIR is exported to the hook
 {
 	const { runner } = makeRunner({
-		SessionStart: [{ hooks: [{ type: "command", command: 'printf "%s" "$ORBCODE_PROJECT_DIR"' }] }],
+		SessionStart: [{ hooks: [{ type: "command", command: 'printf "%s" "$MATTERAI_PROJECT_DIR"' }] }],
 	})
 	const r = await runner.run("SessionStart", { source: "startup" })
 	assert.equal(r.additionalContext, process.cwd())
-	ok("ORBCODE_PROJECT_DIR exported to hook")
+	ok("MATTERAI_PROJECT_DIR exported to hook")
 }
 
 // 12. timeout: a slow hook is killed and surfaces a timeout message

--- a/test-ui.mjs
+++ b/test-ui.mjs
@@ -6,13 +6,13 @@ import { render } from "ink"
 
 import fs from "node:fs"
 
-process.env.ORBCODE_CONFIG_DIR = "/tmp/orbcode-test-config"
+process.env.MATTERAI_CONFIG_DIR = "/tmp/orbcode-test-config"
 // Self-contained fixture: a syntactically valid but fake JWT, so the app starts
 // in chat view and API calls fail with a clean 401.
 const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url")
-fs.mkdirSync(process.env.ORBCODE_CONFIG_DIR, { recursive: true })
+fs.mkdirSync(process.env.MATTERAI_CONFIG_DIR, { recursive: true })
 fs.writeFileSync(
-	process.env.ORBCODE_CONFIG_DIR + "/config.json",
+	process.env.MATTERAI_CONFIG_DIR + "/config.json",
 	JSON.stringify({
 		token: `${b64({ alg: "HS256" })}.${b64({ sub: "test", env: "production" })}.sig`,
 		model: "axon-code-2-5-pro",


### PR DESCRIPTION
## Summary

Breaking change: renames all environment variables prefixed with `ORBCODE_` to `MATTERAI_` to align the CLI's env-var namespace with the MatterAI brand.

## Renamed variables

| Old | New |
| --- | --- |
| `ORBCODE_TOKEN` | `MATTERAI_TOKEN` |
| `ORBCODE_API_KEY` | `MATTERAI_API_KEY` |
| `ORBCODE_BASE_URL` | `MATTERAI_BASE_URL` |
| `ORBCODE_MODEL` | `MATTERAI_MODEL` |
| `ORBCODE_CONFIG_DIR` | `MATTERAI_CONFIG_DIR` |
| `ORBCODE_BACKEND_URL` | `MATTERAI_BACKEND_URL` |
| `ORBCODE_APP_URL` | `MATTERAI_APP_URL` |
| `ORBCODE_PROJECT_DIR` | `MATTERAI_PROJECT_DIR` |
| `ORBCODE_TRUST_PROJECT_HOOKS` | `MATTERAI_TRUST_PROJECT_HOOKS` |

## Files changed

- `src/` — all env var references in source (auth, config, hooks, headless, index, UI)
- Tests — `test-device-auth.mjs`, `test-hook-env.mjs`, `test-hook-trust.mjs`, `test-hooks.mjs`, `test-ui.mjs`
- Docs — `README.md`, `CHANGELOG.md`, `docs/HOOKS.md`
- `package.json` — version bump to `0.2.0`

## Migration

Users who set any of these env vars in scripts, CI configs, or `.env` files must update the prefix from `ORBCODE_` to `MATTERAI_`.

## Version

Bumps to `0.2.0` (minor bump for breaking change in 0.x semver). After merge, a `v0.2.0` tag will be pushed to trigger the release workflow.

## Checklist

- [x] All `ORBCODE_` occurrences renamed to `MATTERAI_`
- [x] `dist/` rebuilt from updated source (`npm run build` exit 0)
- [x] No remaining `ORBCODE_` occurrences outside `node_modules/`, `.git/`, `dist/`
- [x] CHANGELOG entry added
- [x] Version bumped to `0.2.0`