### PR TITLE
release: v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # OrbCode CLI
 
+[![npm version](https://img.shields.io/npm/v/@matterailab/orbcode?color=blue&logo=npm)](https://www.npmjs.com/package/@matterailab/orbcode)
+[![npm downloads](https://img.shields.io/npm/dm/@matterailab/orbcode?logo=npm)](https://www.npmjs.com/package/@matterailab/orbcode)
+[![license](https://img.shields.io/npm/l/@matterailab/orbcode?color=green)](./LICENSE)
+[![node](https://img.shields.io/node/v/@matterailab/orbcode?color=green&logo=node.js)](https://nodejs.org)
+[![github stars](https://img.shields.io/github/stars/MatterAIOrg/OrbCode?style=social&logo=github)](https://github.com/MatterAIOrg/OrbCode)
+[![github issues](https://img.shields.io/github/issues/MatterAIOrg/OrbCode?logo=github)](https://github.com/MatterAIOrg/OrbCode/issues)
+[![docs](https://img.shields.io/badge/docs-docs.matterai.so-purple)](https://docs.matterai.so/orbcode-cli/overview)
+
 Agentic coding in your terminal — powered by **Axon models by MatterAI**.
+
+> 📖 **Full documentation: <https://docs.matterai.so/orbcode-cli/overview>**
 
 OrbCode CLI is a standalone terminal port of the Orbital extension: the same Axon
 models, the same native tool schemas, the same MatterAI auth backend — rebuilt from
@@ -13,6 +23,7 @@ activity rows, edit/command approvals, and todo tracking.
 
 ## Table of contents
 
+- [Quick start](#quick-start)
 - [Install](#install)
 - [Updating / relinking](#updating--relinking)
 - [Usage](#usage)
@@ -31,10 +42,29 @@ activity rows, edit/command approvals, and todo tracking.
 - [Development](#development)
 - [Tests](#tests)
 - [Troubleshooting](#troubleshooting)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
 - [License](#license)
 
 ---
+
+## Quick start
+
+```bash
+npm install -g @matterailab/orbcode   # install the CLI (needs Node.js >= 20)
+orbcode login                          # sign in once via your browser
+cd your-project && orbcode             # start coding
+```
+
+That's it — you're in an interactive agent session. Ask it to read, edit, run
+commands, or fix bugs. New here? Skim the [docs](https://docs.matterai.so/orbcode-cli/overview)
+or jump to [Usage](#usage).
+
+Prefer not to install globally? Run it on the fly:
+
+```bash
+npx @matterailab/orbcode
+```
 
 ## Install
 
@@ -143,18 +173,20 @@ Sign out with `/logout` (removes the saved token).
 
 ## Models
 
-The two Axon models are built in; `/model` opens a scroll-and-select picker
-(`/model <id>` still selects directly). Additional models can be declared via
-`customModels` in settings.json. The choice persists across sessions.
+The built-in Axon models are listed below; `/model` opens a scroll-and-select
+picker (`/model <id>` still selects directly). Additional models can be
+declared via `customModels` in settings.json. The choice persists across
+sessions.
 
-| id                     | context | max output | pricing            |
-| ---------------------- | ------- | ---------- | ------------------ |
-| `axon-eido-3-code-pro` | 400k    | 64k        | $3/M in · $9/M out |
-| `axon-code-2-5-pro`    | 400k    | 64k        | $2/M in · $6/M out |
-| `axon-code-2-5-mini`   | 400k    | 64k        | free               |
+| id                        | context | max output | pricing                |
+| ------------------------- | ------- | ---------- | ---------------------- |
+| `axon-eido-3-code-pro`    | 400k    | 64k        | $3/M in · $9/M out     |
+| `axon-eido-3-code-mini`   | 400k    | 64k        | $1.5/M in · $4.5/M out |
+| `axon-code-2-5-pro`       | 400k    | 64k        | $2/M in · $6/M out     |
+| `axon-code-2-5-mini`      | 400k    | 64k        | free                   |
 
-`axon-code-2-5-pro` is the default. All three support native JSON tool calls and
-image input. Cost comes from the API's usage chunks (`is_byok`-aware) and is
+`axon-eido-3-code-mini` is the default. All four support native JSON tool calls
+and image input. Cost comes from the API's usage chunks (`is_byok`-aware) and is
 shown in the status bar.
 
 ### Other providers (Anthropic, OpenAI-compatible)
@@ -198,6 +230,11 @@ MatterAI login.
   (e.g. for models that don't support `effort`).
 - `provider: "openai-compatible"` → any OpenAI-compatible endpoint; requires
   `baseUrl`. Key from `apiKey` on the entry.
+
+> **Note:** Third-party models are **not** shown in the TUI's `/model` picker.
+> They're still available headlessly via `orbcode -p "..." --model <id>` (or
+> `MATTERAI_MODEL=<id>`); in an interactive session, `/model claude-opus-4-8`
+> prints the exact command to run.
 
 Anything without a `provider` (or `provider: "matterai"`) keeps using the
 MatterAI gateway untouched.
@@ -600,6 +637,13 @@ node test-device-auth.mjs  # device-auth polling flow against a local mock
   terminal, then restart it. Terminals that already prompted for access (e.g.
   iTerm) keep working. A normal global install (`npm install -g @matterailab/orbcode`) is
   unaffected because it lives outside protected folders.
+
+## Documentation
+
+The README covers the essentials. For the complete, kept-up-to-date reference
+(guides, configuration, hooks cookbook, troubleshooting), visit the docs site:
+
+**👉 <https://docs.matterai.so/orbcode-cli/overview>**
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -53,7 +53,8 @@ export const ANTHROPIC_MODELS: Record<string, AxonModel> = {
   "claude-opus-4-8": {
     id: "claude-opus-4-8",
     name: "Claude Opus 4.8",
-    description: "Anthropic's most capable Opus model — long-horizon agentic work, knowledge work, and coding.",
+    description:
+      "Anthropic's most capable Opus model — long-horizon agentic work, knowledge work, and coding.",
     contextWindow: 1_000_000,
     maxOutputTokens: 64000,
     supportsImages: true,
@@ -65,7 +66,8 @@ export const ANTHROPIC_MODELS: Record<string, AxonModel> = {
   "claude-opus-4-7": {
     id: "claude-opus-4-7",
     name: "Claude Opus 4.7",
-    description: "Previous-generation Opus — highly autonomous, strong on agentic, vision, and memory tasks.",
+    description:
+      "Previous-generation Opus — highly autonomous, strong on agentic, vision, and memory tasks.",
     contextWindow: 1_000_000,
     maxOutputTokens: 64000,
     supportsImages: true,
@@ -89,7 +91,8 @@ export const ANTHROPIC_MODELS: Record<string, AxonModel> = {
   "claude-sonnet-4-6": {
     id: "claude-sonnet-4-6",
     name: "Claude Sonnet 4.6",
-    description: "Anthropic's best balance of speed and intelligence; adaptive thinking, 1M context.",
+    description:
+      "Anthropic's best balance of speed and intelligence; adaptive thinking, 1M context.",
     contextWindow: 1_000_000,
     maxOutputTokens: 64000,
     supportsImages: true,
@@ -101,7 +104,8 @@ export const ANTHROPIC_MODELS: Record<string, AxonModel> = {
   "claude-haiku-4-5": {
     id: "claude-haiku-4-5",
     name: "Claude Haiku 4.5",
-    description: "Fastest, most cost-effective Claude model for simple, latency-sensitive tasks.",
+    description:
+      "Fastest, most cost-effective Claude model for simple, latency-sensitive tasks.",
     contextWindow: 200_000,
     maxOutputTokens: 64000,
     supportsImages: true,
@@ -115,7 +119,8 @@ export const ANTHROPIC_MODELS: Record<string, AxonModel> = {
   "claude-fable-5": {
     id: "claude-fable-5",
     name: "Claude Fable 5",
-    description: "Anthropic's most capable widely released model — most demanding reasoning and long-horizon work.",
+    description:
+      "Anthropic's most capable widely released model — most demanding reasoning and long-horizon work.",
     contextWindow: 1_000_000,
     maxOutputTokens: 64000,
     supportsImages: true,
@@ -126,8 +131,14 @@ export const ANTHROPIC_MODELS: Record<string, AxonModel> = {
   },
 };
 
-export const AXON_MODELS: Record<string, AxonModel> = {
-  ...ANTHROPIC_MODELS,
+/**
+ * Axon's own models (MatterAI gateway). These are the only models shown in
+ * the TUI's `/model` picker and are the supported defaults. Third-party
+ * providers (Anthropic, OpenAI-compatible) are registered under
+ * `AXON_MODELS` for `-p --model` runs but are intentionally hidden from the
+ * interactive picker for now.
+ */
+export const BUILTIN_AXON_MODELS: Record<string, AxonModel> = {
   "axon-code-2-5-mini": {
     id: "axon-code-2-5-mini",
     name: "Axon Code 2.5 Mini (free)",
@@ -168,17 +179,28 @@ export const AXON_MODELS: Record<string, AxonModel> = {
     id: "axon-eido-3-code-mini",
     name: "Axon Eido 3 Mini",
     description:
-      "Axon Eido 3 Mini is a general purpose super intelligent LLM coding model for low-effort day-to-day tasks",
+      "Axon Eido 3 Mini is a general purpose super intelligent LLM coding model for high-effort day-to-day tasks",
     contextWindow: 400000,
     maxOutputTokens: 64000,
     supportsImages: true,
-    inputPrice: 0.000001,
-    outputPrice: 0.000003,
+    inputPrice: 0.0000015,
+    outputPrice: 0.0000045,
     free: false,
   },
 };
 
-export const DEFAULT_MODEL_ID = "axon-code-2-5-pro";
+/**
+ * Full model registry, including third-party providers. The TUI picker uses
+ * `BUILTIN_AXON_MODELS`; non-interactive `-p --model` runs resolve through
+ * this map, so a custom 3P entry (e.g. `claude-opus-4-8` from settings.json)
+ * still works headlessly.
+ */
+export const AXON_MODELS: Record<string, AxonModel> = {
+  ...BUILTIN_AXON_MODELS,
+  ...ANTHROPIC_MODELS,
+};
+
+export const DEFAULT_MODEL_ID = "axon-eido-3-code-mini";
 
 /** A model declared in settings.json; everything except the id is optional. */
 export interface CustomModelConfig {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -3,7 +3,7 @@ import { Box, Static, Text, useApp, useInput } from "ink"
 import open from "open"
 
 import { COLORS, VERSION } from "../branding.js"
-import { AXON_MODELS, getModel, isValidAxonModel } from "../api/models.js"
+import { BUILTIN_AXON_MODELS, getModel, isValidAxonModel } from "../api/models.js"
 import { LoginView } from "./LoginView.js"
 import { APP_URL, fetchBalance, fetchProfile, fetchTaskTitle, type ProfileData } from "../auth/auth.js"
 import {
@@ -524,21 +524,31 @@ export function App({
 					})
 					break
 				case "/model": {
-					const ids = Object.keys(AXON_MODELS)
-					if (arg && isValidAxonModel(arg)) {
+					// The interactive picker is restricted to Axon's own models for now.
+					// Third-party providers (Anthropic, OpenAI-compatible) are still
+					// usable headlessly via `orbcode -p "..." --model <id>` — see
+					// the README "Other providers" section.
+					const pickerIds = Object.keys(BUILTIN_AXON_MODELS)
+					if (arg && pickerIds.includes(arg)) {
 						switchModel(arg)
+					} else if (arg && isValidAxonModel(arg)) {
+						// Recognized id, but it's a third-party model: not selectable in the TUI.
+						pushRow({
+							kind: "info",
+							text: `Model "${arg}" is only available in non-interactive mode. Run: orbcode -p "..." --model ${arg}`,
+						})
 					} else if (arg) {
 						// Allow short suffixes like "pro" or "mini" to resolve to the
 						// latest matching registered id, so /model pro keeps working
 						// as new model generations are added.
-						const matches = ids
+						const matches = pickerIds
 							.filter((id) => id.endsWith(`-${arg}`))
 							.sort()
 							.reverse()
 						if (matches.length > 0) {
 							switchModel(matches[0])
 						} else {
-							pushRow({ kind: "error", text: `Unknown model "${arg}". Available: ${ids.join(", ")}` })
+							pushRow({ kind: "error", text: `Unknown model "${arg}". Available: ${pickerIds.join(", ")}` })
 						}
 					} else {
 						setModelPickerOpen(true)

--- a/src/ui/components/ModelPicker.tsx
+++ b/src/ui/components/ModelPicker.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import { Box, Text, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
-import { AXON_MODELS, type AxonModel } from "../../api/models.js"
+import { BUILTIN_AXON_MODELS, type AxonModel } from "../../api/models.js"
 
 const VISIBLE_ROWS = 6
 
@@ -19,7 +19,7 @@ function formatPrice(model: AxonModel): string {
 }
 
 export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps) {
-	const models = Object.values(AXON_MODELS)
+	const models = Object.values(BUILTIN_AXON_MODELS)
 	const [selected, setSelected] = useState(() => {
 		const index = models.findIndex((m) => m.id === currentId)
 		return index === -1 ? 0 : index


### PR DESCRIPTION
## v0.2.2

### Highlights

- **README polish**: added npm/license/node/stars/docs badges, a quick-start section, and a link to the full docs site (https://docs.matterai.so/orbcode-cli/overview).
- **Default model → Axon Eido 3 Mini**: fresh installs and users who haven't picked a model via `/model` now land on `axon-eido-3-code-mini`. Existing users keep their persisted choice.
- **TUI `/model` picker is Axon-only**: third-party models (Anthropic, OpenAI-compatible) no longer appear in the interactive picker. They're still available headlessly via `orbcode -p "..." --model <id>` (or `MATTERAI_MODEL`); the TUI prints a hint pointing there when a 3P id is requested via `/model <id>`.

### Files changed

- `package.json` — bump version to 0.2.2
- `README.md` — badges, quick start, docs link, model table updated
- `src/api/models.ts` — `DEFAULT_MODEL_ID` → `axon-eido-3-code-mini`; split `BUILTIN_AXON_MODELS` from `AXON_MODELS`
- `src/ui/App.tsx` — `/model` command rejects 3P ids with a hint to use headless
- `src/ui/components/ModelPicker.tsx` — picker reads `BUILTIN_AXON_MODELS`

### Release flow

Per `RELEASE.md`: after this PR is merged, the maintainer will tag the merge commit `v0.2.2` on `main` and push the tag — that's what triggers the npm publish via `.github/workflows/release.yml`.