### PR TITLE
release: v0.2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ build/
 .DS_Store
 coverage/
 .cache/
+
+# Per-developer project memory loaded by the agent at runtime.
+# The .orbcode/ directory itself is a valid project-config location
+# (project-level settings.json), so only the personal AGENTS.md is excluded.
+.orbcode/AGENTS.md

--- a/.orbital/AGENTS.md
+++ b/.orbital/AGENTS.md
@@ -1,4 +1,0 @@
-# Update CHANGELOG.md Rule
-
-- When implementing a feature, bug-fix or any change, ensure CHANGELOG.md is updated.
-- Before pushing the changes, ensure the changes in the CHANGELOG.md are part of the new version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-06-19
+
+### Fixed
+
+- **`orbcode mcp add` no longer swallows a `--` separator after the server
+  name as the command.** `orbcode mcp add --scope user context7 -- npx -y
+  @upstash/context7-mcp ...` previously wrote `command: "--"` (a literal
+  `--`), so the server failed to spawn. A `--` immediately after the server
+  name is now consumed as the flag/command separator, matching Claude Code's
+  `claude mcp add <name> -- <command>`. A later `--` is still passed through
+  as a literal argument to the server command.
+
+### Changed
+
+- **`/cost` slash command renamed to `/usage`.** It now fetches and prints
+  your plan usage from `/axoncode/profile` — the plan name (uppercased) and,
+  for tiered accounts, the 5-hour / weekly / monthly windows with percentage
+  used and reset time (or the credits reset date for non-tiered accounts) —
+  instead of showing the session cost and fetching the account balance.
+  Session cost remains in the status bar and `/status`. The usage block no
+  longer prints the legacy `usagePercentage` and `remainingReviews` lines.
+
 ## [0.2.0] - 2026-06-17
 
 ### Changed
@@ -284,7 +306,9 @@ non-interactive mode.
 - Cross-platform shell detection and path handling in
   `execute_command` (Windows vs POSIX, `cmd` vs `bash`, etc.).
 
-[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.1.14...HEAD
+[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.2.0...HEAD
+[0.2.3]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.2.3
+[0.2.0]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.2.0
 [0.1.14]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.1.14
 [0.1.13]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.1.13
 [0.1.8]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.1.8

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ MatterAI gateway untouched.
 | `/compact`   | summarize the conversation and replace history with the summary                                       |
 | `/tasks`     | print the current task list                                                                           |
 | `/status`    | version, model, account, gateway, context usage, cost, approval modes                                 |
-| `/cost`      | show session cost and fetch account balance                                                           |
+| `/usage`     | fetch plan usage                                                                                      |
 | `/init`      | analyze the codebase and create/improve `AGENTS.md`                                                   |
 | `/mcp`       | manage MCP servers — enable, disable, reconnect, view status & tool counts                            |
 | `/login`     | start the browser sign-in flow                                                                        |
@@ -876,7 +876,7 @@ extension). It shows in the status bar, is written into the session file (so
 `/resume` lists real titles), and becomes the terminal window title:
 `<title> (orbcode)`.
 
-**Usage data**: `/status` and `/cost` fetch `/axoncode/profile` and show the
+**Usage data**: `/status` and `/usage` fetch `/axoncode/profile` and show the
 plan, usage percentage (used/remaining), remaining reviews, and the credits
 reset date — the same data as the extension's profile view.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ activity rows, edit/command approvals, and todo tracking.
 - [Headless mode](#headless-mode)
 - [Configuration](#configuration)
 - [Hooks](#hooks)
+- [MCP servers](#mcp-servers)
+- [Skills](#skills)
+- [AGENTS.md memory](#agentsmd-memory)
 - [Architecture](#architecture)
 - [Tools](#tools)
 - [Agent loop](#agent-loop)
@@ -295,6 +298,7 @@ MatterAI gateway untouched.
 | `/status`    | version, model, account, gateway, context usage, cost, approval modes                                 |
 | `/cost`      | show session cost and fetch account balance                                                           |
 | `/init`      | analyze the codebase and create/improve `AGENTS.md`                                                   |
+| `/mcp`       | manage MCP servers — enable, disable, reconnect, view status & tool counts                            |
 | `/login`     | start the browser sign-in flow                                                                        |
 | `/logout`    | remove the saved token                                                                                |
 | `/version`   | print the CLI version                                                                                 |
@@ -486,6 +490,316 @@ untrusted.
 **→ Full reference with worked recipes for every event:
 [docs/HOOKS.md](https://github.com/MatterAIOrg/OrbCode/blob/main/docs/HOOKS.md).**
 
+## MCP servers
+
+OrbCode connects to external tools via the **Model Context Protocol** (MCP). MCP
+servers expose tools that appear alongside the native tools as
+`mcp__<server>__<tool>` and can be called by the model like any other tool.
+
+### Configuration
+
+MCP servers are configured in three scopes (highest precedence last):
+
+1. **User scope** — `mcpServers` in `~/.orbcode/settings.json`. Applies to every
+   project on this machine.
+2. **Project scope** — `.mcp.json` in the project root (and parent directories,
+   closer-to-cwd wins). This is the check-into-git, shared format, compatible
+   with Claude Code's `.mcp.json`.
+3. **Local scope** — `mcpServers` in `.orbcode/settings.json`. Per-project,
+   per-machine overrides (not checked in).
+
+### Adding servers from the command line
+
+The `orbcode mcp` subcommand manages servers without editing JSON by hand —
+like Claude Code's `claude mcp add/remove/list`:
+
+```bash
+# stdio (default transport): name + command + args
+orbcode mcp add filesystem npx -y @modelcontextprotocol/server-filesystem /Users/me/projects
+
+# http transport
+orbcode mcp add --transport http linear-server https://mcp.linear.app/mcp
+
+# sse transport with a header
+orbcode mcp add -t sse --header "Authorization=Bearer ${TOKEN}" my-sse https://example.com/sse
+
+# http with OAuth (auth from /mcp after adding)
+orbcode mcp add --transport http --oauth notion https://mcp.notion.com/mcp
+orbcode mcp add -t http --oauth --oauth-scope "read:issues" linear https://mcp.linear.app/mcp
+
+# stdio with env vars, written to user scope (~/.orbcode/settings.json)
+orbcode mcp add -s user -e API_KEY=secret -e DEBUG=true my-server node server.js
+
+# list all configured servers (name, scope, transport detail)
+orbcode mcp list
+
+# remove a server (finds it in whichever scope it lives)
+orbcode mcp remove filesystem
+```
+
+Flags go before the server name; everything after the name is the command +
+args (so stdio servers can take their own flags like `-y`). Use `--` to force
+the split if needed. `-s`/`--scope` selects `project` (default, writes
+`.mcp.json`), `user` (writes `~/.orbcode/settings.json`), or `local` (writes
+`.orbcode/settings.json`). Run `orbcode mcp help` for the full reference.
+
+`add` and `remove` print the file they modified:
+
+```
+$ orbcode mcp add --transport http linear-server https://mcp.linear.app/mcp
+Added HTTP MCP server linear-server
+  URL: https://mcp.linear.app/mcp
+  Scope: project
+  File modified: /Users/me/my-project/.mcp.json
+```
+
+OAuth servers show `needs-auth` after adding — they don't auto-open a browser.
+Open `/mcp` in the TUI, select the server, and press `a` (or `1`) to
+authenticate. OrbCode shows an auth screen:
+
+```
+  Authenticating with linear-server…
+
+  ✽  A browser window will open for authentication
+
+  If your browser doesn't open automatically, copy this URL manually (c to copy)
+  https://mcp.linear.app/authorize?response_type=code&client_id=…
+
+  If the redirect page shows a connection error, paste the URL from your browser's address bar:
+  URL> █
+
+  Return here after authenticating in your browser. Press Esc to go back.
+```
+
+The browser opens automatically to the server's OAuth authorize page (RFC 9728
+discovery → PKCE → redirect to a loopback callback → token exchange). Press `c`
+to copy the URL to the clipboard if the browser doesn't open. If the redirect
+fails (e.g. wrong port), press enter and paste the redirect URL from the
+browser's address bar — OrbCode extracts the code from it. Either path
+(callback or paste) completes the flow. Tokens persist under
+`~/.orbcode/mcp-auth/<server>.json` (mode 0600) for future sessions; refresh
+happens automatically when they expire. For M2M grants (`client_credentials`,
+`private_key_jwt`), there's no browser — the token exchange is direct.
+
+`.mcp.json` format (project scope):
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/me/projects"]
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": { "Authorization": "Bearer ${GITHUB_TOKEN}" }
+    }
+  }
+}
+```
+
+`settings.json` `mcpServers` (user/local scope) uses the same per-server shape.
+Environment variables (`${VAR}`) are expanded from `process.env`.
+
+Three server types are supported:
+
+- **stdio** (default, omit `type`): OrbCode spawns `command` with `args` and
+  talks over stdin/stdout. Optional `env` and `cwd`.
+- **http**: Streamable HTTP transport. `url` + optional `headers` + optional
+  `oauth` (see [Authentication](#mcp-authentication)).
+- **sse**: Server-Sent Events (legacy remote). `url` + optional `headers` +
+  optional `oauth`.
+
+### MCP authentication
+
+Remote servers (http/sse) often require auth. OrbCode supports three ways:
+
+**1. Static headers** (API keys, personal access tokens). Use `headers` with
+`${ENV_VAR}` expansion — the token is read from the environment, never written
+to disk:
+
+```json
+{
+  "github": {
+    "type": "http",
+    "url": "https://api.githubcopilot.com/mcp/",
+    "headers": { "Authorization": "Bearer ${GITHUB_TOKEN}" }
+  }
+}
+```
+
+**2. OAuth 2.0 flows** (for servers that require user login: GitHub, Google
+Drive, Slack, Notion, …). Set `oauth: true` (or `{ "scope": "..." }`) on an
+http/sse server. OrbCode runs the full authorization-code flow via the SDK:
+RFC 9728 protected-resource discovery, RFC 8414 authorization-server metadata,
+PKCE, dynamic client registration, and token refresh. A one-shot loopback HTTP
+server receives the browser redirect. Tokens, client info, code verifiers, and
+discovery state are persisted per-server under `~/.orbcode/mcp-auth/<server>.json`
+(mode 0600) so re-auth is only needed when a token expires or is revoked.
+
+```json
+{
+  "notion": {
+    "type": "http",
+    "url": "https://mcp.notion.com/mcp",
+    "oauth": true
+  },
+  "google-drive": {
+    "type": "http",
+    "url": "https://mcp.google.com/drive",
+    "oauth": { "scope": "https://www.googleapis.com/auth/drive.readonly" }
+  }
+}
+```
+
+**3. Machine-to-machine OAuth** (no browser). For service-to-service auth,
+use `client_credentials` or `private_key_jwt` grants — these use the SDK's
+built-in `ClientCredentialsProvider` / `PrivateKeyJwtProvider`:
+
+```json
+{
+  "internal-api": {
+    "type": "http",
+    "url": "https://internal.example.com/mcp",
+    "oauth": {
+      "grantType": "client_credentials",
+      "clientId": "orbcode-client",
+      "clientSecret": "${INTERNAL_CLIENT_SECRET}",
+      "scope": "mcp:tools"
+    }
+  },
+  "jwt-api": {
+    "type": "http",
+    "url": "https://jwt.example.com/mcp",
+    "oauth": {
+      "grantType": "private_key_jwt",
+      "clientId": "orbcode-client",
+      "privateKey": "${JWT_PRIVATE_KEY_PEM}",
+      "algorithm": "RS256"
+    }
+  }
+}
+```
+
+When a server needs auth, its status shows `needs-auth` in `/mcp`; press **a**
+to re-authenticate (clears stored tokens and re-runs the flow). Secrets in
+`oauth` blocks support `${ENV_VAR}` expansion like `headers`, so client
+secrets and private keys can be sourced from the environment rather than
+committed to `.mcp.json`.
+
+### Enabling & disabling servers
+
+- **User/local-scope servers** connect automatically on startup (you wrote them,
+  so they're trusted).
+- **Project-scope servers** (from `.mcp.json`) require a one-time approval: on
+  first launch in a project, OrbCode shows a checklist of detected servers.
+  Select the ones you trust; the decision is persisted to
+  `.orbcode/settings.json` (`enabledMcpServers` / `disabledMcpServers`) so they
+  auto-connect on future sessions.
+
+The `/mcp` command opens an interactive manager at any time:
+
+- ↑/↓ to select a server. The selected server shows a detail panel with
+  **Status**, **Auth** (authenticated / not authenticated / static headers),
+  **URL** (or stdio command), **Config location** (the file path), and a
+  numbered action list.
+- **enter** or **2** toggles enable/disable. **r** or **3** reconnects. **a**
+  or **1** authenticates a `needs-auth` OAuth server (opens a browser for the
+  authorization-code flow; M2M grants exchange directly). **esc** closes.
+- Each server shows a live status icon: `✓ connected`, `△ needs-auth`,
+  `✗ failed`, `○ disabled`, `⋯ connecting`, plus a tool count when connected.
+- Enable/disable choices are persisted per-project. OAuth tokens are persisted
+  per-server under `~/.orbcode/mcp-auth/`.
+
+### Headless mode
+
+In `orbcode -p`, there's no interactive approval, so project-scope servers are
+only connected if they were previously approved (via an interactive `/mcp`
+session). Unapproved project servers are skipped with a stderr note. User/local
+servers connect as usual.
+
+## Skills
+
+Skills are reusable instruction sets the model can load on demand. A skill is a
+directory containing a `SKILL.md` file with optional YAML frontmatter and a
+markdown body of specialized instructions.
+
+### Creating a skill
+
+Place a directory under `~/.orbcode/skills/` (user, applies everywhere) or
+`.orbcode/skills/` (project, checked into the repo):
+
+```
+~/.orbcode/skills/
+  my-skill/
+    SKILL.md
+```
+
+`SKILL.md` format:
+
+```markdown
+---
+description: Write concise, idiomatic Go code following project conventions
+when_to_use: the task involves writing or reviewing Go code
+---
+
+# Go style skill
+
+When writing Go in this project:
+- Use `errors.Join` for multi-error aggregation
+- Prefer table-driven tests
+- ...
+```
+
+- `description` (frontmatter or first paragraph): shown in the skill catalog.
+- `when_to_use` (frontmatter): a hint telling the model when to invoke this skill.
+- `${SKILL_DIR}` in the body is replaced with the skill's absolute directory
+  path, so you can reference bundled scripts.
+
+### How skills are used
+
+The skill catalog (names + descriptions + when-to-use) is injected into the
+system prompt. When a task matches a skill's `when_to_use` condition, the model
+calls the `use_skill` tool with the skill's name, which loads the full
+instructions into context. Project skills override user skills on name
+collisions (closer-to-cwd wins).
+
+## AGENTS.md memory
+
+AGENTS.md files provide project- and user-level instructions that are injected
+into every system prompt — build commands, code style, architecture notes,
+conventions. This is OrbCode's equivalent of Claude Code's `CLAUDE.md`, using
+the open `AGENTS.md` filename so it works across tools.
+
+### Discovery
+
+Files are loaded in this order (lowest precedence first; higher-precedence files
+appear later and get more weight):
+
+1. **User memory**: `~/.orbcode/AGENTS.md` — personal global instructions.
+2. **Project memory**: `AGENTS.md` and `.orbcode/AGENTS.md` in the cwd and every
+   parent directory (closer-to-cwd wins). Checked into the repo, shared with the
+   team.
+3. **Local memory**: `AGENTS.local.md` in the cwd and parents — private
+   per-machine overrides (gitignore this).
+
+### @include directives
+
+An AGENTS.md file can include other files with `@path` references:
+
+```markdown
+# Project guide
+
+See the detailed style guide: @./docs/style.md
+And the global one: @~/orbcode-global.md
+```
+
+`@path` (relative to the including file), `@./path`, `@~/path`, and `@/abs/path`
+are all supported. Includes are resolved recursively (up to 5 levels, with cycle
+detection). Use `/init` to have OrbCode generate a starter `AGENTS.md` by
+analyzing the codebase.
+
 ## Architecture
 
 ```
@@ -502,22 +816,49 @@ src/
     stream.ts        chunk model: text / reasoning / native_tool_calls / usage
     headers.ts       X-AxonCode-Version, X-AxonCode-TaskId, X-AXON-REPO, …
   prompts/system.ts  system prompt: agent roleDefinition + tool guide (ported
-                     verbatim from the extension) + CLI system-info section
+                     verbatim from the extension) + CLI system-info section +
+                     AGENTS.md memory + skills catalog injection
   tools/
     schemas/         native-tools JSON schemas, copied verbatim from the extension
-    executors/       CLI implementations (fs, child_process, search, web)
-    index.ts         dispatch, approval classification, call summaries
+    executors/       CLI implementations (fs, child_process, search, web, skills)
+    index.ts         dispatch, approval classification, call summaries, MCP routing
   core/
-    agent.ts         the agent loop (see below)
+    agent.ts         the agent loop (see below); owns the McpManager
     events.ts        AgentEvent model consumed by the UI
     hooks.ts         lifecycle hooks engine, Claude-Code compatible (see Hooks)
+  mcp/
+    types.ts         MCP server config + connection state types
+    config.ts        .mcp.json + settings.json mcpServers loader (3-scope merge)
+    client.ts        SDK transport (stdio/http/sse) + tool enum + tool call
+    manager.ts       McpManager: connection lifecycle, enable/disable, tool routing
+  skills/
+    types.ts         Skill + frontmatter types
+    loader.ts        ~/.orbcode/skills + .orbcode/skills discovery (SKILL.md format)
+  memory/
+    types.ts         MemoryFile type
+    loader.ts        AGENTS.md discovery (user/project/local) + @include resolution
   ui/
     App.tsx          main Ink app: static finalized rows + dynamic streaming area
     LoginView.tsx    device-flow login screen with paste fallback
     components/      Header, InputBox, rows, ApprovalPrompt, FollowupPrompt,
-                     Spinner, StatusBar
+                     HookTrustPrompt, McpApprovalPrompt, McpPicker, ModelPicker,
+                     SessionPicker, Spinner, StatusBar
     markdown.ts      markdown → ANSI renderer
 ```
+
+**MCP integration**: the `McpManager` (owned by the agent) loads the merged
+config on `start()`, connects to approved servers in parallel, and exposes
+their tools as `mcp__<server>__<tool>` definitions alongside the native tools.
+The agent routes any `mcp__*` tool call to the manager, which dispatches it to
+the right SDK client. Project-scope servers (from `.mcp.json`) require a
+one-time approval; the TUI shows a checklist at startup and `/mcp` manages them
+at runtime. Connections are torn down on session end.
+
+**Skills & memory**: on agent construction, `loadMemoryFiles()` walks the
+AGENTS.md discovery chain (user → project → local, with `@include` resolution)
+and `loadSkills()` walks the skills directories. Both are injected into the
+system prompt so the model sees project instructions and the skill catalog on
+every turn. The `use_skill` tool loads a skill's full body on demand.
 
 **Streaming** faithfully ports the extension's handler quirks: cumulative
 content dedup (some backends re-send full content), `<think>` blocks routed to
@@ -554,11 +895,13 @@ Active in the CLI (schemas byte-identical to the extension's `native-tools`):
 | `execute_command`          | user's shell, 120s timeout, 30k output cap, optional cwd                                     |
 | `web_search` / `web_fetch` | proxied through the MatterAI backend with your token                                         |
 | `update_todo_list`         | drives the TUI todo panel                                                                    |
+| `use_skill`                | loads a skill's full instructions from ~/.orbcode/skills or .orbcode/skills                  |
 | `ask_followup_question`    | interactive menu in the TUI                                                                  |
 | `attempt_completion`       | ends the turn with a completion card                                                         |
+| `mcp__<server>__<tool>`    | any tool exposed by a connected MCP server (see [MCP servers](#mcp-servers))                 |
 
 Present in `tools/schemas/` but **inactive** (need IDE services): `codebase_search`,
-`lsp`, `list_code_definition_names`, `use_skill`, `check_past_chat_memories`,
+`lsp`, `list_code_definition_names`, `check_past_chat_memories`,
 `browser_action`, `generate_image`, `new_task`, `switch_mode`,
 `fetch_instructions`, `run_slash_command`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.1.13",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matterailab/orbcode",
-      "version": "0.1.13",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/openai-compatible": "^2.0.51",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.207",
         "chalk": "^5.3.0",
         "ink": "^5.2.1",
@@ -566,6 +567,58 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -646,6 +699,44 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -674,6 +765,39 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -733,6 +857,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -748,6 +909,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -759,6 +929,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chalk": {
@@ -856,6 +1042,28 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -865,12 +1073,78 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -921,6 +1195,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -935,11 +1218,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -1050,6 +1348,12 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
@@ -1057,6 +1361,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/event-target-shim": {
@@ -1068,6 +1381,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
@@ -1075,6 +1400,135 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/form-data": {
@@ -1106,6 +1560,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -1232,6 +1704,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -1239,6 +1740,22 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/indent-string": {
@@ -1252,6 +1769,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ink": {
       "version": "5.2.1",
@@ -1299,6 +1822,24 @@
         "react-devtools-core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-docker": {
@@ -1361,6 +1902,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -1376,6 +1923,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1387,6 +1949,18 @@
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1407,6 +1981,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mime-db": {
@@ -1445,6 +2040,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -1463,6 +2067,48 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -1543,6 +2189,15 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -1550,6 +2205,25 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picomatch": {
@@ -1562,6 +2236,67 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/react": {
@@ -1592,6 +2327,15 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
@@ -1608,6 +2352,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -1620,6 +2380,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -1627,6 +2393,175 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -1678,6 +2613,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -1708,6 +2652,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {
@@ -1747,6 +2700,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1767,6 +2776,24 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -1781,6 +2808,21 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/widest-line": {
@@ -1814,6 +2856,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -1862,9 +2910,17 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {
@@ -38,6 +38,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.85",
     "@ai-sdk/openai-compatible": "^2.0.51",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6.0.207",
     "chalk": "^5.3.0",
     "ink": "^5.2.1",

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,0 +1,268 @@
+import {
+	addMcpServer,
+	configPathForScope,
+	loadMcpConfig,
+	removeMcpServerAnyScope,
+} from "../mcp/config.js"
+import type { McpHttpServerConfig, McpScope, McpServerConfig, McpSseServerConfig, McpStdioServerConfig } from "../mcp/types.js"
+
+/**
+ * `orbcode mcp` subcommand — manage MCP servers from the command line, like
+ * Claude Code's `claude mcp add/remove/list`.
+ *
+ * Usage:
+ *   orbcode mcp add <name> <command> [args...]                    stdio (default)
+ *   orbcode mcp add --transport http <name> <url>                  http
+ *   orbcode mcp add --transport sse <name> <url>                   sse
+ *   orbcode mcp add -s <scope> -e KEY=value ... <name> ...         with scope/env
+ *   orbcode mcp add --header KEY=value ... <name> <url>            http/sse headers
+ *   orbcode mcp remove <name>                                      remove from any scope
+ *   orbcode mcp list                                               list all servers
+ *
+ * Flags:
+ *   -s, --scope <user|project|local>   config scope (default: project)
+ *   -t, --transport <stdio|http|sse>   transport type (default: stdio)
+ *   -e, --env KEY=value                environment variable (repeatable, stdio)
+ *       --header KEY=value             HTTP header (repeatable, http/sse)
+ *       --oauth                        enable OAuth for http/sse
+ *       --oauth-scope <scope>          OAuth scope (implies --oauth)
+ */
+
+const VALID_SCOPES: McpScope[] = ["user", "project", "local"]
+const VALID_TRANSPORTS = ["stdio", "http", "sse"] as const
+
+/** Parse a KEY=value pair from a flag argument. */
+function parseKeyValue(arg: string): [string, string] {
+	const idx = arg.indexOf("=")
+	if (idx === -1) throw new Error(`Expected KEY=value, got "${arg}"`)
+	return [arg.slice(0, idx), arg.slice(idx + 1)]
+}
+
+/** Print usage and exit. */
+function printMcpHelp(): void {
+	console.log(`orbcode mcp — manage MCP servers
+
+Usage:
+  orbcode mcp add [options] <name> <command> [args...]    add a stdio server
+  orbcode mcp add [options] --transport http <name> <url>  add an http server
+  orbcode mcp add [options] --transport sse <name> <url>   add an sse server
+  orbcode mcp remove <name>                                remove a server
+  orbcode mcp list                                         list all servers
+
+Options:
+  -s, --scope <user|project|local>   config scope (default: project)
+  -t, --transport <stdio|http|sse>   transport type (default: stdio)
+  -e, --env KEY=value                environment variable (repeatable, stdio)
+      --header KEY=value             HTTP header (repeatable, http/sse)
+      --oauth                        enable OAuth for http/sse
+      --oauth-scope <scope>          OAuth scope (implies --oauth)
+
+Scopes:
+  project   .mcp.json in the current directory (shared, checked into git)
+  user      ~/.orbcode/settings.json (applies to all projects on this machine)
+  local     .orbcode/settings.json (per-project, per-machine, not checked in)`)
+}
+
+/** Handle `orbcode mcp ...`. Returns the process exit code. */
+export async function runMcpCommand(args: string[]): Promise<number> {
+	const [subcommand, ...rest] = args
+
+	switch (subcommand) {
+		case "add":
+			return runAdd(rest)
+		case "remove":
+		case "rm":
+			return runRemove(rest)
+		case "list":
+		case "ls":
+			return runList(rest)
+		case "help":
+		case "--help":
+		case "-h":
+			printMcpHelp()
+			return 0
+		default:
+			console.error(`Unknown mcp subcommand: "${subcommand ?? ""}". Try: orbcode mcp help`)
+			return 1
+	}
+}
+
+/** Parse the flags shared by add (scope, transport, env, headers, oauth). */
+function parseAddFlags(args: string[]): {
+	scope: McpScope
+	transport: (typeof VALID_TRANSPORTS)[number]
+	env: Record<string, string>
+	headers: Record<string, string>
+	oauth: boolean | { scope: string }
+	positional: string[]
+} {
+	let scope: McpScope = "project"
+	let transport: (typeof VALID_TRANSPORTS)[number] = "stdio"
+	const env: Record<string, string> = {}
+	const headers: Record<string, string> = {}
+	let oauth: boolean | { scope: string } = false
+	const positional: string[] = []
+
+	// Flags must come before the server name. Once we hit the first positional
+	// (the server name), everything after it — including args that look like
+	// flags (-y, -f, --foo) — becomes the server's command/args. This matches
+	// Claude Code and lets stdio servers take their own flags.
+	let sawPositional = false
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i]!
+		if (sawPositional) {
+			positional.push(arg)
+			continue
+		}
+		if (arg === "-s" || arg === "--scope") {
+			const value = args[++i]
+			if (!value || !VALID_SCOPES.includes(value as McpScope)) {
+				throw new Error(`Invalid scope "${value ?? ""}". Valid: ${VALID_SCOPES.join(", ")}`)
+			}
+			scope = value as McpScope
+		} else if (arg === "-t" || arg === "--transport") {
+			const value = args[++i]
+			if (!value || !VALID_TRANSPORTS.includes(value as (typeof VALID_TRANSPORTS)[number])) {
+				throw new Error(`Invalid transport "${value ?? ""}". Valid: ${VALID_TRANSPORTS.join(", ")}`)
+			}
+			transport = value as (typeof VALID_TRANSPORTS)[number]
+		} else if (arg === "-e" || arg === "--env") {
+			const value = args[++i]
+			if (!value) throw new Error("Missing value for --env")
+			const [k, v] = parseKeyValue(value)
+			env[k] = v
+		} else if (arg === "--header") {
+			const value = args[++i]
+			if (!value) throw new Error("Missing value for --header")
+			const [k, v] = parseKeyValue(value)
+			headers[k] = v
+		} else if (arg === "--oauth") {
+			oauth = true
+		} else if (arg === "--oauth-scope") {
+			const value = args[++i]
+			if (!value) throw new Error("Missing value for --oauth-scope")
+			oauth = { scope: value }
+		} else if (arg === "--") {
+			// Explicit separator: everything after is positional.
+			sawPositional = true
+		} else if (arg.startsWith("-") && arg.length > 1) {
+			throw new Error(`Unknown flag: ${arg}. Put flags before the server name, or use -- to separate.`)
+		} else {
+			positional.push(arg)
+			sawPositional = true
+		}
+	}
+
+	return { scope, transport, env, headers, oauth, positional }
+}
+
+/** `orbcode mcp add` — build a server config from flags and write it. */
+function runAdd(args: string[]): number {
+	let parsed
+	try {
+		parsed = parseAddFlags(args)
+	} catch (error) {
+		console.error((error as Error).message)
+		return 1
+	}
+	const { scope, transport, env, headers, oauth, positional } = parsed
+
+	if (positional.length === 0) {
+		console.error("Missing server name. Usage: orbcode mcp add <name> <command> [args...]")
+		return 1
+	}
+	const [name, ...rest] = positional
+
+	let config: McpServerConfig
+	if (transport === "http" || transport === "sse") {
+		if (rest.length === 0) {
+			console.error(`Missing URL for ${transport} transport. Usage: orbcode mcp add -t ${transport} <name> <url>`)
+			return 1
+		}
+		const url = rest[0]!
+		const cfg: McpHttpServerConfig | McpSseServerConfig = { type: transport, url }
+		if (Object.keys(headers).length > 0) cfg.headers = headers
+		if (oauth !== false) cfg.oauth = oauth
+		config = cfg
+	} else {
+		// stdio
+		if (rest.length === 0) {
+			console.error("Missing command for stdio transport. Usage: orbcode mcp add <name> <command> [args...]")
+			return 1
+		}
+		const [command, ...cmdArgs] = rest
+		const cfg: McpStdioServerConfig = { type: "stdio", command: command! }
+		if (cmdArgs.length > 0) cfg.args = cmdArgs
+		if (Object.keys(env).length > 0) cfg.env = env
+		config = cfg
+	}
+
+	let detail: string
+	if (transport === "http" || transport === "sse") {
+		const cfg = config as McpHttpServerConfig | McpSseServerConfig
+		detail = `${transport} ${cfg.url}`
+	} else {
+		const cfg = config as McpStdioServerConfig
+		detail = `stdio ${cfg.command}${cfg.args?.length ? " " + cfg.args.join(" ") : ""}`
+	}
+
+	try {
+		addMcpServer(process.cwd(), name!, config, scope)
+	} catch (error) {
+		console.error((error as Error).message)
+		return 1
+	}
+
+	const filePath = configPathForScope(process.cwd(), scope)
+	console.log(`Added ${transport === "http" || transport === "sse" ? transport.toUpperCase() : "stdio"} MCP server ${name}`)
+	if (transport === "http" || transport === "sse") {
+		console.log(`  URL: ${(config as McpHttpServerConfig).url}`)
+	}
+	console.log(`  Scope: ${scope}`)
+	console.log(`  File modified: ${filePath}`)
+	return 0
+}
+
+/** `orbcode mcp remove <name>` — remove from whichever scope it's in. */
+function runRemove(args: string[]): number {
+	if (args.length === 0) {
+		console.error("Missing server name. Usage: orbcode mcp remove <name>")
+		return 1
+	}
+	const name = args[0]!
+	const scope = removeMcpServerAnyScope(process.cwd(), name)
+	if (!scope) {
+		console.error(`MCP server "${name}" not found in any scope.`)
+		return 1
+	}
+	const filePath = configPathForScope(process.cwd(), scope)
+	console.log(`Removed MCP server "${name}" from ${scope} scope.`)
+	console.log(`  File modified: ${filePath}`)
+	return 0
+}
+
+/** `orbcode mcp list` — print all configured servers with their scope + status. */
+function runList(_args: string[]): number {
+	const { servers } = loadMcpConfig(process.cwd())
+	const names = Object.keys(servers).sort()
+	if (names.length === 0) {
+		console.log("No MCP servers configured.")
+		console.log("Add one with: orbcode mcp add <name> <command> [args...]")
+		return 0
+	}
+	for (const name of names) {
+		const cfg = servers[name]!
+		const scope = cfg.scope
+		let detail: string
+		if (cfg.type === "http" || cfg.type === "sse") {
+			detail = `${cfg.type} ${cfg.url}`
+		} else {
+			// stdio (type undefined or "stdio")
+			const cmd = cfg.command
+			const args = cfg.args ?? []
+			detail = `stdio ${cmd}${args.length ? " " + args.join(" ") : ""}`
+		}
+		console.log(`  ${name.padEnd(20)} ${scope.padEnd(8)} ${detail}`)
+	}
+	return 0
+}

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -111,6 +111,12 @@ function parseAddFlags(args: string[]): {
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i]!
 		if (sawPositional) {
+			// A "--" immediately after the server name is the separator between
+			// orbcode's flags and the server's command (e.g. `add name -- npx`),
+			// matching Claude Code's `claude mcp add <name> -- <command>`. Consume
+			// it so it isn't mistaken for the command. A later "--" is kept as a
+			// literal arg for the server command.
+			if (arg === "--" && positional.length === 1) continue
 			positional.push(arg)
 			continue
 		}

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -5,6 +5,7 @@ import * as path from "node:path"
 
 import { DEFAULT_MODEL_ID, isValidAxonModel, registerCustomModels, type CustomModelConfig } from "../api/models.js"
 import { isHookEvent, type HookMatcher, type HooksConfig } from "../core/hooks.js"
+import type { McpServerConfig } from "../mcp/types.js"
 
 export interface OrbCodeSettings {
 	/** login token, written by `orbcode login` (config.json only) */
@@ -26,6 +27,13 @@ export interface OrbCodeSettings {
 	env?: Record<string, string>
 	/** lifecycle hooks (Claude-Code style); merged across all settings.json files */
 	hooks?: HooksConfig
+	/** MCP servers defined in settings.json (user/local scope). Project-scope
+	 *  servers live in `.mcp.json` and are loaded by the MCP config layer. */
+	mcpServers?: Record<string, McpServerConfig>
+	/** project-scope MCP server names the user has approved to connect. */
+	enabledMcpServers?: string[]
+	/** MCP server names the user has explicitly disabled. */
+	disabledMcpServers?: string[]
 }
 
 const DEFAULTS: OrbCodeSettings = {
@@ -43,6 +51,8 @@ const SETTINGS_KEYS = [
 	"baseUrl",
 	"apiKey",
 	"env",
+	"enabledMcpServers",
+	"disabledMcpServers",
 ] as const
 
 export function getConfigDir(): string {
@@ -178,6 +188,12 @@ export function loadSettings(): OrbCodeSettings {
 		if (Array.isArray(fileSettings.customModels)) {
 			customModels.push(...(fileSettings.customModels as CustomModelConfig[]))
 		}
+		// MCP servers: merge across scopes (local overrides project overrides
+		// user on name collisions). The MCP config layer also reads .mcp.json;
+		// settings.json mcpServers are the per-user/per-machine override path.
+		if (fileSettings.mcpServers && typeof fileSettings.mcpServers === "object") {
+			settings.mcpServers = { ...(settings.mcpServers ?? {}), ...(fileSettings.mcpServers as Record<string, McpServerConfig>) }
+		}
 	}
 	if (customModels.length > 0) {
 		settings.customModels = customModels
@@ -238,4 +254,27 @@ export function saveSettings(settings: OrbCodeSettings): void {
 		autoApproveSafeCommands: settings.autoApproveSafeCommands,
 	}
 	fs.writeFileSync(getConfigPath(), JSON.stringify(toPersist, null, "\t") + "\n", { mode: 0o600 })
+}
+
+/**
+ * Persist the enabled/disabled MCP server lists to the local project
+ * settings.json (`.orbcode/settings.json`). These are per-project approval
+ * decisions, so they live in the local scope, not in config.json.
+ */
+export function saveMcpApproval(
+	cwd: string,
+	enabled: string[],
+	disabled: string[],
+): void {
+	const settingsPath = path.join(cwd, ".orbcode", "settings.json")
+	let existing: Record<string, unknown> = {}
+	try {
+		existing = JSON.parse(fs.readFileSync(settingsPath, "utf8"))
+	} catch {
+		// file may not exist yet
+	}
+	existing.enabledMcpServers = [...new Set(enabled)]
+	existing.disabledMcpServers = [...new Set(disabled)]
+	fs.mkdirSync(path.dirname(settingsPath), { recursive: true })
+	fs.writeFileSync(settingsPath, JSON.stringify(existing, null, "\t") + "\n", { mode: 0o600 })
 }

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -18,6 +18,9 @@ import { previewFileChange } from "../tools/executors/files.js"
 import type { AgentCallbacks, ApprovalDecision } from "./events.js"
 import { getSessionFilePath, saveSession, type SessionData } from "./sessions.js"
 import { HookRunner, type HooksConfig } from "./hooks.js"
+import { McpManager } from "../mcp/manager.js"
+import { loadMemoryFiles } from "../memory/loader.js"
+import { loadSkills } from "../skills/loader.js"
 
 const MAX_STEPS_PER_TURN = 50
 const RESULT_PREVIEW_LINES = 6
@@ -35,6 +38,8 @@ export interface AgentOptions {
 	resume?: SessionData
 	/** lifecycle hooks from settings.json */
 	hooks?: HooksConfig
+	/** MCP server manager (started externally; may be undefined when MCP is off). */
+	mcp?: McpManager
 }
 
 interface PendingToolCall {
@@ -110,6 +115,8 @@ export class Agent {
 	private title = ""
 	private createdAt = new Date().toISOString()
 	private readonly hooks: HookRunner
+	/** MCP server manager (may be undefined when MCP is disabled). */
+	private mcp?: McpManager
 	/** SessionStart fires once, lazily, before the first turn of this instance. */
 	private sessionStarted = false
 	/** carries SessionStart additionalContext into the first user message */
@@ -142,7 +149,13 @@ export class Agent {
 			this.firstMessageSent = this.messages.length > 0
 		}
 		this.sessionApproveEdits = options.autoApproveEdits
-		this.systemPrompt = buildSystemPrompt(options.cwd)
+		this.mcp = options.mcp
+		// Build the system prompt with AGENTS.md memory files and the skills
+		// catalog injected, so the model sees project/user instructions and
+		// knows which skills it can invoke.
+		const memoryFiles = loadMemoryFiles(options.cwd)
+		const skills = loadSkills(options.cwd)
+		this.systemPrompt = buildSystemPrompt(options.cwd, { memoryFiles, skills })
 		this.client = createLLMClient({
 			token: options.token,
 			modelId: options.modelId,
@@ -399,12 +412,24 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 	async endSession(reason: string): Promise<void> {
 		// Let in-flight Notification hooks settle before the final SessionEnd.
 		await this.awaitBackground(3000)
-		if (!this.hooks.hasHooks("SessionEnd")) return
-		try {
-			await this.hooks.run("SessionEnd", { reason })
-		} catch {
-			// a SessionEnd hook must never prevent the app from exiting
+		if (this.hooks.hasHooks("SessionEnd")) {
+			try {
+				await this.hooks.run("SessionEnd", { reason })
+			} catch {
+				// a SessionEnd hook must never prevent the app from exiting
+			}
 		}
+		// Tear down MCP server connections so child processes / sockets don't leak.
+		try {
+			await this.mcp?.stop()
+		} catch {
+			// best-effort
+		}
+	}
+
+	/** The MCP manager (for the TUI's /mcp command and approval flow). */
+	get mcpManager(): McpManager | undefined {
+		return this.mcp
 	}
 
 	/** Summarize the conversation so far and replace history with the summary. */
@@ -495,7 +520,7 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 		const toolCallsByIndex = new Map<number, PendingToolCall>()
 		let nextSyntheticIndex = 10000
 
-		const stream = this.client.createMessage(this.systemPrompt, this.outgoingMessages(), getActiveTools(), signal)
+		const stream = this.client.createMessage(this.systemPrompt, this.outgoingMessages(), getActiveTools(this.mcp), signal)
 
 		for await (const chunk of stream) {
 			if (signal.aborted) throw new DOMException("aborted", "AbortError")
@@ -707,7 +732,7 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 			}
 		}
 
-		const result = await executeTool(toolCall.name, args, this.toolContext())
+		const result = await executeTool(toolCall.name, args, this.toolContext(), this.mcp)
 
 		// PostToolUse can feed extra context (or a block reason) back to the
 		// model. PreToolUse additionalContext is delivered here too.

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -2,6 +2,7 @@ import { getModel, isValidAxonModel, usesAiSdk } from "./api/models.js"
 import { getAuthToken, getPendingProjectHooks, loadSettings } from "./config/settings.js"
 import { Agent } from "./core/agent.js"
 import type { AgentEvent } from "./core/events.js"
+import { McpManager } from "./mcp/manager.js"
 
 /** Non-interactive `orbcode -p "prompt"` mode: prints the final response to stdout. */
 export async function runHeadless(prompt: string, yolo: boolean): Promise<void> {
@@ -38,6 +39,28 @@ export async function runHeadless(prompt: string, yolo: boolean): Promise<void> 
 		)
 	}
 
+	// Start MCP servers. In headless mode there's no interactive approval, so
+	// project-scope servers are only connected if they were previously approved
+	// (persisted in .orbcode/settings.json). Unapproved project servers are
+	// skipped with a note, matching the project-hooks behavior.
+	const mcp = new McpManager(
+		process.cwd(),
+		settings.disabledMcpServers ?? [],
+		settings.enabledMcpServers ?? [],
+	)
+	const mcpSnapshot = await mcp.start()
+	const pendingMcp = mcp.getPendingApproval()
+	if (pendingMcp.length > 0) {
+		process.stderr.write(
+			`note: ${pendingMcp.length} project MCP server(s) in .mcp.json are unapproved and were skipped. ` +
+				`Approve them in an interactive session with /mcp.\n`,
+		)
+	}
+	const connectedMcp = mcpSnapshot.servers.filter((s) => s.status === "connected").length
+	if (connectedMcp > 0) {
+		process.stderr.write(`MCP: ${connectedMcp}/${mcpSnapshot.servers.length} server(s) connected.\n`)
+	}
+
 	let exitCode = 0
 	// Only the final content is printed: either the attempt_completion result
 	// or, failing that, the last assistant text. Intermediate text and tool
@@ -56,6 +79,7 @@ export async function runHeadless(prompt: string, yolo: boolean): Promise<void> 
 		autoApproveEdits: yolo,
 		autoApproveSafeCommands: yolo,
 		hooks: settings.hooks,
+		mcp,
 		callbacks: {
 			onEvent: (event: AgentEvent) => {
 				switch (event.type) {
@@ -94,6 +118,7 @@ export async function runHeadless(prompt: string, yolo: boolean): Promise<void> 
 
 	await agent.runTurn(prompt)
 	await agent.endSession("other")
+	await mcp.stop().catch(() => {})
 	const finalContent = completionResult || lastText || textBuffer
 	if (finalContent) {
 		process.stdout.write(finalContent.trimEnd() + "\n")

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { render } from "ink"
 import { PRODUCT_NAME, VERSION } from "./branding.js"
 import { App } from "./ui/App.js"
 import { runHeadless } from "./headless.js"
+import { runMcpCommand } from "./commands/mcp.js"
 import { loadSessionById, type SessionData } from "./core/sessions.js"
 import {
 	clearUpdateCache,
@@ -26,6 +27,9 @@ Usage:
   orbcode login           sign in to MatterAI
   orbcode update          install the latest version from npm
   orbcode update --force  force a global install even if this CLI doesn't look global
+  orbcode mcp add ...     add an MCP server (see: orbcode mcp help)
+  orbcode mcp remove ...  remove an MCP server
+  orbcode mcp list        list configured MCP servers
   orbcode -p "<prompt>"   run a single prompt non-interactively (prints only the final response)
   orbcode -p "…" --yolo   non-interactive with auto-approved edits/commands
   orbcode --model <id>    use a specific model for this run
@@ -102,6 +106,12 @@ async function main(): Promise<void> {
 	if (args[0] === "update") {
 		const force = args.includes("--force") || args.includes("-f")
 		const code = await runUpdate(force)
+		process.exit(code)
+	}
+
+	// `orbcode mcp ...` — manage MCP servers from the command line (add/remove/list).
+	if (args[0] === "mcp") {
+		const code = await runMcpCommand(args.slice(1))
 		process.exit(code)
 	}
 

--- a/src/mcp/auth.ts
+++ b/src/mcp/auth.ts
@@ -1,0 +1,377 @@
+import * as http from "node:http"
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+import open from "open"
+import {
+	ClientCredentialsProvider,
+	PrivateKeyJwtProvider,
+} from "@modelcontextprotocol/sdk/client/auth-extensions.js"
+import {
+	auth,
+	type OAuthClientProvider,
+	type OAuthDiscoveryState,
+} from "@modelcontextprotocol/sdk/client/auth.js"
+import {
+	type OAuthClientMetadata,
+	type OAuthClientInformationMixed,
+	type OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
+
+import { getConfigDir } from "../config/settings.js"
+import { VERSION } from "../branding.js"
+import type { McpOAuthConfig, McpServerConfig } from "./types.js"
+
+/**
+ * MCP OAuth support.
+ *
+ * Remote MCP servers (http/sse) often require OAuth. The SDK ships a full
+ * OAuth client (RFC 9728 discovery + RFC 8414 metadata + PKCE + dynamic client
+ * registration + token refresh), gated behind an `OAuthClientProvider` that
+ * persists per-server state. This module provides:
+ *
+ *   - `FileOAuthProvider`: a filesystem-backed provider that stores tokens,
+ *     client info, code verifiers, and discovery state per server under
+ *     `~/.orbcode/mcp-auth/<server>.json`.
+ *   - `startCallbackServer`: a one-shot loopback HTTP server that receives the
+ *     OAuth redirect and resolves with the authorization code.
+ *   - `buildAuthProvider`: turns an `McpOAuthConfig` into an `OAuthClientProvider`
+ *     (interactive auth-code flow, or M2M client_credentials / private_key_jwt).
+ *   - `connectWithAuth`: wraps the transport connect + auth retry loop.
+ */
+
+const CLIENT_METADATA: OAuthClientMetadata = {
+	client_name: "OrbCode CLI",
+	redirect_uris: [], // filled in per-callback-port at runtime
+	grant_types: ["authorization_code", "refresh_token"],
+	token_endpoint_auth_method: "none",
+	scope: "",
+}
+
+interface McpAuthStore {
+	clientInformation?: OAuthClientInformationMixed
+	tokens?: OAuthTokens
+	codeVerifier?: string
+	discoveryState?: OAuthDiscoveryState
+	client?: OAuthClientInformationMixed
+}
+
+/** Directory holding per-server OAuth state files. */
+function authDir(): string {
+	return path.join(getConfigDir(), "mcp-auth")
+}
+
+/** Path to a server's persistent OAuth store. */
+function authFilePath(serverName: string): string {
+	return path.join(authDir(), `${serverName}.json`)
+}
+
+/** Read a server's OAuth store (or undefined if none). */
+function readAuthStore(serverName: string): McpAuthStore | undefined {
+	try {
+		return JSON.parse(fs.readFileSync(authFilePath(serverName), "utf8"))
+	} catch {
+		return undefined
+	}
+}
+
+/** Write a server's OAuth store (best-effort). */
+function writeAuthStore(serverName: string, store: McpAuthStore): void {
+	try {
+		fs.mkdirSync(authDir(), { recursive: true })
+		fs.writeFileSync(authFilePath(serverName), JSON.stringify(store, null, "\t") + "\n", {
+			mode: 0o600,
+		})
+	} catch {
+		// best-effort; auth will just re-prompt next time
+	}
+}
+
+/** A filesystem-backed OAuthClientProvider for one MCP server. */
+class FileOAuthProvider implements OAuthClientProvider {
+	private readonly serverName: string
+	private readonly callbackPort: number
+	private readonly scope?: string
+	private store: McpAuthStore
+	/** The authorization URL captured from the last redirectToAuthorization call. */
+	private authUrl?: string
+	/** Resolved by redirectToAuthorization; awaited by the connect loop. */
+	private codeResolve?: (code: string) => void
+
+	constructor(serverName: string, callbackPort: number, scope?: string) {
+		this.serverName = serverName
+		this.callbackPort = callbackPort
+		this.scope = scope
+		this.store = readAuthStore(serverName) ?? {}
+	}
+
+	get redirectUrl(): string {
+		return `http://localhost:${this.callbackPort}/callback`
+	}
+
+	get clientMetadata(): OAuthClientMetadata {
+		return { ...CLIENT_METADATA, redirect_uris: [this.redirectUrl], scope: this.scope ?? "" }
+	}
+
+	clientInformation(): OAuthClientInformationMixed | undefined {
+		return this.store.clientInformation
+	}
+
+	saveClientInformation(info: OAuthClientInformationMixed): void {
+		this.store.clientInformation = info
+		writeAuthStore(this.serverName, this.store)
+	}
+
+	tokens(): OAuthTokens | undefined {
+		return this.store.tokens
+	}
+
+	saveTokens(tokens: OAuthTokens): void {
+		this.store.tokens = tokens
+		writeAuthStore(this.serverName, this.store)
+	}
+
+	saveCodeVerifier(verifier: string): void {
+		this.store.codeVerifier = verifier
+		writeAuthStore(this.serverName, this.store)
+	}
+
+	codeVerifier(): string {
+		if (!this.store.codeVerifier) throw new Error("No PKCE code verifier stored.")
+		return this.store.codeVerifier
+	}
+
+	saveDiscoveryState(state: OAuthDiscoveryState): void {
+		this.store.discoveryState = state
+		writeAuthStore(this.serverName, this.store)
+	}
+
+	discoveryState(): OAuthDiscoveryState | undefined {
+		return this.store.discoveryState
+	}
+
+	invalidateCredentials(scope: "all" | "client" | "tokens" | "verifier" | "discovery"): void {
+		if (scope === "all") this.store = {}
+		else if (scope === "client") delete this.store.clientInformation
+		else if (scope === "tokens") delete this.store.tokens
+		else if (scope === "verifier") delete this.store.codeVerifier
+		else if (scope === "discovery") delete this.store.discoveryState
+		writeAuthStore(this.serverName, this.store)
+	}
+
+	/** Open the user's browser to the authorization URL and capture it so the
+	 *  caller can surface it in the TUI (with copy + paste fallback). */
+	redirectToAuthorization(authorizationUrl: URL): void {
+		this.authUrl = authorizationUrl.toString()
+		void open(this.authUrl).catch(() => {
+			// best-effort; the user can copy the URL from the TUI
+		})
+	}
+
+	/** The authorization URL captured from the last redirect (for TUI display). */
+	getAuthUrl(): string | undefined {
+		return this.authUrl
+	}
+
+	/** Called by the callback server when the OAuth redirect lands. */
+	resolveCode(code: string): void {
+		this.codeResolve?.(code)
+	}
+
+	/** Await the authorization code from the browser redirect or a manual paste. */
+	waitForCode(): Promise<string> {
+		return new Promise<string>((resolve) => {
+			this.codeResolve = resolve
+		})
+	}
+}
+
+/** Start a one-shot loopback HTTP server to receive the OAuth redirect. */
+function startCallbackServer(
+	port: number,
+	onCode: (code: string) => void,
+): http.Server {
+	const server = http.createServer((req, res) => {
+		const url = new URL(req.url ?? "/", `http://localhost:${port}`)
+		if (url.pathname !== "/callback") {
+			res.writeHead(404).end("not found")
+			return
+		}
+		const code = url.searchParams.get("code")
+		const error = url.searchParams.get("error")
+		if (code) {
+			onCode(code)
+			res.writeHead(200, { "Content-Type": "text/html" })
+			res.end("<h1>Authorized</h1><p>You can close this tab and return to OrbCode.</p>")
+		} else if (error) {
+			res.writeHead(400, { "Content-Type": "text/html" })
+			res.end(`<h1>Authorization failed</h1><p>${error}</p>`)
+		} else {
+			res.writeHead(400, { "Content-Type": "text/html" })
+			res.end("<h1>Missing code</h1>")
+		}
+		// Close after responding so the port is freed immediately.
+		server.close()
+	})
+	server.listen(port, "127.0.0.1")
+	return server
+}
+
+/** Pick an ephemeral loopback port for the callback server. */
+function ephemeralPort(): number {
+	// Bind to port 0 and read back the assigned port, then close immediately.
+	const probe = http.createServer().listen(0, "127.0.0.1")
+	const addr = probe.address()
+	probe.close()
+	return typeof addr === "object" && addr ? addr.port : 8765
+}
+
+/** Build an OAuthClientProvider from an McpOAuthConfig. Returns the provider
+ *  plus a callback-port hint (for the interactive flow). */
+export function buildAuthProvider(
+	serverName: string,
+	oauth: McpOAuthConfig,
+): { provider: OAuthClientProvider; callbackPort?: number } {
+	// M2M: client_credentials grant (no browser).
+	if (typeof oauth === "object" && "grantType" in oauth && oauth.grantType === "client_credentials") {
+		return {
+			provider: new ClientCredentialsProvider({
+				clientId: oauth.clientId,
+				clientSecret: oauth.clientSecret,
+				scope: oauth.scope,
+				clientName: "OrbCode CLI",
+			}),
+		}
+	}
+
+	// M2M: private_key_jwt assertion (no browser).
+	if (typeof oauth === "object" && "grantType" in oauth && oauth.grantType === "private_key_jwt") {
+		return {
+			provider: new PrivateKeyJwtProvider({
+				clientId: oauth.clientId,
+				privateKey: oauth.privateKey,
+				algorithm: oauth.algorithm,
+				scope: oauth.scope,
+				clientName: "OrbCode CLI",
+			}),
+		}
+	}
+
+	// Interactive authorization-code flow (browser redirect).
+	const scope = typeof oauth === "object" ? oauth.scope : undefined
+	const port = ephemeralPort()
+	return { provider: new FileOAuthProvider(serverName, port, scope), callbackPort: port }
+}
+
+/** True if the config requests OAuth (vs. static headers). */
+export function hasOAuth(config: { oauth?: McpOAuthConfig }): boolean {
+	return config.oauth !== undefined && config.oauth !== false
+}
+
+/** True if a server config is http/sse with OAuth enabled. */
+export function isOAuthConfig(config: McpServerConfig): boolean {
+	return (config.type === "http" || config.type === "sse") && hasOAuth(config)
+}
+
+/** True if this server has persisted OAuth tokens (i.e. already authenticated). */
+export function hasStoredAuth(serverName: string): boolean {
+	const store = readAuthStore(serverName)
+	return Boolean(store && store.tokens && store.tokens.access_token)
+}
+
+/** Lets the caller intercept the interactive OAuth flow: surface the auth URL
+ *  in the TUI and provide the authorization code (from the callback server or
+ *  a manual paste). When no intercept is provided, the flow auto-waits for the
+ *  loopback callback (headless mode). */
+export interface AuthIntercept {
+	/** Called with the authorization URL when the flow needs a browser redirect.
+	 *  The caller should display it (with copy + paste fallback). */
+	onAuthUrl: (url: string) => void
+	/** Resolve with the authorization code (from the callback server or a manual
+	 *  paste). Reject to abort the auth flow. */
+	getCode: () => Promise<string>
+}
+
+export interface AuthTransport {
+	transport: StreamableHTTPClientTransport | SSEClientTransport
+	/** Run the auth flow to obtain/refresh tokens. Resolves when the provider
+	 *  has valid tokens; rejects on failure. Does NOT call transport.start() —
+	 *  that's done by client.connect() later. */
+	authenticate: () => Promise<void>
+	/** The provider, if any (for finishAuth coordination). */
+	provider?: FileOAuthProvider
+}
+
+/** Create an http/sse transport with an auth provider. The `authenticate()`
+ *  function uses the standalone `auth()` orchestrator to obtain tokens BEFORE
+ *  the transport is started (by client.connect()). This avoids the
+ *  "StreamableHTTPClientTransport already started" error that occurs when
+ *  transport.start() is called both by authenticate() and by client.connect().
+ *
+ *  When `intercept` is provided, the caller controls how the auth URL is shown
+ *  and how the code is obtained (TUI with copy + paste fallback). When omitted,
+ *  the flow auto-waits for the loopback callback server (headless mode). */
+export function createAuthTransport(
+	serverName: string,
+	url: URL,
+	kind: "http" | "sse",
+	oauth: McpOAuthConfig,
+	requestInit: RequestInit,
+	intercept?: AuthIntercept,
+): AuthTransport {
+	const { provider, callbackPort } = buildAuthProvider(serverName, oauth)
+	const fileProvider = provider instanceof FileOAuthProvider ? provider : undefined
+
+	const transport =
+		kind === "http"
+			? new StreamableHTTPClientTransport(url, { authProvider: provider, requestInit })
+			: new SSEClientTransport(url, { authProvider: provider, requestInit })
+
+	const authenticate = async (): Promise<void> => {
+		// M2M providers (ClientCredentialsProvider, PrivateKeyJwtProvider) don't
+		// need a browser — the auth() call handles token acquisition directly.
+		if (!fileProvider) {
+			const result = await auth(provider, { serverUrl: url })
+			if (result === "REDIRECT") {
+				throw new Error("M2M provider requested a browser redirect — unexpected.")
+			}
+			return
+		}
+
+		// Interactive flow: use the standalone auth() orchestrator.
+		// If we already have valid tokens, auth() returns AUTHORIZED immediately.
+		// If not, it returns REDIRECT (after calling redirectToAuthorization,
+		// which opens the browser and captures the URL).
+		const serverUrlStr = url.toString()
+		const result = await auth(provider, { serverUrl: serverUrlStr })
+
+		if (result === "AUTHORIZED") return // tokens are valid
+
+		// REDIRECT: the provider's redirectToAuthorization was called, which
+		// captured the auth URL and opened the browser. Surface it to the TUI.
+		const authUrl = fileProvider.getAuthUrl()
+		if (intercept && authUrl) intercept.onAuthUrl(authUrl)
+
+		// Start the callback server (the browser redirect may arrive here).
+		const callbackServer = startCallbackServer(callbackPort!, (code) => fileProvider.resolveCode(code))
+
+		try {
+			let code: string
+			if (intercept) {
+				// Interactive: race the callback against a manual paste.
+				code = await Promise.race([intercept.getCode(), fileProvider.waitForCode()])
+			} else {
+				code = await fileProvider.waitForCode()
+			}
+
+			// Exchange the code for tokens via the standalone auth() call.
+			await auth(provider, { serverUrl: serverUrlStr, authorizationCode: code })
+		} finally {
+			callbackServer.close()
+		}
+	}
+
+	return { transport, authenticate, provider: fileProvider }
+}

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,0 +1,153 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+
+import { VERSION } from "../branding.js"
+import type { McpServerConfig, McpTool } from "./types.js"
+import { createAuthTransport, hasOAuth, type AuthIntercept } from "./auth.js"
+
+/** The SDK transport type (union of the three we use). */
+type AnyTransport = StdioClientTransport | StreamableHTTPClientTransport | SSEClientTransport
+
+/** Build the SDK transport for a server config. For http/sse servers with an
+ *  `oauth` block, returns an auth-aware transport whose `authenticate()` runs
+ *  the OAuth flow (browser redirect or M2M) before `start()`. */
+function buildTransport(name: string, config: McpServerConfig, intercept?: AuthIntercept): {
+	transport: AnyTransport
+	authenticate?: () => Promise<void>
+} {
+	if (config.type === "sse") {
+		if (hasOAuth(config)) {
+			const auth = createAuthTransport(name, new URL(config.url), "sse", config.oauth!, {
+				headers: config.headers ?? {},
+			}, intercept)
+			return { transport: auth.transport, authenticate: auth.authenticate }
+		}
+		return {
+			transport: new SSEClientTransport(new URL(config.url), {
+				requestInit: { headers: config.headers ?? {} },
+			}),
+		}
+	}
+	if (config.type === "http") {
+		if (hasOAuth(config)) {
+			const auth = createAuthTransport(name, new URL(config.url), "http", config.oauth!, {
+				headers: config.headers ?? {},
+			}, intercept)
+			return { transport: auth.transport, authenticate: auth.authenticate }
+		}
+		return {
+			transport: new StreamableHTTPClientTransport(new URL(config.url), {
+				requestInit: { headers: config.headers ?? {} },
+			}),
+		}
+	}
+	// stdio (default)
+	return {
+		transport: new StdioClientTransport({
+			command: config.command,
+			args: config.args ?? [],
+			env: config.env,
+			cwd: config.cwd,
+			stderr: "pipe",
+		}),
+	}
+}
+
+/** A live connection to a single MCP server. */
+export interface McpConnection {
+	client: Client
+	tools: McpTool[]
+	/** Close the transport and free the child process / socket. */
+	close: () => Promise<void>
+}
+
+const CONNECT_TIMEOUT_MS = 30_000
+const CLIENT_INFO = { name: "orbcode", version: VERSION }
+
+/** Connect to one MCP server and enumerate its tools. The optional
+ *  `authIntercept` lets the caller surface the OAuth URL in the TUI and
+ *  provide the auth code (from the callback or a manual paste). */
+export async function connectMcpServer(name: string, config: McpServerConfig, authIntercept?: AuthIntercept): Promise<McpConnection> {
+	const { transport, authenticate } = buildTransport(name, config, authIntercept)
+	const client = new Client(CLIENT_INFO, { capabilities: {} })
+
+	// For OAuth servers, run the auth flow (browser redirect or M2M) before
+	// connecting. This may open a browser and block until the user authorizes.
+	if (authenticate) {
+		await withTimeout(authenticate(), CONNECT_TIMEOUT_MS, `MCP server "${name}" auth timed out`)
+	}
+
+	// Wrap connect in a timeout so a hung server doesn't block startup.
+	await withTimeout(client.connect(transport), CONNECT_TIMEOUT_MS, `MCP server "${name}" timed out`)
+
+	const tools = await listServerTools(name, client)
+	return {
+		client,
+		tools,
+		close: async () => {
+			try {
+				await transport.close()
+			} catch {
+				// best-effort
+			}
+			try {
+				await client.close()
+			} catch {
+				// best-effort
+			}
+		},
+	}
+}
+
+/** Enumerate tools from a connected client, namespaced as mcp__<server>__<tool>. */
+export async function listServerTools(server: string, client: Client): Promise<McpTool[]> {
+	const result = await client.listTools()
+	return (result.tools ?? []).map((tool) => ({
+		name: `mcp__${server}__${tool.name}`,
+		originalName: tool.name,
+		server,
+		description: tool.description,
+		inputSchema: (tool.inputSchema as Record<string, unknown>) ?? { type: "object", properties: {} },
+	}))
+}
+
+/** Call a tool on a connected client and return a text result for the model. */
+export async function callMcpTool(
+	connection: McpConnection,
+	originalName: string,
+	args: Record<string, unknown>,
+): Promise<{ text: string; isError?: boolean }> {
+	const result = await connection.client.callTool({ name: originalName, arguments: args })
+	const content = (result.content ?? []) as Array<Record<string, unknown>>
+	const parts: string[] = []
+	for (const block of content) {
+		const type = block.type as string
+		if (type === "text" && typeof block.text === "string") {
+			parts.push(block.text)
+		} else if (type === "resource") {
+			const resource = block.resource as Record<string, unknown> | undefined
+			if (resource && typeof resource.text === "string") parts.push(resource.text)
+		} else if (type === "image") {
+			parts.push(`[image: ${block.mimeType}]`)
+		} else if (type === "audio") {
+			parts.push(`[audio: ${block.mimeType}]`)
+		} else if (type === "resource_link" && typeof block.uri === "string") {
+			parts.push(`[resource: ${block.uri}]`)
+		}
+	}
+	const text = parts.join("\n") || "(empty MCP tool result)"
+	return { text, isError: Boolean(result.isError) }
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined
+	const cap = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(message)), ms)
+		timer.unref?.()
+	})
+	return Promise.race([promise, cap]).finally(() => {
+		if (timer) clearTimeout(timer)
+	}) as Promise<T>
+}

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -1,0 +1,288 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+import { getConfigDir } from "../config/settings.js"
+import type {
+	McpHttpServerConfig,
+	McpJsonConfig,
+	McpOAuthConfig,
+	McpScope,
+	McpServerConfig,
+	McpSseServerConfig,
+	McpStdioServerConfig,
+	ScopedMcpServerConfig,
+} from "./types.js"
+
+/**
+ * MCP server configuration loader.
+ *
+ * Resolution order (lowest precedence first), mirroring Claude Code:
+ *   1. User scope: `~/.orbcode/settings.json` -> `mcpServers`
+ *   2. Project scope: `.mcp.json` in the cwd and every parent directory
+ *      (closer-to-cwd wins on name collisions)
+ *   3. Local scope: `.orbcode/settings.json` -> `mcpServers` (highest precedence)
+ *
+ * `.mcp.json` is the shared, check-into-git project file (Claude Code compatible).
+ * The `mcpServers` block in settings.json is the per-user/per-machine override.
+ */
+
+function readJson(filePath: string): Record<string, unknown> | undefined {
+	try {
+		return JSON.parse(fs.readFileSync(filePath, "utf8"))
+	} catch {
+		return undefined
+	}
+}
+
+/** Expand ${VAR} and $VAR references in a string using process.env. */
+function expandEnv(value: string): string {
+	return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (_, braced, bare) => {
+		const name = braced ?? bare
+		return process.env[name] ?? ""
+	})
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Normalize an `oauth` config value: boolean, or an object with grant/scope. */
+function normalizeOAuth(raw: unknown): McpOAuthConfig | undefined {
+	if (raw === true) return true
+	if (typeof raw === "string" && raw === "true") return true
+	if (!isPlainObject(raw)) return undefined
+	if (raw.grantType === "client_credentials") {
+		if (typeof raw.clientId !== "string" || typeof raw.clientSecret !== "string") return undefined
+		return {
+			grantType: "client_credentials",
+			clientId: String(raw.clientId),
+			clientSecret: String(raw.clientSecret),
+			scope: typeof raw.scope === "string" ? raw.scope : undefined,
+		}
+	}
+	if (raw.grantType === "private_key_jwt") {
+		if (typeof raw.clientId !== "string") return undefined
+		if (typeof raw.algorithm !== "string") return undefined
+		const privateKey = typeof raw.privateKey === "string" ? raw.privateKey : isPlainObject(raw.privateKey) ? raw.privateKey : undefined
+		if (privateKey === undefined) return undefined
+		return {
+			grantType: "private_key_jwt",
+			clientId: String(raw.clientId),
+			privateKey,
+			algorithm: String(raw.algorithm),
+			scope: typeof raw.scope === "string" ? raw.scope : undefined,
+		}
+	}
+	// Plain object (no grantType) → interactive auth-code flow with optional scope.
+	return { scope: typeof raw.scope === "string" ? raw.scope : undefined }
+}
+
+/** Validate + normalize a single server config object from disk. */
+function normalizeServerConfig(raw: unknown): McpServerConfig | undefined {
+	if (!isPlainObject(raw)) return undefined
+	const type = typeof raw.type === "string" ? raw.type : "stdio"
+
+	if (type === "stdio") {
+		if (typeof raw.command !== "string" || !raw.command.trim()) return undefined
+		const config: McpStdioServerConfig = { type: "stdio", command: expandEnv(raw.command) }
+		if (Array.isArray(raw.args)) {
+			config.args = raw.args.map((a) => expandEnv(String(a)))
+		}
+		if (isPlainObject(raw.env)) {
+			const env: Record<string, string> = {}
+			for (const [k, v] of Object.entries(raw.env)) {
+				if (typeof v === "string") env[k] = expandEnv(v)
+			}
+			config.env = env
+		}
+		if (typeof raw.cwd === "string") config.cwd = expandEnv(raw.cwd)
+		return config
+	}
+
+	if (type === "http" || type === "sse") {
+		if (typeof raw.url !== "string" || !raw.url.trim()) return undefined
+		const config: McpHttpServerConfig | McpSseServerConfig = {
+			type,
+			url: expandEnv(raw.url),
+		} as McpHttpServerConfig | McpSseServerConfig
+		if (isPlainObject(raw.headers)) {
+			const headers: Record<string, string> = {}
+			for (const [k, v] of Object.entries(raw.headers)) {
+				if (typeof v === "string") headers[k] = expandEnv(v)
+			}
+			;(config as McpHttpServerConfig).headers = headers
+		}
+		const oauth = normalizeOAuth(raw.oauth)
+		if (oauth !== undefined) (config as McpHttpServerConfig).oauth = oauth
+		return config
+	}
+
+	return undefined
+}
+
+/** Validate + normalize a whole `mcpServers` record. */
+function normalizeServers(
+	raw: unknown,
+): Record<string, McpServerConfig> {
+	if (!isPlainObject(raw)) return {}
+	const servers: Record<string, McpServerConfig> = {}
+	for (const [name, cfg] of Object.entries(raw)) {
+		if (!/^[A-Za-z0-9_-]+$/.test(name)) continue
+		const normalized = normalizeServerConfig(cfg)
+		if (normalized) servers[name] = normalized
+	}
+	return servers
+}
+
+/** Read `mcpServers` from a settings.json file (user or local scope). */
+function readSettingsServers(filePath: string): Record<string, McpServerConfig> {
+	const json = readJson(filePath)
+	if (!json) return {}
+	return normalizeServers(json.mcpServers)
+}
+
+/** Read a `.mcp.json` file (project scope). */
+function readMcpJson(filePath: string): Record<string, McpServerConfig> {
+	const json = readJson(filePath)
+	if (!json || !isPlainObject(json.mcpServers)) return {}
+	return normalizeServers(json.mcpServers)
+}
+
+/** Walk from cwd up to the filesystem root, collecting directories (root last). */
+function ancestorDirs(cwd: string): string[] {
+	const dirs: string[] = []
+	let current = path.resolve(cwd)
+	const root = path.parse(current).root
+	while (current !== root) {
+		dirs.push(current)
+		const parent = path.dirname(current)
+		if (parent === current) break
+		current = parent
+	}
+	return dirs
+}
+
+export interface ResolvedMcpConfig {
+	/** server name -> scoped config, with local overriding project overriding user. */
+	servers: Record<string, ScopedMcpServerConfig>
+}
+
+/**
+ * Load and merge MCP server configs from all scopes. Closer-to-cwd and
+ * higher-precedence scopes override earlier ones on name collisions.
+ */
+export function loadMcpConfig(cwd = process.cwd()): ResolvedMcpConfig {
+	const servers: Record<string, ScopedMcpServerConfig> = {}
+
+	// 1. User scope (~/.orbcode/settings.json -> mcpServers)
+	const userServers = readSettingsServers(path.join(getConfigDir(), "settings.json"))
+	for (const [name, cfg] of Object.entries(userServers)) {
+		servers[name] = { ...cfg, scope: "user" as McpScope }
+	}
+
+	// 2. Project scope (.mcp.json, root -> cwd so cwd wins)
+	for (const dir of ancestorDirs(cwd).reverse()) {
+		const projectServers = readMcpJson(path.join(dir, ".mcp.json"))
+		for (const [name, cfg] of Object.entries(projectServers)) {
+			servers[name] = { ...cfg, scope: "project" as McpScope }
+		}
+	}
+
+	// 3. Local scope (.orbcode/settings.json -> mcpServers) — highest precedence
+	const localServers = readSettingsServers(path.join(cwd, ".orbcode", "settings.json"))
+	for (const [name, cfg] of Object.entries(localServers)) {
+		servers[name] = { ...cfg, scope: "local" as McpScope }
+	}
+
+	return { servers }
+}
+
+/** Write a `.mcp.json` file in the cwd (project scope). */
+export function writeProjectMcpJson(cwd: string, servers: Record<string, McpServerConfig>): void {
+	const config: McpJsonConfig = { mcpServers: servers }
+	fs.writeFileSync(path.join(cwd, ".mcp.json"), JSON.stringify(config, null, "\t") + "\n")
+}
+
+/** Read just the project-scope `.mcp.json` from the cwd (no parent walk). */
+export function readProjectMcpJson(cwd: string): Record<string, McpServerConfig> {
+	return readMcpJson(path.join(cwd, ".mcp.json"))
+}
+
+/** Read a settings.json file, returning the full object (not just mcpServers). */
+function readFullSettings(filePath: string): Record<string, unknown> {
+	return readJson(filePath) ?? {}
+}
+
+/** Write a settings.json file, preserving existing keys. */
+function writeFullSettings(filePath: string, data: Record<string, unknown>): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true })
+	fs.writeFileSync(filePath, JSON.stringify(data, null, "\t") + "\n", { mode: 0o600 })
+}
+
+/** Path to the settings file for a given scope. */
+function settingsPathForScope(cwd: string, scope: McpScope): string {
+	if (scope === "user") return path.join(getConfigDir(), "settings.json")
+	return path.join(cwd, ".orbcode", "settings.json")
+}
+
+/** Path to the config file for a given scope (`.mcp.json` for project,
+ *  settings.json for user/local). */
+export function configPathForScope(cwd: string, scope: McpScope): string {
+	if (scope === "project") return path.join(cwd, ".mcp.json")
+	return settingsPathForScope(cwd, scope)
+}
+
+/** Add (or overwrite) a server in the given scope's config file. */
+export function addMcpServer(cwd: string, name: string, config: McpServerConfig, scope: McpScope): void {
+	if (!/^[A-Za-z0-9_-]+$/.test(name)) {
+		throw new Error(`Invalid server name "${name}". Use only letters, numbers, hyphens, and underscores.`)
+	}
+	if (scope === "project") {
+		const existing = readProjectMcpJson(cwd)
+		existing[name] = config
+		writeProjectMcpJson(cwd, existing)
+	} else {
+		const filePath = settingsPathForScope(cwd, scope)
+		const settings = readFullSettings(filePath)
+		const servers = normalizeServers(settings.mcpServers)
+		servers[name] = config
+		settings.mcpServers = servers
+		writeFullSettings(filePath, settings)
+	}
+}
+
+/** Remove a server from the given scope's config file. Returns true if it
+ *  existed and was removed, false if it wasn't found. */
+export function removeMcpServer(cwd: string, name: string, scope: McpScope): boolean {
+	if (scope === "project") {
+		const existing = readProjectMcpJson(cwd)
+		if (!(name in existing)) return false
+		delete existing[name]
+		writeProjectMcpJson(cwd, existing)
+		return true
+	}
+	const filePath = settingsPathForScope(cwd, scope)
+	const settings = readFullSettings(filePath)
+	const servers = normalizeServers(settings.mcpServers)
+	if (!(name in servers)) return false
+	delete servers[name]
+	settings.mcpServers = servers
+	writeFullSettings(filePath, settings)
+	return true
+}
+
+/** Find which scope a server name lives in (highest-precedence scope wins).
+ *  Returns undefined if the name isn't configured anywhere. */
+export function findServerScope(cwd: string, name: string): McpScope | undefined {
+	const { servers } = loadMcpConfig(cwd)
+	return servers[name]?.scope
+}
+
+/** Remove a server from whichever scope it's configured in. Returns the scope
+ *  it was removed from, or undefined if not found. */
+export function removeMcpServerAnyScope(cwd: string, name: string): McpScope | undefined {
+	const scope = findServerScope(cwd, name)
+	if (!scope) return undefined
+	removeMcpServer(cwd, name, scope)
+	return scope
+}

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -1,0 +1,293 @@
+import type OpenAI from "openai"
+
+import { callMcpTool, connectMcpServer, type McpConnection } from "./client.js"
+import { configPathForScope, loadMcpConfig } from "./config.js"
+import { hasStoredAuth, isOAuthConfig, type AuthIntercept } from "./auth.js"
+import type { McpHttpServerConfig, McpServerConfig, McpServerState, McpSnapshot, McpTool, ScopedMcpServerConfig } from "./types.js"
+
+/**
+ * Owns the lifecycle of all MCP server connections for a session.
+ *
+ * On `start()`, it loads the merged config, filters by the enabled/disabled
+ * lists, connects to each enabled server in parallel, and exposes the union of
+ * their tools as OpenAI-compatible tool definitions. The agent calls
+ * `callTool()` for any `mcp__*` tool name; unknown names return an error.
+ */
+export class McpManager {
+	private readonly cwd: string
+	private connections = new Map<string, McpConnection>()
+	private configs = new Map<string, ScopedMcpServerConfig>()
+	private states = new Map<string, McpServerState>()
+	/** server names the user has explicitly disabled (persisted in settings). */
+	private disabled: Set<string>
+	/** server names the user has explicitly enabled (for unapproved project servers). */
+	private enabled: Set<string>
+	/** project-scope server names that require user approval before connecting. */
+	private pendingApproval: Set<string> = new Set()
+	private started = false
+
+	constructor(cwd: string, disabled: string[], enabled: string[]) {
+		this.cwd = cwd
+		this.disabled = new Set(disabled)
+		this.enabled = new Set(enabled)
+	}
+
+	/** Load config and connect to all approved, non-disabled servers. */
+	async start(): Promise<McpSnapshot> {
+		if (this.started) return this.snapshot()
+		this.started = true
+		const { servers } = loadMcpConfig(this.cwd)
+		this.configs.clear()
+		this.states.clear()
+		for (const [name, cfg] of Object.entries(servers)) {
+			this.configs.set(name, cfg)
+			this.states.set(name, {
+				name,
+				scope: cfg.scope,
+				status: "disabled",
+				toolCount: 0,
+				disabled: this.disabled.has(name),
+				detail: undefined,
+			})
+		}
+
+		// Project-scope servers need explicit approval (they ship in the repo).
+		// User/local-scope servers are trusted (the user wrote them).
+		const toConnect: string[] = []
+		for (const [name, cfg] of this.configs) {
+			if (this.disabled.has(name)) continue
+			if (cfg.scope === "project" && !this.enabled.has(name)) {
+				this.pendingApproval.add(name)
+				this.states.get(name)!.status = "disabled"
+				this.states.get(name)!.detail = "awaiting approval"
+				continue
+			}
+			toConnect.push(name)
+		}
+
+		// At startup, skip the OAuth browser flow for servers with no stored
+		// tokens — mark them needs-auth so the user can auth explicitly from /mcp.
+		await Promise.all(toConnect.map((name) => this.connectOne(name, { skipUnauthOAuth: true })))
+		return this.snapshot()
+	}
+
+	/** Connect (or reconnect) a single server by name.
+	 *  When `skipUnauthOAuth` is set, OAuth servers with no stored tokens are
+	 *  marked needs-auth instead of opening a browser (used at startup).
+	 *  When `authIntercept` is provided, the caller controls the OAuth UI
+	 *  (surfacing the auth URL, providing the code via callback or paste).
+	 *  When `forceOAuth` is set, an http/sse server without an explicit `oauth`
+	 *  config is treated as `oauth: true` (auto-detected OAuth — used when the
+	 *  user triggers auth after a 401). */
+	async connectOne(name: string, options?: { skipUnauthOAuth?: boolean; authIntercept?: AuthIntercept; forceOAuth?: boolean }): Promise<void> {
+		const cfg = this.configs.get(name)
+		if (!cfg) return
+		const state = this.states.get(name)!
+		const isRemote = cfg.type === "http" || cfg.type === "sse"
+
+		// At startup, don't open a browser for OAuth servers that haven't been
+		// authenticated yet — surface them as needs-auth so the user can trigger
+		// auth explicitly from the /mcp picker. This applies to both explicitly
+		// configured OAuth servers and any remote server (which may require OAuth
+		// we don't know about yet — we'll find out on the first connect attempt).
+		if (options?.skipUnauthOAuth && isOAuthConfig(cfg) && !hasStoredAuth(name)) {
+			state.status = "needs-auth"
+			state.detail = "not authenticated — press a to authenticate"
+			return
+		}
+
+		state.status = "connecting"
+		state.detail = undefined
+		try {
+			const { scope: _scope, ...serverConfig } = cfg
+			// Auto-detect: if forceOAuth is set and this is a remote server without
+			// explicit oauth config, inject oauth: true so the auth transport is used.
+			if (options?.forceOAuth && isRemote && !isOAuthConfig(cfg)) {
+				;(serverConfig as McpHttpServerConfig).oauth = true
+			}
+			const connection = await connectMcpServer(name, serverConfig, options?.authIntercept)
+			this.connections.set(name, connection)
+			state.status = "connected"
+			state.toolCount = connection.tools.length
+			state.detail = `${connection.tools.length} tool${connection.tools.length === 1 ? "" : "s"}`
+			this.pendingApproval.delete(name)
+		} catch (error) {
+			const msg = (error as Error).message
+			// Any remote server that returns 401/unauthorized/invalid_token needs
+			// auth — surface as needs-auth regardless of whether `oauth` was
+			// explicitly configured (auto-detection, like Claude Code).
+			if (isRemote && /unauthorized|auth|401|oauth|invalid_token/i.test(msg)) {
+				state.status = "needs-auth"
+				state.detail = "authentication required — press a to authenticate"
+			} else {
+				state.status = "failed"
+				state.detail = msg
+			}
+		}
+	}
+
+	/** Disconnect a single server (keeps config; marks it disabled). */
+	async disconnectOne(name: string): Promise<void> {
+		const connection = this.connections.get(name)
+		if (connection) {
+			await connection.close()
+			this.connections.delete(name)
+		}
+		const state = this.states.get(name)
+		if (state) {
+			state.status = "disabled"
+			state.toolCount = 0
+			state.detail = undefined
+		}
+	}
+
+	/** Enable a project server (approving it) and connect. Uses
+	 *  skipUnauthOAuth so enabling doesn't open a browser — the user auths
+	 *  explicitly from /mcp. */
+	async enableServer(name: string): Promise<void> {
+		this.enabled.add(name)
+		this.disabled.delete(name)
+		const state = this.states.get(name)
+		if (state) state.disabled = false
+		await this.connectOne(name, { skipUnauthOAuth: true })
+	}
+
+	/** Disable a server and disconnect it. */
+	async disableServer(name: string): Promise<void> {
+		this.disabled.add(name)
+		this.enabled.delete(name)
+		const state = this.states.get(name)
+		if (state) state.disabled = true
+		await this.disconnectOne(name)
+	}
+
+	/** Re-authenticate a server in the needs-auth state: disconnect, clear
+	 *  persisted OAuth tokens, then reconnect with `forceOAuth` so even servers
+	 *  without an explicit `oauth` config use the OAuth flow (auto-detect).
+	 *  The `authIntercept` lets the TUI surface the auth URL and provide the
+	 *  code via callback or paste. */
+	async reauthServer(name: string, authIntercept?: AuthIntercept): Promise<void> {
+		await this.disconnectOne(name)
+		try {
+			const fs = await import("node:fs")
+			const path = await import("node:path")
+			const { getConfigDir } = await import("../config/settings.js")
+			fs.unlinkSync(path.join(getConfigDir(), "mcp-auth", `${name}.json`))
+		} catch {
+			// best-effort; no stored tokens to clear
+		}
+		this.disabled.delete(name)
+		await this.connectOne(name, { authIntercept, forceOAuth: true })
+	}
+
+	/** Close every connection. Call on session end / exit. */
+	async stop(): Promise<void> {
+		await Promise.all(
+			[...this.connections.values()].map((c) => c.close().catch(() => {})),
+		)
+		this.connections.clear()
+		this.started = false
+	}
+
+	/** All tools from all connected servers, as OpenAI tool definitions. */
+	getTools(): OpenAI.Chat.ChatCompletionTool[] {
+		const tools: OpenAI.Chat.ChatCompletionTool[] = []
+		for (const connection of this.connections.values()) {
+			for (const tool of connection.tools) {
+				tools.push({
+					type: "function",
+					function: {
+						name: tool.name,
+						description: tool.description ?? `MCP tool ${tool.originalName} from server ${tool.server}`,
+						parameters: (tool.inputSchema as Record<string, unknown>) ?? {
+							type: "object",
+							properties: {},
+						},
+					},
+				})
+			}
+		}
+		return tools
+	}
+
+	/** Route an `mcp__<server>__<tool>` call to the right connection. */
+	async callTool(toolName: string, args: Record<string, unknown>): Promise<{ text: string; isError?: boolean }> {
+		const match = /^mcp__([^_]+)__(.+)$/.exec(toolName)
+		if (!match) {
+			return { text: `Invalid MCP tool name: ${toolName}`, isError: true }
+		}
+		const [, server, originalName] = match
+		const connection = this.connections.get(server)
+		if (!connection) {
+			return { text: `MCP server "${server}" is not connected.`, isError: true }
+		}
+		try {
+			return await callMcpTool(connection, originalName, args)
+		} catch (error) {
+			return { text: `MCP tool ${toolName} failed: ${(error as Error).message}`, isError: true }
+		}
+	}
+
+	/** True if `toolName` is an MCP tool managed by this manager. */
+	hasTool(toolName: string): boolean {
+		return /^mcp__[^_]+__/.test(toolName)
+	}
+
+	/** Current snapshot for the TUI / status display. */
+	snapshot(): McpSnapshot {
+		return {
+			servers: [...this.states.values()],
+			tools: [...this.connections.values()].flatMap((c) => c.tools),
+		}
+	}
+
+	/** Project-scope server names awaiting the user's approval. */
+	getPendingApproval(): string[] {
+		return [...this.pendingApproval]
+	}
+
+	/** Persisted enabled list (for saving to settings). */
+	getEnabled(): string[] {
+		return [...this.enabled]
+	}
+
+	/** Persisted disabled list (for saving to settings). */
+	getDisabled(): string[] {
+		return [...this.disabled]
+	}
+
+	/** All configured server names. */
+	getServerNames(): string[] {
+		return [...this.configs.keys()]
+	}
+
+	/** A config by name (for the TUI detail view). */
+	getConfig(name: string): ScopedMcpServerConfig | undefined {
+		return this.configs.get(name)
+	}
+
+	/** The file path where a server's config lives (for the TUI detail view). */
+	getConfigPath(name: string): string | undefined {
+		const cfg = this.configs.get(name)
+		if (!cfg) return undefined
+		return configPathForScope(this.cwd, cfg.scope)
+	}
+
+	/** True if a server uses OAuth (explicitly configured or auto-detected from
+	 *  a 401/needs-auth state). Remote servers in needs-auth state are treated
+	 *  as OAuth so the detail panel shows "not authenticated". */
+	isOAuthServer(name: string): boolean {
+		const cfg = this.configs.get(name)
+		if (!cfg) return false
+		if (isOAuthConfig(cfg)) return true
+		// Auto-detect: a remote server in needs-auth state requires OAuth.
+		const state = this.states.get(name)
+		if (state?.status === "needs-auth" && (cfg.type === "http" || cfg.type === "sse")) return true
+		return false
+	}
+
+	/** True if a server has persisted OAuth tokens (already authenticated). */
+	isAuthenticated(name: string): boolean {
+		return hasStoredAuth(name)
+	}
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,119 @@
+/**
+ * MCP server configuration and connection types.
+ *
+ * These are OrbCode's own types (not re-exported from the SDK) so the config
+ * layer stays decoupled from the SDK's internal schema shape. The connection
+ * manager converts these into SDK transports/clients.
+ */
+
+/** Where a server config lives, mirroring Claude Code's scoping model. */
+export type McpScope = "user" | "project" | "local"
+
+/** A stdio server: OrbCode spawns a child process and talks over stdin/stdout. */
+export interface McpStdioServerConfig {
+	type?: "stdio"
+	command: string
+	args?: string[]
+	env?: Record<string, string>
+	/** Working directory for the spawned process. */
+	cwd?: string
+}
+
+/** OAuth configuration for a remote (http/sse) MCP server.
+ *
+ *  - `true` or `{}`: run the interactive authorization-code flow (browser
+ *    redirect via a loopback callback server). Use this for servers that
+ *    require user login (GitHub, Google Drive, Slack, Notion, …).
+ *  - `{ scope }`: same flow with a custom OAuth scope.
+ *  - `{ grantType: "client_credentials", clientId, clientSecret }`:
+ *    machine-to-machine flow with no browser (uses the SDK's
+ *    ClientCredentialsProvider).
+ *  - `{ grantType: "private_key_jwt", clientId, privateKey, algorithm }`:
+ *    M2M with a signed JWT assertion (RFC 7523). */
+export type McpOAuthConfig =
+	| boolean
+	| {
+			/** OAuth scope(s) to request (space-separated). */
+			scope?: string
+	  }
+	| {
+			grantType: "client_credentials"
+			clientId: string
+			clientSecret: string
+			scope?: string
+	  }
+	| {
+			grantType: "private_key_jwt"
+			clientId: string
+			/** PEM-encoded private key (or JWK). */
+			privateKey: string | Record<string, unknown>
+			/** JWT signing algorithm, e.g. RS256, ES256. */
+			algorithm: string
+			scope?: string
+	  }
+
+/** A Streamable HTTP server (the modern MCP remote transport). */
+export interface McpHttpServerConfig {
+	type: "http"
+	url: string
+	headers?: Record<string, string>
+	/** OAuth authentication (disables static Authorization header). */
+	oauth?: McpOAuthConfig
+}
+
+/** A Server-Sent Events server (legacy remote transport, still supported). */
+export interface McpSseServerConfig {
+	type: "sse"
+	url: string
+	headers?: Record<string, string>
+	/** OAuth authentication (disables static Authorization header). */
+	oauth?: McpOAuthConfig
+}
+
+export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig | McpSseServerConfig
+
+/** A server config annotated with the scope it was loaded from. */
+export type ScopedMcpServerConfig = McpServerConfig & { scope: McpScope }
+
+/** Shape of `.mcp.json` and the `mcpServers` block in settings.json. */
+export interface McpJsonConfig {
+	mcpServers: Record<string, McpServerConfig>
+}
+
+/** A normalized tool surfaced by a connected MCP server. */
+export interface McpTool {
+	/** Globally-unique tool name: `mcp__<server>__<tool>`. */
+	name: string
+	/** The original tool name on the server (without the mcp__ prefix). */
+	originalName: string
+	/** The server that provides this tool. */
+	server: string
+	description?: string
+	inputSchema: Record<string, unknown>
+}
+
+/** Connection state for a single MCP server. */
+export type McpConnectionStatus =
+	| "connecting"
+	| "connected"
+	| "failed"
+	| "disabled"
+	| "needs-auth"
+
+export interface McpServerState {
+	name: string
+	scope: McpScope
+	status: McpConnectionStatus
+	/** Human-readable detail (error message, server info, …). */
+	detail?: string
+	/** Number of tools currently exposed by this server. */
+	toolCount: number
+	/** Whether the user has explicitly disabled this server. */
+	disabled: boolean
+}
+
+/** Snapshot of all servers + their tools, used by the agent and the TUI. */
+export interface McpSnapshot {
+	servers: McpServerState[]
+	tools: McpTool[]
+}

--- a/src/memory/loader.ts
+++ b/src/memory/loader.ts
@@ -1,0 +1,182 @@
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+
+import { getConfigDir } from "../config/settings.js"
+import type { MemoryFile } from "./types.js"
+
+/**
+ * AGENTS.md memory loader.
+ *
+ * OrbCode's memory system mirrors Claude Code's CLAUDE.md discovery, but uses
+ * the open `AGENTS.md` filename (the cross-tool standard) instead of a
+ * vendor-specific name. Files are loaded in this order (lowest precedence
+ * first), with closer-to-cwd and higher-precedence types winning:
+ *
+ *   1. User memory:   ~/.orbcode/AGENTS.md
+ *   2. Project memory: AGENTS.md and .orbcode/AGENTS.md in cwd and every
+ *      parent directory (closer-to-cwd wins)
+ *   3. Local memory:   AGENTS.local.md in cwd and parents (highest precedence)
+ *
+ * Memory files support `@path` include directives (relative, `~/`, or
+ * absolute) to pull in other files. Includes are resolved recursively up to a
+ * small depth limit, with cycle detection.
+ */
+
+const MAX_INCLUDE_DEPTH = 5
+const MAX_TOTAL_CHARS = 200_000
+
+/** Read a file as UTF-8, returning undefined if it's missing or unreadable. */
+function readText(filePath: string): string | undefined {
+	try {
+		return fs.readFileSync(filePath, "utf8")
+	} catch {
+		return undefined
+	}
+}
+
+/** Resolve an @include path relative to the including file's directory. */
+function resolveInclude(ref: string, baseDir: string): string {
+	if (ref.startsWith("~/")) return path.join(os.homedir(), ref.slice(2))
+	if (path.isAbsolute(ref)) return ref
+	return path.resolve(baseDir, ref)
+}
+
+/**
+ * Extract `@path` references from leaf text (not inside code spans/blocks).
+ * A simple, conservative parser: skips fenced code blocks and inline code.
+ */
+function extractIncludes(content: string, baseDir: string): string[] {
+	const refs: string[] = []
+	let inFence = false
+	for (const line of content.split(/\r?\n/)) {
+		if (/^```/.test(line.trim())) {
+			inFence = !inFence
+			continue
+		}
+		if (inFence) continue
+		// Strip inline code spans before scanning for @refs.
+		const stripped = line.replace(/`[^`]*`/g, "")
+		const regex = /(?:^|\s)@((?:\.\/|~\/|\/)?[^\s]+)/g
+		let match: RegExpExecArray | null
+		while ((match = regex.exec(stripped)) !== null) {
+			const ref = match[1].replace(/\\ /g, " ")
+			// Avoid matching emails, @mentions, etc.
+			if (!/^[A-Za-z0-9._~/-]/.test(ref)) continue
+			refs.push(resolveInclude(ref, baseDir))
+		}
+	}
+	return refs
+}
+
+/** Recursively load a memory file and all its @includes. */
+function loadWithIncludes(
+	filePath: string,
+	type: MemoryFile["type"],
+	processed: Set<string>,
+	depth: number,
+): MemoryFile[] {
+	const real = safeRealpath(filePath)
+	if (processed.has(real) || depth >= MAX_INCLUDE_DEPTH) return []
+	const raw = readText(filePath)
+	if (raw === undefined) return []
+	processed.add(real)
+
+	const baseDir = path.dirname(filePath)
+	const includePaths = extractIncludes(raw, baseDir)
+	const results: MemoryFile[] = []
+
+	// Includes come first (so they appear before the including file's content).
+	for (const includePath of includePaths) {
+		results.push(...loadWithIncludes(includePath, type, processed, depth + 1))
+	}
+
+	results.push({ path: filePath, content: raw, type })
+	return results
+}
+
+/** realpathSync that never throws (falls back to the input path). */
+function safeRealpath(p: string): string {
+	try {
+		return fs.realpathSync(p)
+	} catch {
+		return path.resolve(p)
+	}
+}
+
+/** Walk from cwd up to root, collecting directories (root last). */
+function ancestorDirs(cwd: string): string[] {
+	const dirs: string[] = []
+	let current = path.resolve(cwd)
+	const root = path.parse(current).root
+	while (current !== root) {
+		dirs.push(current)
+		const parent = path.dirname(current)
+		if (parent === current) break
+		current = parent
+	}
+	return dirs
+}
+
+/**
+ * Load all AGENTS.md memory files, in precedence order (lowest first). The
+ * caller concatenates them in order so higher-precedence files appear last
+ * (and thus get more weight from the model).
+ */
+export function loadMemoryFiles(cwd = process.cwd()): MemoryFile[] {
+	const processed = new Set<string>()
+	const files: MemoryFile[] = []
+
+	// 1. User memory (~/.orbcode/AGENTS.md)
+	files.push(...loadWithIncludes(path.join(getConfigDir(), "AGENTS.md"), "user", processed, 0))
+
+	// 2. Project memory (AGENTS.md + .orbcode/AGENTS.md), root -> cwd
+	for (const dir of ancestorDirs(cwd).reverse()) {
+		files.push(...loadWithIncludes(path.join(dir, "AGENTS.md"), "project", processed, 0))
+		files.push(...loadWithIncludes(path.join(dir, ".orbcode", "AGENTS.md"), "project", processed, 0))
+	}
+
+	// 3. Local memory (AGENTS.local.md), root -> cwd — highest precedence
+	for (const dir of ancestorDirs(cwd).reverse()) {
+		files.push(...loadWithIncludes(path.join(dir, "AGENTS.local.md"), "local", processed, 0))
+	}
+
+	return files
+}
+
+/** Render the memory files into a single system-prompt section. */
+export function renderMemorySection(files: MemoryFile[]): string {
+	const valid = files.filter((f) => f.content.trim())
+	if (valid.length === 0) return ""
+	const parts: string[] = [
+		"# Project & User Instructions (AGENTS.md)",
+		"",
+		"Instructions from AGENTS.md files are shown below. Adhere to these instructions; they override default behavior. Treat them as authoritative guidance from the user about this codebase.",
+		"",
+	]
+	let total = 0
+	for (const file of valid) {
+		if (total >= MAX_TOTAL_CHARS) {
+			parts.push("… (remaining memory files truncated to stay within context budget)")
+			break
+		}
+		const label = labelFor(file)
+		parts.push(`## ${label}: \`${file.path}\``)
+		parts.push("")
+		parts.push(file.content.trim())
+		parts.push("")
+		total += file.content.length
+	}
+	return parts.join("\n")
+}
+
+function labelFor(file: MemoryFile): string {
+	switch (file.type) {
+		case "user":
+			return "User memory"
+		case "project":
+			return "Project memory"
+		case "local":
+			return "Local memory"
+	}
+}

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -1,0 +1,9 @@
+/** A loaded memory (AGENTS.md) file with its origin metadata. */
+export interface MemoryFile {
+	/** Absolute path to the file on disk. */
+	path: string
+	/** The file's content (with @includes inlined). */
+	content: string
+	/** Where this memory was loaded from. */
+	type: "user" | "project" | "local"
+}

--- a/src/prompts/system.ts
+++ b/src/prompts/system.ts
@@ -1,6 +1,10 @@
 import * as os from "node:os"
 
 import { getShell } from "../utils/shell.js"
+import type { MemoryFile } from "../memory/types.js"
+import { renderMemorySection } from "../memory/loader.js"
+import type { Skill } from "../skills/types.js"
+import { renderSkillCatalog } from "../skills/loader.js"
 
 // Role definition and tool guide ported verbatim from the Orbital extension
 // (agent mode roleDefinition + applyDiffToolDescription). Only the system
@@ -53,6 +57,18 @@ Bias towards not asking the user for help if you can find the answer yourself.
 # Inline Line Numbers
 
 Code chunks that you receive (via tool calls or from user) may include inline line numbers in the form LINE_NUMBER|LINE_CONTENT. Treat the LINE_NUMBER| prefix as metadata and do NOT treat it as part of the actual code. LINE_NUMBER is right-aligned number padded with spaces to 6 characters.
+
+# Project & User Instructions (AGENTS.md)
+
+Your system prompt may include an "Project & User Instructions (AGENTS.md)" section. These are instructions from AGENTS.md files in the user's home directory, the project root, and parent directories. They contain project-specific guidance: build commands, code style, architecture notes, conventions. Treat them as authoritative instructions from the user about this codebase and follow them exactly. They override default behavior.
+
+# Skills
+
+Your system prompt may include an "Available Skills" section listing skills by name with a description and when-to-use hint. Skills are reusable instruction sets stored in ~/.orbcode/skills/ and .orbcode/skills/. When a task matches a skill's when-to-use condition, invoke the \`use_skill\` tool with the skill's name to load its full instructions, then follow them for the current task.
+
+# MCP Tools
+
+Tools whose names start with \`mcp__\` are provided by external MCP servers the user has configured. They work exactly like native tools — call them with the standard tool call format when the task requires their capabilities. Their descriptions and parameter schemas come from the MCP servers.
 
 CRITICAL: For any task, small or big, you will always and always use the update_todo_list tool to create the TODO list, always keep is upto date with updates to the status and updating/editing the list as needed.`
 
@@ -379,11 +395,23 @@ function getSystemInfoSection(cwd: string): string {
 The Current Workspace Directory is the directory the user launched OrbCode CLI from, and is therefore the default directory for all tool operations. Commands run in the current workspace directory unless a different cwd is passed; changing directories inside a command does not modify the workspace directory. When the user initially gives you a task, a listing of filepaths in the current workspace directory will be included in the Environment Details section. This provides an overview of the project's file structure, offering key insights into the project from directory/file names (how developers conceptualize and organize their code) and file extensions (the language used). This can also guide decision-making on which files to explore further. If you need to further explore directories such as outside the current workspace directory, you can use the list_files tool. If you pass 'true' for the recursive parameter, it will list files recursively. Otherwise, it will list files at the top level, which is better suited for generic directories where you don't necessarily need the nested structure, like the Desktop.`
 }
 
-export function buildSystemPrompt(cwd: string): string {
-	return `${roleDefinition}
+export interface SystemPromptOptions {
+	/** AGENTS.md memory files to inject (lowest precedence first). */
+	memoryFiles?: MemoryFile[]
+	/** Skills catalog to advertise to the model. */
+	skills?: Map<string, Skill>
+}
 
-${toolGuide}
-
-${getSystemInfoSection(cwd)}
-`
+export function buildSystemPrompt(cwd: string, options: SystemPromptOptions = {}): string {
+	const memorySection = options.memoryFiles ? renderMemorySection(options.memoryFiles) : ""
+	const skillSection = options.skills ? renderSkillCatalog(options.skills) : ""
+	return [
+		roleDefinition,
+		toolGuide,
+		getSystemInfoSection(cwd),
+		memorySection,
+		skillSection,
+	]
+		.filter(Boolean)
+		.join("\n\n")
 }

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,0 +1,137 @@
+import * as fs from "node:fs"
+import * as path from "node:path"
+
+import { getConfigDir } from "../config/settings.js"
+import type { ParsedFrontmatter, Skill } from "./types.js"
+
+/**
+ * Skill loader.
+ *
+ * Skills are markdown files that inject specialized instructions when the model
+ * invokes the `use_skill` tool. Discovery mirrors Claude Code's layout:
+ *
+ *   - User skills:   ~/.orbcode/skills/<name>/SKILL.md
+ *   - Project skills: .orbcode/skills/<name>/SKILL.md (in cwd and parents)
+ *
+ * Only the directory format (`<name>/SKILL.md`) is supported, matching Claude
+ * Code's current skills/ convention. Project skills override user skills on
+ * name collisions (closer-to-cwd wins).
+ */
+
+/** Parse a leading `---\n...---\n` YAML frontmatter block. */
+export function parseFrontmatter(raw: string): ParsedFrontmatter {
+	const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(raw)
+	if (!match) return { frontmatter: {}, content: raw }
+	const [, yamlBlock, body] = match
+	const frontmatter: Record<string, string> = {}
+	for (const line of yamlBlock.split(/\r?\n/)) {
+		const idx = line.indexOf(":")
+		if (idx === -1) continue
+		const key = line.slice(0, idx).trim()
+		const value = line.slice(idx + 1).trim().replace(/^["']|["']$/g, "")
+		if (key) frontmatter[key] = value
+	}
+	return { frontmatter, content: body.trimStart() }
+}
+
+/** Extract a description from the first markdown paragraph if frontmatter lacks one. */
+function descriptionFromBody(content: string): string {
+	const text = content
+		.replace(/^#+\s.*$/gm, "")
+		.replace(/```[\s\S]*?```/g, "")
+		.trim()
+	const firstPara = text.split(/\n\s*\n/)[0] ?? ""
+	return firstPara.replace(/\s+/g, " ").trim().slice(0, 160)
+}
+
+/** Load a single skill from a `<dir>/SKILL.md` path. */
+function loadSkill(skillDir: string, source: "user" | "project"): Skill | undefined {
+	const skillFile = path.join(skillDir, "SKILL.md")
+	let raw: string
+	try {
+		raw = fs.readFileSync(skillFile, "utf8")
+	} catch {
+		return undefined
+	}
+	const name = path.basename(skillDir)
+	const { frontmatter, content } = parseFrontmatter(raw)
+	return {
+		name,
+		description: frontmatter.description || descriptionFromBody(content),
+		whenToUse: frontmatter.when_to_use,
+		content,
+		source,
+		dir: skillDir,
+	}
+}
+
+/** Load all skills from a `skills/` directory (each subdirectory is one skill). */
+function loadSkillsDir(skillsDir: string, source: "user" | "project"): Skill[] {
+	let entries: fs.Dirent[]
+	try {
+		entries = fs.readdirSync(skillsDir, { withFileTypes: true })
+	} catch {
+		return []
+	}
+	const skills: Skill[] = []
+	for (const entry of entries) {
+		if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
+		const skill = loadSkill(path.join(skillsDir, entry.name), source)
+		if (skill) skills.push(skill)
+	}
+	return skills
+}
+
+/** Walk from cwd up to root, collecting `.orbcode/skills` dirs (root last). */
+function projectSkillsDirs(cwd: string): string[] {
+	const dirs: string[] = []
+	let current = path.resolve(cwd)
+	const root = path.parse(current).root
+	while (current !== root) {
+		dirs.push(path.join(current, ".orbcode", "skills"))
+		const parent = path.dirname(current)
+		if (parent === current) break
+		current = parent
+	}
+	return dirs
+}
+
+/**
+ * Load all skills. Project skills (closer-to-cwd) override user skills on name
+ * collisions. Returns a map keyed by skill name.
+ */
+export function loadSkills(cwd = process.cwd()): Map<string, Skill> {
+	const skills = new Map<string, Skill>()
+
+	// User skills first (lowest precedence).
+	for (const skill of loadSkillsDir(path.join(getConfigDir(), "skills"), "user")) {
+		skills.set(skill.name, skill)
+	}
+
+	// Project skills, root -> cwd so cwd wins.
+	for (const dir of projectSkillsDirs(cwd).reverse()) {
+		for (const skill of loadSkillsDir(dir, "project")) {
+			skills.set(skill.name, skill)
+		}
+	}
+
+	return skills
+}
+
+/** Render the skill catalog for the system prompt (names + when_to_use). */
+export function renderSkillCatalog(skills: Map<string, Skill>): string {
+	if (skills.size === 0) return ""
+	const lines = ["# Available Skills", ""]
+	for (const skill of skills.values()) {
+		const when = skill.whenToUse ? ` — use when: ${skill.whenToUse}` : ""
+		lines.push(`- \`${skill.name}\`: ${skill.description}${when}`)
+	}
+	lines.push("")
+	lines.push("Use the `use_skill` tool with a `skill_name` to load a skill's full instructions.")
+	return lines.join("\n")
+}
+
+/** Substitute ${SKILL_DIR} in a skill's content with its directory path. */
+export function renderSkillContent(skill: Skill): string {
+	return skill.content.replace(/\$\{SKILL_DIR\}/g, skill.dir)
+}

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -1,0 +1,21 @@
+/** A loaded skill (markdown prompt with frontmatter metadata). */
+export interface Skill {
+	/** Skill name (the directory name under skills/). */
+	name: string
+	/** Human-readable description, from frontmatter or the first paragraph. */
+	description: string
+	/** When the model should invoke this skill (frontmatter `when_to_use`). */
+	whenToUse?: string
+	/** The full markdown body (without frontmatter). */
+	content: string
+	/** Where this skill was loaded from. */
+	source: "user" | "project"
+	/** Absolute path to the skill's directory (for ${SKILL_DIR} substitution). */
+	dir: string
+}
+
+/** Minimal frontmatter parser: extracts a top-level YAML block + the body. */
+export interface ParsedFrontmatter {
+	frontmatter: Record<string, string>
+	content: string
+}

--- a/src/tools/executors/skills.ts
+++ b/src/tools/executors/skills.ts
@@ -1,0 +1,30 @@
+import type { ToolContext, ToolResult } from "../types.js"
+import { loadSkills, renderSkillContent } from "../../skills/loader.js"
+
+/**
+ * `use_skill` executor: loads a skill's full markdown instructions and returns
+ * them to the model so it can follow the skill's guidance for the current task.
+ *
+ * Skills are discovered from ~/.orbcode/skills/ and .orbcode/skills/ (see the
+ * skills loader). The model sees the catalog in the system prompt and invokes
+ * this tool with a `skill_name`.
+ */
+export async function useSkill(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
+	const skillName = String(args.skill_name ?? "").trim()
+	if (!skillName) {
+		return { text: "No skill_name provided.", isError: true }
+	}
+	const skills = loadSkills(context.cwd)
+	const skill = skills.get(skillName)
+	if (!skill) {
+		const available = [...skills.keys()].join(", ") || "(none)"
+		return {
+			text: `Skill "${skillName}" not found. Available skills: ${available}`,
+			isError: true,
+		}
+	}
+	const content = renderSkillContent(skill)
+	return {
+		text: `# Skill: ${skill.name}\n\n${content}\n\n---\nFollow this skill's instructions for the current task.`,
+	}
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,7 +6,9 @@ import { fileEdit, fileWrite, multiFileEdit, readFile } from "./executors/files.
 import { listFiles } from "./executors/listFiles.js"
 import { searchFiles } from "./executors/searchFiles.js"
 import { executeCommand } from "./executors/executeCommand.js"
+import { useSkill } from "./executors/skills.js"
 import { webFetch, webSearch } from "./executors/web.js"
+import type { McpManager } from "../mcp/manager.js"
 
 export { nativeTools }
 export type { ToolContext, ToolResult }
@@ -53,11 +55,18 @@ export function describeToolCall(toolName: string, args: Record<string, unknown>
 			return String(args.url ?? "")
 		case "update_todo_list":
 			return "updating tasks"
+		case "use_skill":
+			return String(args.skill_name ?? "")
 		case "ask_followup_question":
 			return String(args.question ?? "")
 		case "attempt_completion":
 			return "task complete"
 		default:
+			// MCP tools (mcp__<server>__<tool>) — show the server + tool name.
+			if (/^mcp__/.test(toolName)) {
+				const match = /^mcp__([^_]+)__(.+)$/.exec(toolName)
+				return match ? `${match[2]} (${match[1]})` : toolName
+			}
 			return toolName
 	}
 }
@@ -72,18 +81,26 @@ const executors: Record<string, (args: Record<string, unknown>, context: ToolCon
 	execute_command: executeCommand,
 	web_search: webSearch,
 	web_fetch: webFetch,
+	use_skill: useSkill,
 	update_todo_list: async (args, context) => {
 		context.setTodos(String(args.todos ?? ""))
 		return { text: "Todo list updated." }
 	},
 	// ask_followup_question and attempt_completion are handled by the agent loop.
+	// MCP tools (mcp__<server>__<tool>) are routed via the McpManager in executeTool.
 }
 
 export async function executeTool(
 	toolName: string,
 	args: Record<string, unknown>,
 	context: ToolContext,
+	mcp?: McpManager,
 ): Promise<ToolResult> {
+	// MCP tools are namespaced as mcp__<server>__<tool> and routed to the manager.
+	if (mcp && mcp.hasTool(toolName)) {
+		const result = await mcp.callTool(toolName, args)
+		return { text: result.text, isError: result.isError }
+	}
 	const executor = executors[toolName]
 	if (!executor) {
 		return { text: `Tool "${toolName}" is not available in OrbCode CLI.`, isError: true }
@@ -95,6 +112,9 @@ export async function executeTool(
 	}
 }
 
-export function getActiveTools(): OpenAI.Chat.ChatCompletionTool[] {
-	return nativeTools
+/** Native tools plus any MCP tools from connected servers. */
+export function getActiveTools(mcp?: McpManager): OpenAI.Chat.ChatCompletionTool[] {
+	const tools: OpenAI.Chat.ChatCompletionTool[] = [...nativeTools]
+	if (mcp) tools.push(...mcp.getTools())
+	return tools
 }

--- a/src/tools/schemas/index.ts
+++ b/src/tools/schemas/index.ts
@@ -10,12 +10,14 @@ import listFiles from "./list_files.js"
 import { read_file_single } from "./read_file.js"
 import searchFiles from "./search_files.js"
 import updateTodoList from "./update_todo_list.js"
+import useSkill from "./use_skill.js"
 import webFetch from "./web_fetch.js"
 import webSearch from "./web_search.js"
 
-// Native tool schemas ported verbatim from the Orbital extension (native-tools).
-// Tools that depend on IDE-only services (codebase_search, lsp, use_skill,
-// check_past_chat_memories, browser_action, …) are not active in the CLI.
+// Native tool schemas ported from the Orbital extension. IDE-only tools
+// (codebase_search, lsp, check_past_chat_memories, browser_action, …) are not
+// active in the CLI. use_skill is now active: skills are loaded from
+// ~/.orbcode/skills/ and .orbcode/skills/ (see src/skills/loader.ts).
 export const nativeTools = [
 	fileEdit,
 	multiFileEdit,
@@ -27,6 +29,7 @@ export const nativeTools = [
 	read_file_single,
 	searchFiles,
 	updateTodoList,
+	useSkill,
 	webFetch,
 	webSearch,
 ] satisfies OpenAI.Chat.ChatCompletionTool[]

--- a/src/tools/schemas/use_skill.ts
+++ b/src/tools/schemas/use_skill.ts
@@ -5,7 +5,7 @@ export default {
 	function: {
 		name: "use_skill",
 		description:
-			"Use a specific skill to guide the task execution. This tool allows you to apply predefined skills stored in the workspace's .agent/skills directory. Each skill contains specialized instructions for performing specific tasks or following particular patterns.",
+			"Use a specific skill to guide the task execution. This tool applies predefined skills stored in ~/.orbcode/skills/ (user) and .orbcode/skills/ (project). Each skill is a directory containing a SKILL.md file with specialized instructions for performing specific tasks or following particular patterns. The available skills are listed in the 'Available Skills' section of your system prompt — invoke this tool with a skill_name from that list when the task matches a skill's when-to-use condition.",
 		strict: true,
 		parameters: {
 			type: "object",

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -10,11 +10,13 @@ import {
 	getAuthToken,
 	getPendingProjectHooks,
 	loadSettings,
+	saveMcpApproval,
 	saveSettings,
 	trustProjectHooks,
 	type OrbCodeSettings,
 } from "../config/settings.js"
 import { Agent } from "../core/agent.js"
+import { McpManager } from "../mcp/manager.js"
 import type { UpdateInfo } from "../utils/updateCheck.js"
 import type {
 	AgentEvent,
@@ -27,6 +29,8 @@ import { InputBox, type SlashCommand } from "./components/InputBox.js"
 import { ApprovalPrompt } from "./components/ApprovalPrompt.js"
 import { FollowupPrompt } from "./components/FollowupPrompt.js"
 import { HookTrustPrompt } from "./components/HookTrustPrompt.js"
+import { McpApprovalPrompt } from "./components/McpApprovalPrompt.js"
+import { McpPicker } from "./components/McpPicker.js"
 import { StatusBar, type ApprovalMode } from "./components/StatusBar.js"
 import { ModelPicker } from "./components/ModelPicker.js"
 import { SessionPicker } from "./components/SessionPicker.js"
@@ -44,6 +48,7 @@ const SLASH_COMMANDS: SlashCommand[] = [
 	{ name: "/status", description: "show session status (model, context, cost, account)" },
 	{ name: "/cost", description: "show session cost and balance" },
 	{ name: "/init", description: "analyze this codebase and create an AGENTS.md" },
+	{ name: "/mcp", description: "manage MCP servers — enable, disable, reconnect, view status" },
 	{ name: "/commit", description: "check pending changes and create detailed commits" },
 	{ name: "/code-review", description: "expert review of pending changes: performance, security, bugs, tests" },
 	{ name: "/analytics", description: "open your MatterAI analytics dashboard" },
@@ -217,6 +222,12 @@ export function App({
 	const [queuedMessages, setQueuedMessages] = useState<string[]>([])
 	const [modelPickerOpen, setModelPickerOpen] = useState(false)
 	const [resumableSessions, setResumableSessions] = useState<SessionData[] | null>(null)
+	// MCP manager (created once, shared across agents in this process). Null until
+	// the first agent is created so we don't spawn servers before login.
+	const mcpManagerRef = useRef<McpManager | null>(null)
+	const [mcpPickerOpen, setMcpPickerOpen] = useState(false)
+	// Project-scope MCP servers awaiting the user's approval at startup.
+	const [pendingMcpApproval, setPendingMcpApproval] = useState<string[] | null>(null)
 	const [staticKey, setStaticKey] = useState(0)
 	const [tasks, setTasks] = useState("")
 	const [contextTokens, setContextTokens] = useState(0)
@@ -411,6 +422,17 @@ export function App({
 	const createAgent = useCallback(
 		(resume?: SessionData): Agent => {
 			const current = loadSettings()
+			// Create the MCP manager once per process and reuse it across agents
+			// (so /new and /resume keep the same server connections). It reads
+			// the enabled/disabled lists from settings and connects to approved
+			// servers lazily on start().
+			if (!mcpManagerRef.current) {
+				mcpManagerRef.current = new McpManager(
+					process.cwd(),
+					current.disabledMcpServers ?? [],
+					current.enabledMcpServers ?? [],
+				)
+			}
 			return new Agent({
 				cwd: process.cwd(),
 				token: getAuthToken(current)!,
@@ -420,6 +442,7 @@ export function App({
 				autoApproveEdits: current.autoApproveEdits,
 				autoApproveSafeCommands: current.autoApproveSafeCommands,
 				hooks: current.hooks,
+				mcp: mcpManagerRef.current,
 				resume,
 				callbacks: {
 					onEvent: handleEvent,
@@ -488,6 +511,8 @@ export function App({
 		(reason: string) => {
 			const agent = agentRef.current
 			if (!agent) {
+				// No agent yet, but the MCP manager may have started; tear it down.
+				void mcpManagerRef.current?.stop().catch(() => {})
 				exit()
 				return
 			}
@@ -639,6 +664,15 @@ export function App({
 					setBusyLabel("Thinking")
 					void getAgent().runTurn(INIT_PROMPT)
 					break
+				case "/mcp": {
+					const manager = mcpManagerRef.current
+					if (!manager) {
+						pushRow({ kind: "info", text: "MCP not initialized yet — send a message first." })
+						break
+					}
+					setMcpPickerOpen(true)
+					break
+				}
 				case "/commit":
 					if (!getAuthToken(settings)) {
 						setView("login")
@@ -754,6 +788,31 @@ export function App({
 		[handleSubmit, pushRow],
 	)
 
+	// Resolve the MCP server approval prompt: connect to the approved project
+	// servers, persist the decision, and proceed with any deferred startup prompt.
+	const resolveMcpApproval = useCallback(
+		async (approved: string[]) => {
+			setPendingMcpApproval(null)
+			const manager = mcpManagerRef.current
+			if (manager) {
+				// Enable each approved server (connects immediately). Disapproved
+				// ones stay disabled and won't prompt again (persisted below).
+				await Promise.all(approved.map((name) => manager.enableServer(name).catch(() => {})))
+				saveMcpApproval(process.cwd(), manager.getEnabled(), manager.getDisabled())
+				const snap = manager.snapshot()
+				const connected = snap.servers.filter((s) => s.status === "connected").length
+				pushRow({
+					kind: "info",
+					text: `MCP: ${connected}/${snap.servers.length} server${snap.servers.length === 1 ? "" : "s"} connected${approved.length ? ` (approved: ${approved.join(", ")})` : ""}.`,
+				})
+			}
+			const deferred = deferredPromptRef.current
+			deferredPromptRef.current = null
+			if (deferred) handleSubmit(deferred)
+		},
+		[handleSubmit, pushRow],
+	)
+
 	// Apply --resume and an initial prompt (`orbcode "do something"`) on startup.
 	const bootedRef = useRef(false)
 	useEffect(() => {
@@ -768,6 +827,22 @@ export function App({
 			deferredPromptRef.current = initialPrompt ?? null
 		} else if (initialPrompt) {
 			handleSubmit(initialPrompt)
+		}
+		// Start the MCP manager and surface any project-scope servers that need
+		// approval. The approval prompt is non-blocking: the agent can start
+		// working while the user decides, and approved servers connect live.
+		const current = loadSettings()
+		if (getAuthToken(current)) {
+			const manager = new McpManager(
+				process.cwd(),
+				current.disabledMcpServers ?? [],
+				current.enabledMcpServers ?? [],
+			)
+			mcpManagerRef.current = manager
+			void manager.start().then(() => {
+				const pendingMcp = manager.getPendingApproval()
+				if (pendingMcp.length > 0) setPendingMcpApproval(pendingMcp)
+			})
 		}
 		refreshUsage()
 	}, [initialSession, initialPrompt, handleResume, handleSubmit, refreshUsage])
@@ -845,7 +920,9 @@ export function App({
 		!pendingApproval &&
 		!pendingFollowup &&
 		!pendingHookTrust &&
+		!pendingMcpApproval &&
 		!modelPickerOpen &&
+		!mcpPickerOpen &&
 		!resumableSessions
 
 	return (
@@ -948,6 +1025,26 @@ export function App({
 							/>
 						</Box>
 					)}
+					{pendingMcpApproval && (
+						<Box marginTop={1}>
+							<McpApprovalPrompt
+								serverNames={pendingMcpApproval}
+								onApprove={resolveMcpApproval}
+							/>
+						</Box>
+					)}
+					{mcpPickerOpen && mcpManagerRef.current && (
+						<Box marginTop={1}>
+							<McpPicker
+								manager={mcpManagerRef.current}
+								onChanged={() => {
+									const m = mcpManagerRef.current
+									if (m) saveMcpApproval(process.cwd(), m.getEnabled(), m.getDisabled())
+								}}
+								onCancel={() => setMcpPickerOpen(false)}
+							/>
+						</Box>
+					)}
 					{pendingApproval && (
 						<Box marginTop={1}>
 							<ApprovalPrompt
@@ -972,7 +1069,7 @@ export function App({
 							/>
 						</Box>
 					)}
-					{busy && !pendingApproval && !pendingFollowup && !pendingHookTrust && !streamingText && (
+					{busy && !pendingApproval && !pendingFollowup && !pendingHookTrust && !pendingMcpApproval && !mcpPickerOpen && !streamingText && (
 						<Box marginTop={1}>
 							<Spinner label={busyLabel} />
 						</Box>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,116 +1,146 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Box, Static, Text, useApp, useInput } from "ink"
-import open from "open"
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { Box, Static, Text, useApp, useInput } from "ink";
+import open from "open";
 
-import { COLORS, VERSION } from "../branding.js"
-import { BUILTIN_AXON_MODELS, getModel, isValidAxonModel } from "../api/models.js"
-import { LoginView } from "./LoginView.js"
-import { APP_URL, fetchBalance, fetchProfile, fetchTaskTitle, type ProfileData } from "../auth/auth.js"
+import { COLORS, VERSION } from "../branding.js";
 import {
-	getAuthToken,
-	getPendingProjectHooks,
-	loadSettings,
-	saveMcpApproval,
-	saveSettings,
-	trustProjectHooks,
-	type OrbCodeSettings,
-} from "../config/settings.js"
-import { Agent } from "../core/agent.js"
-import { McpManager } from "../mcp/manager.js"
-import type { UpdateInfo } from "../utils/updateCheck.js"
+  BUILTIN_AXON_MODELS,
+  getModel,
+  isValidAxonModel,
+} from "../api/models.js";
+import { LoginView } from "./LoginView.js";
+import {
+  APP_URL,
+  fetchProfile,
+  fetchTaskTitle,
+  type ProfileData,
+} from "../auth/auth.js";
+import {
+  getAuthToken,
+  getPendingProjectHooks,
+  loadSettings,
+  saveMcpApproval,
+  saveSettings,
+  trustProjectHooks,
+  type OrbCodeSettings,
+} from "../config/settings.js";
+import { Agent } from "../core/agent.js";
+import { McpManager } from "../mcp/manager.js";
+import type { UpdateInfo } from "../utils/updateCheck.js";
 import type {
-	AgentEvent,
-	ApprovalDecision,
-	ApprovalRequest,
-	FollowupSuggestion,
-} from "../core/events.js"
-import { Spinner } from "./components/Spinner.js"
-import { InputBox, type SlashCommand } from "./components/InputBox.js"
-import { ApprovalPrompt } from "./components/ApprovalPrompt.js"
-import { FollowupPrompt } from "./components/FollowupPrompt.js"
-import { HookTrustPrompt } from "./components/HookTrustPrompt.js"
-import { McpApprovalPrompt } from "./components/McpApprovalPrompt.js"
-import { McpPicker } from "./components/McpPicker.js"
-import { StatusBar, type ApprovalMode } from "./components/StatusBar.js"
-import { ModelPicker } from "./components/ModelPicker.js"
-import { SessionPicker } from "./components/SessionPicker.js"
-import { listSessions, type SessionData } from "../core/sessions.js"
-import { RowView, formatToolName, type Row } from "./components/rows.js"
+  AgentEvent,
+  ApprovalDecision,
+  ApprovalRequest,
+  FollowupSuggestion,
+} from "../core/events.js";
+import { Spinner } from "./components/Spinner.js";
+import { InputBox, type SlashCommand } from "./components/InputBox.js";
+import { ApprovalPrompt } from "./components/ApprovalPrompt.js";
+import { FollowupPrompt } from "./components/FollowupPrompt.js";
+import { HookTrustPrompt } from "./components/HookTrustPrompt.js";
+import { McpApprovalPrompt } from "./components/McpApprovalPrompt.js";
+import { McpPicker } from "./components/McpPicker.js";
+import { StatusBar, type ApprovalMode } from "./components/StatusBar.js";
+import { ModelPicker } from "./components/ModelPicker.js";
+import { SessionPicker } from "./components/SessionPicker.js";
+import { listSessions, type SessionData } from "../core/sessions.js";
+import { RowView, formatToolName, type Row } from "./components/rows.js";
 
 const SLASH_COMMANDS: SlashCommand[] = [
-	{ name: "/help", description: "show available commands" },
-	{ name: "/model", description: "select the Axon model to use" },
-	{ name: "/clear", description: "clear the screen — the conversation continues" },
-	{ name: "/new", description: "start a new conversation with a clean slate" },
-	{ name: "/resume", description: "resume a previous session" },
-	{ name: "/compact", description: "summarize the conversation to free up context" },
-	{ name: "/tasks", description: "show the current task list" },
-	{ name: "/status", description: "show session status (model, context, cost, account)" },
-	{ name: "/cost", description: "show session cost and balance" },
-	{ name: "/init", description: "analyze this codebase and create an AGENTS.md" },
-	{ name: "/mcp", description: "manage MCP servers — enable, disable, reconnect, view status" },
-	{ name: "/commit", description: "check pending changes and create detailed commits" },
-	{ name: "/code-review", description: "expert review of pending changes: performance, security, bugs, tests" },
-	{ name: "/analytics", description: "open your MatterAI analytics dashboard" },
-	{ name: "/login", description: "sign in to MatterAI" },
-	{ name: "/logout", description: "sign out and remove the saved token" },
-	{ name: "/version", description: "show the OrbCode CLI version" },
-	{ name: "/exit", description: "quit OrbCode CLI" },
-]
+  { name: "/help", description: "show available commands" },
+  { name: "/model", description: "select the Axon model to use" },
+  {
+    name: "/clear",
+    description: "clear the screen — the conversation continues",
+  },
+  { name: "/new", description: "start a new conversation with a clean slate" },
+  { name: "/resume", description: "resume a previous session" },
+  {
+    name: "/compact",
+    description: "summarize the conversation to free up context",
+  },
+  { name: "/tasks", description: "show the current task list" },
+  {
+    name: "/status",
+    description: "show session status (model, context, cost, account)",
+  },
+  { name: "/usage", description: "fetch plan usage" },
+  {
+    name: "/init",
+    description: "analyze this codebase and create an AGENTS.md",
+  },
+  {
+    name: "/mcp",
+    description: "manage MCP servers — enable, disable, reconnect, view status",
+  },
+  {
+    name: "/commit",
+    description: "check pending changes and create detailed commits",
+  },
+  {
+    name: "/code-review",
+    description:
+      "expert review of pending changes: performance, security, bugs, tests",
+  },
+  { name: "/analytics", description: "open your MatterAI analytics dashboard" },
+  { name: "/login", description: "sign in to MatterAI" },
+  { name: "/logout", description: "sign out and remove the saved token" },
+  { name: "/version", description: "show the OrbCode CLI version" },
+  { name: "/exit", description: "quit OrbCode CLI" },
+];
 
 function setTerminalTitle(title: string): void {
-	if (process.stdout.isTTY) {
-		process.stdout.write(`\x1b]0;${title}\x07`)
-	}
+  if (process.stdout.isTTY) {
+    process.stdout.write(`\x1b]0;${title}\x07`);
+  }
 }
 
 function formatRelativeTime(isoStr?: string): string {
-	if (!isoStr) return "???"
-	const now = Date.now()
-	const target = new Date(isoStr).getTime()
-	if (Number.isNaN(target)) return "???"
-	const diff = target - now
-	if (diff <= 0) return "now"
-	const sec = Math.floor(diff / 1000)
-	const min = Math.floor(sec / 60)
-	const hrs = Math.floor(min / 60)
-	const days = Math.floor(hrs / 24)
-	if (days >= 1) return `in ${days} day${days > 1 ? "s" : ""}`
-	if (hrs >= 1) return `in ${hrs}h ${min % 60}m`
-	if (min >= 1) return `in ${min}m`
-	return "soon"
+  if (!isoStr) return "???";
+  const now = Date.now();
+  const target = new Date(isoStr).getTime();
+  if (Number.isNaN(target)) return "???";
+  const diff = target - now;
+  if (diff <= 0) return "now";
+  const sec = Math.floor(diff / 1000);
+  const min = Math.floor(sec / 60);
+  const hrs = Math.floor(min / 60);
+  const days = Math.floor(hrs / 24);
+  if (days >= 1) return `in ${days} day${days > 1 ? "s" : ""}`;
+  if (hrs >= 1) return `in ${hrs}h ${min % 60}m`;
+  if (min >= 1) return `in ${min}m`;
+  return "soon";
 }
 
-/** Human lines for the /status and /cost usage block (extension profile data). */
+/** Human lines for the /status and /usage usage block (extension profile data). */
 function usageLines(profile: ProfileData): string[] {
-	const lines: string[] = []
-	if (profile.plan) lines.push(`Plan        ${profile.plan}`)
-	if (typeof profile.usagePercentage === "number") {
-		lines.push(
-			`Usage       ${profile.usagePercentage}% used · ${Math.max(0, 100 - profile.usagePercentage)}% remaining`,
-		)
-	}
-	if (typeof profile.remainingReviews === "number") {
-		lines.push(`Reviews     ${profile.remainingReviews} remaining`)
-	}
-	if (profile.tieredUsage) {
-		const ws: [string, string, import("../auth/auth.js").AxonCodeWindowUsage][] = [
-			["5hr", "5-Hour", profile.tieredUsage.fiveHour],
-			["wk",  "Weekly", profile.tieredUsage.weekly],
-			["mo",  "Monthly", profile.tieredUsage.monthly],
-		]
-		for (const [short, label, w] of ws) {
-			const remaining = Math.max(0, w.remaining || 0)
-			const pct = Math.max(0, Math.min(100, w.percentage || 0))
-			const reset = formatRelativeTime(w.resetsAt)
-			lines.push(
-				`${label.padEnd(12)} ${remaining.toFixed(1)}/${w.limit.toFixed(1)} left (${pct}% used) · Resets ${reset}`,
-			)
-		}
-	} else if (profile.creditsResetDate) {
-		lines.push(`Resets      ${profile.creditsResetDate}`)
-	}
-	return lines
+  const lines: string[] = [];
+  if (profile.plan) lines.push(`Plan        ${profile.plan?.toUpperCase()}`);
+  if (profile.tieredUsage) {
+    const ws: [
+      string,
+      string,
+      import("../auth/auth.js").AxonCodeWindowUsage,
+    ][] = [
+      ["5hr", "5-Hour", profile.tieredUsage.fiveHour],
+      ["wk", "Weekly", profile.tieredUsage.weekly],
+      ["mo", "Monthly", profile.tieredUsage.monthly],
+    ];
+    for (const [short, label, w] of ws) {
+      const pct = Math.max(0, Math.min(100, w.percentage || 0));
+      const reset = formatRelativeTime(w.resetsAt);
+      lines.push(`${label.padEnd(12)}${pct}% used · Resets ${reset}`);
+    }
+  } else if (profile.creditsResetDate) {
+    lines.push(`Resets      ${profile.creditsResetDate}`);
+  }
+  return lines;
 }
 
 const INIT_PROMPT = `Analyze this codebase and create an AGENTS.md file containing:
@@ -119,10 +149,12 @@ const INIT_PROMPT = `Analyze this codebase and create an AGENTS.md file containi
 3. Architecture and code structure (key directories and what lives in them)
 4. Code style conventions used in this repo (imports, formatting, naming, error handling)
 
-If an AGENTS.md already exists, improve it. Keep it under ~60 lines so it is cheap to include in future prompts.`
+If an AGENTS.md already exists, improve it. Keep it under ~60 lines so it is cheap to include in future prompts.`;
 
 // Ported from the Orbital extension's commit slash command (commitCommandResponse).
-const buildCommitPrompt = (userInput: string) => `The user has explicitly asked you to check pending changes and generate detailed commit messages. You MUST now help them with this.
+const buildCommitPrompt = (
+  userInput: string,
+) => `The user has explicitly asked you to check pending changes and generate detailed commit messages. You MUST now help them with this.
 
 Please check all the pending changes in the git repository and generate detailed commit messages. If needed, you can split into multiple commits also.
 
@@ -142,9 +174,11 @@ To detect if the repository is hosted on GitHub, check the remote URL using:
 If the remote URL contains "github.com", use the author flag:
   git commit --author="matterai-app[bot] <matterai-app[bot]@users.noreply.github.com>"
 
-Before committing, present the commit messages to the user for review and ask them to confirm before executing.${userInput ? `\n\nThe user provided the following input with the commit command:\n${userInput}` : ""}`
+Before committing, present the commit messages to the user for review and ask them to confirm before executing.${userInput ? `\n\nThe user provided the following input with the commit command:\n${userInput}` : ""}`;
 
-const buildCodeReviewPrompt = (userInput: string) => `The user has explicitly asked you to perform a thorough code review of the pending changes. You MUST now help them with this.
+const buildCodeReviewPrompt = (
+  userInput: string,
+) => `The user has explicitly asked you to perform a thorough code review of the pending changes. You MUST now help them with this.
 
 Review the code as a panel of four experts. Adopt each expert persona fully, one at a time, and review the complete change set from that specialty before moving on to the next:
 
@@ -160,967 +194,1110 @@ Instructions:
 4. Only report real findings. If an expert finds nothing significant, state that explicitly — do not invent issues to fill space.
 5. Finish with a short summary: all findings ordered by severity, and an overall verdict on whether the changes are safe to merge.
 
-This is a review only — do NOT modify any files. Present the findings to the user.${userInput ? `\n\nThe user provided the following input with the code-review command:\n${userInput}` : ""}`
+This is a review only — do NOT modify any files. Present the findings to the user.${userInput ? `\n\nThe user provided the following input with the code-review command:\n${userInput}` : ""}`;
 
 interface PendingApproval {
-	request: ApprovalRequest
-	resolve: (decision: ApprovalDecision) => void
+  request: ApprovalRequest;
+  resolve: (decision: ApprovalDecision) => void;
 }
 
 interface PendingFollowup {
-	question: string
-	suggestions: FollowupSuggestion[]
-	resolve: (answer: string) => void
+  question: string;
+  suggestions: FollowupSuggestion[];
+  resolve: (answer: string) => void;
 }
 
 interface RunningTool {
-	id: string
-	name: string
-	summary: string
+  id: string;
+  name: string;
+  summary: string;
 }
 
-let rowCounter = 0
+let rowCounter = 0;
 function rowId(): string {
-	return `row-${rowCounter++}`
+  return `row-${rowCounter++}`;
 }
 
-type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never
+type DistributiveOmit<T, K extends keyof T> = T extends unknown
+  ? Omit<T, K>
+  : never;
 
 export function App({
-	initialView,
-	initialPrompt,
-	initialSession,
-	updateCheck,
+  initialView,
+  initialPrompt,
+  initialSession,
+  updateCheck,
 }: {
-	initialView?: "login" | "chat"
-	initialPrompt?: string
-	initialSession?: SessionData
-	/** Promise resolving to the latest-npm-version comparison; resolved after first paint. */
-	updateCheck?: Promise<UpdateInfo>
+  initialView?: "login" | "chat";
+  initialPrompt?: string;
+  initialSession?: SessionData;
+  /** Promise resolving to the latest-npm-version comparison; resolved after first paint. */
+  updateCheck?: Promise<UpdateInfo>;
 }) {
-	const { exit } = useApp()
-	const [settings, setSettings] = useState<OrbCodeSettings>(() => loadSettings())
-	const [view, setView] = useState<"login" | "chat">(initialView ?? (getAuthToken(settings) ? "chat" : "login"))
-	const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null)
+  const { exit } = useApp();
+  const [settings, setSettings] = useState<OrbCodeSettings>(() =>
+    loadSettings(),
+  );
+  const [view, setView] = useState<"login" | "chat">(
+    initialView ?? (getAuthToken(settings) ? "chat" : "login"),
+  );
+  const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
 
-	const [rows, setRows] = useState<Row[]>(() => [
-		{ kind: "header", id: "header", cwd: process.cwd(), modelName: getModel(loadSettings().model).name },
-	])
-	const [busy, setBusy] = useState(false)
-	const [busyLabel, setBusyLabel] = useState("Thinking")
-	const [streamingReasoning, setStreamingReasoning] = useState("")
-	const [streamingText, setStreamingText] = useState("")
-	const [runningTool, setRunningTool] = useState<RunningTool | null>(null)
-	const [pendingApproval, setPendingApproval] = useState<PendingApproval | null>(null)
-	const [pendingFollowup, setPendingFollowup] = useState<PendingFollowup | null>(null)
-	// Set when the current project defines hooks that haven't been trusted yet;
-	// gates input until the user decides (project hooks run shell commands).
-	const [pendingHookTrust, setPendingHookTrust] = useState<{ commands: string[] } | null>(null)
-	// FIFO queue of messages the user typed while the LLM was still streaming.
-	// Drained one-per-turn on each `turn-end` event so multi-step work can
-	// keep flowing without making the user wait for the previous response.
-	const [queuedMessages, setQueuedMessages] = useState<string[]>([])
-	const [modelPickerOpen, setModelPickerOpen] = useState(false)
-	const [resumableSessions, setResumableSessions] = useState<SessionData[] | null>(null)
-	// MCP manager (created once, shared across agents in this process). Null until
-	// the first agent is created so we don't spawn servers before login.
-	const mcpManagerRef = useRef<McpManager | null>(null)
-	const [mcpPickerOpen, setMcpPickerOpen] = useState(false)
-	// Project-scope MCP servers awaiting the user's approval at startup.
-	const [pendingMcpApproval, setPendingMcpApproval] = useState<string[] | null>(null)
-	const [staticKey, setStaticKey] = useState(0)
-	const [tasks, setTasks] = useState("")
-	const [contextTokens, setContextTokens] = useState(0)
-	const [totalCost, setTotalCost] = useState(0)
-	const [approvalMode, setApprovalMode] = useState<ApprovalMode>(() =>
-		settings.autoApproveEdits && settings.autoApproveSafeCommands
-			? "auto"
-			: settings.autoApproveEdits
-				? "edits"
-				: "ask",
-	)
+  const [rows, setRows] = useState<Row[]>(() => [
+    {
+      kind: "header",
+      id: "header",
+      cwd: process.cwd(),
+      modelName: getModel(loadSettings().model).name,
+    },
+  ]);
+  const [busy, setBusy] = useState(false);
+  const [busyLabel, setBusyLabel] = useState("Thinking");
+  const [streamingReasoning, setStreamingReasoning] = useState("");
+  const [streamingText, setStreamingText] = useState("");
+  const [runningTool, setRunningTool] = useState<RunningTool | null>(null);
+  const [pendingApproval, setPendingApproval] =
+    useState<PendingApproval | null>(null);
+  const [pendingFollowup, setPendingFollowup] =
+    useState<PendingFollowup | null>(null);
+  // Set when the current project defines hooks that haven't been trusted yet;
+  // gates input until the user decides (project hooks run shell commands).
+  const [pendingHookTrust, setPendingHookTrust] = useState<{
+    commands: string[];
+  } | null>(null);
+  // FIFO queue of messages the user typed while the LLM was still streaming.
+  // Drained one-per-turn on each `turn-end` event so multi-step work can
+  // keep flowing without making the user wait for the previous response.
+  const [queuedMessages, setQueuedMessages] = useState<string[]>([]);
+  const [modelPickerOpen, setModelPickerOpen] = useState(false);
+  const [resumableSessions, setResumableSessions] = useState<
+    SessionData[] | null
+  >(null);
+  // MCP manager (created once, shared across agents in this process). Null until
+  // the first agent is created so we don't spawn servers before login.
+  const mcpManagerRef = useRef<McpManager | null>(null);
+  const [mcpPickerOpen, setMcpPickerOpen] = useState(false);
+  // Project-scope MCP servers awaiting the user's approval at startup.
+  const [pendingMcpApproval, setPendingMcpApproval] = useState<string[] | null>(
+    null,
+  );
+  const [staticKey, setStaticKey] = useState(0);
+  const [tasks, setTasks] = useState("");
+  const [contextTokens, setContextTokens] = useState(0);
+  const [totalCost, setTotalCost] = useState(0);
+  const [approvalMode, setApprovalMode] = useState<ApprovalMode>(() =>
+    settings.autoApproveEdits && settings.autoApproveSafeCommands
+      ? "auto"
+      : settings.autoApproveEdits
+        ? "edits"
+        : "ask",
+  );
 
-	const [sessionTitle, setSessionTitle] = useState("")
-	const [usage, setUsage] = useState<{ plan?: string; usagePercentage?: number; tieredUsage?: import("../auth/auth.js").AxonCodeTieredUsage } | null>(null)
+  const [sessionTitle, setSessionTitle] = useState("");
+  const [usage, setUsage] = useState<{
+    plan?: string;
+    usagePercentage?: number;
+    tieredUsage?: import("../auth/auth.js").AxonCodeTieredUsage;
+  } | null>(null);
 
-	// Refresh plan/usage from /axoncode/profile (shown below the chat box).
-	const refreshUsage = useCallback(() => {
-		const token = getAuthToken(loadSettings())
-		if (!token) return
-		fetchProfile(token)
-			.then((profile) =>
-				setUsage({ plan: profile.plan, usagePercentage: profile.usagePercentage, tieredUsage: profile.tieredUsage }),
-			)
-			.catch(() => {})
-	}, [])
+  // Refresh plan/usage from /axoncode/profile (shown below the chat box).
+  const refreshUsage = useCallback(() => {
+    const token = getAuthToken(loadSettings());
+    if (!token) return;
+    fetchProfile(token)
+      .then((profile) =>
+        setUsage({
+          plan: profile.plan,
+          usagePercentage: profile.usagePercentage,
+          tieredUsage: profile.tieredUsage,
+        }),
+      )
+      .catch(() => {});
+  }, []);
 
-	const agentRef = useRef<Agent | null>(null)
-	const expandReasoningRef = useRef(false)
-	const reasoningBufferRef = useRef("")
-	const textBufferRef = useRef("")
-	// taskId for which a title fetch has already been started (once per task).
-	const titleTaskRef = useRef<string | null>(null)
-	// Mirror of `queuedMessages` for the agent event handler (kept on a ref so
-	// we can drain it inside `handleEvent` without re-creating that callback
-	// on every keystroke).
-	const queueRef = useRef<string[]>([])
-	// Holds the startup prompt while we wait for a project-hook trust decision.
-	const deferredPromptRef = useRef<string | null>(null)
-	// Guards endAndExit against double-invocation (Ctrl+D spam).
-	const exitingRef = useRef(false)
+  const agentRef = useRef<Agent | null>(null);
+  const expandReasoningRef = useRef(false);
+  const reasoningBufferRef = useRef("");
+  const textBufferRef = useRef("");
+  // taskId for which a title fetch has already been started (once per task).
+  const titleTaskRef = useRef<string | null>(null);
+  // Mirror of `queuedMessages` for the agent event handler (kept on a ref so
+  // we can drain it inside `handleEvent` without re-creating that callback
+  // on every keystroke).
+  const queueRef = useRef<string[]>([]);
+  // Holds the startup prompt while we wait for a project-hook trust decision.
+  const deferredPromptRef = useRef<string | null>(null);
+  // Guards endAndExit against double-invocation (Ctrl+D spam).
+  const exitingRef = useRef(false);
 
-	const enqueueMessage = useCallback((text: string) => {
-		queueRef.current = [...queueRef.current, text]
-		setQueuedMessages(queueRef.current)
-	}, [])
+  const enqueueMessage = useCallback((text: string) => {
+    queueRef.current = [...queueRef.current, text];
+    setQueuedMessages(queueRef.current);
+  }, []);
 
-	const drainQueue = useCallback((): string | null => {
-		if (queueRef.current.length === 0) return null
-		const [next, ...rest] = queueRef.current
-		queueRef.current = rest
-		setQueuedMessages(rest)
-		return next
-	}, [])
+  const drainQueue = useCallback((): string | null => {
+    if (queueRef.current.length === 0) return null;
+    const [next, ...rest] = queueRef.current;
+    queueRef.current = rest;
+    setQueuedMessages(rest);
+    return next;
+  }, []);
 
-	const clearQueue = useCallback(() => {
-		queueRef.current = []
-		setQueuedMessages([])
-	}, [])
+  const clearQueue = useCallback(() => {
+    queueRef.current = [];
+    setQueuedMessages([]);
+  }, []);
 
-	const maybeFetchTitle = useCallback(() => {
-		const agent = agentRef.current
-		if (!agent || titleTaskRef.current === agent.taskId) return
-		titleTaskRef.current = agent.taskId
-		const token = getAuthToken(loadSettings())
-		if (!token) return
-		void fetchTaskTitle(agent.taskId, token).then((title) => {
-			if (title && agentRef.current?.taskId === agent.taskId) {
-				setSessionTitle(title)
-				setTerminalTitle(title)
-				agent.setTitle(title)
-			}
-		})
-	}, [])
+  const maybeFetchTitle = useCallback(() => {
+    const agent = agentRef.current;
+    if (!agent || titleTaskRef.current === agent.taskId) return;
+    titleTaskRef.current = agent.taskId;
+    const token = getAuthToken(loadSettings());
+    if (!token) return;
+    void fetchTaskTitle(agent.taskId, token).then((title) => {
+      if (title && agentRef.current?.taskId === agent.taskId) {
+        setSessionTitle(title);
+        setTerminalTitle(title);
+        agent.setTitle(title);
+      }
+    });
+  }, []);
 
-	const pushRow = useCallback((row: DistributiveOmit<Row, "id">) => {
-		setRows((prev) => [...prev, { ...row, id: rowId() } as Row])
-	}, [])
+  const pushRow = useCallback((row: DistributiveOmit<Row, "id">) => {
+    setRows((prev) => [...prev, { ...row, id: rowId() } as Row]);
+  }, []);
 
-	// Wipe the visible transcript and remount <Static> with just the header —
-	// a clean slate for /clear, /new and /resume.
-	const resetTranscript = useCallback(() => {
-		if (process.stdout.isTTY) {
-			process.stdout.write("\x1b[2J\x1b[H")
-		}
-		setRows([
-			{ kind: "header", id: rowId(), cwd: process.cwd(), modelName: getModel(loadSettings().model).name },
-		])
-		setStaticKey((k) => k + 1)
-	}, [])
+  // Wipe the visible transcript and remount <Static> with just the header —
+  // a clean slate for /clear, /new and /resume.
+  const resetTranscript = useCallback(() => {
+    if (process.stdout.isTTY) {
+      process.stdout.write("\x1b[2J\x1b[H");
+    }
+    setRows([
+      {
+        kind: "header",
+        id: rowId(),
+        cwd: process.cwd(),
+        modelName: getModel(loadSettings().model).name,
+      },
+    ]);
+    setStaticKey((k) => k + 1);
+  }, []);
 
-	const handleEvent = useCallback(
-		(event: AgentEvent) => {
-			switch (event.type) {
-				case "reasoning-delta":
-					reasoningBufferRef.current += event.text
-					setStreamingReasoning(reasoningBufferRef.current)
-					setBusyLabel("Thinking")
-					break
-				case "reasoning-done":
-					pushRow({
-						kind: "reasoning",
-						text: reasoningBufferRef.current,
-						durationMs: event.durationMs,
-						expanded: expandReasoningRef.current,
-					})
-					reasoningBufferRef.current = ""
-					setStreamingReasoning("")
-					break
-				case "text-delta":
-					textBufferRef.current += event.text
-					setStreamingText(textBufferRef.current)
-					setBusyLabel("Responding")
-					break
-				case "text-done":
-					pushRow({ kind: "assistant", text: textBufferRef.current })
-					textBufferRef.current = ""
-					setStreamingText("")
-					break
-				case "tool-start":
-					setRunningTool({ id: event.id, name: event.name, summary: event.summary })
-					setBusyLabel(`Running ${event.name}`)
-					break
-				case "tool-end":
-					setRunningTool(null)
-					setBusyLabel("Thinking")
-					pushRow({
-						kind: "tool",
-						name: event.name,
-						summary: event.summary,
-						resultPreview: event.resultPreview,
-						isError: event.isError,
-						diff: event.diff,
-					})
-					break
-				case "todos":
-					setTasks(event.todos)
-					break
-				case "usage":
-					setContextTokens(event.inputTokens + event.outputTokens)
-					setTotalCost(event.totalCost)
-					// A usage chunk arrives once per LLM response, so the plan/usage
-					// shown below the chat box stays current mid-turn, not only
-					// after the turn finishes.
-					refreshUsage()
-					break
-				case "completion":
-					pushRow({ kind: "completion", text: event.result })
-					break
-				case "system":
-					pushRow({ kind: event.isError ? "error" : "info", text: event.message })
-					break
-				case "error":
-					pushRow({ kind: "error", text: event.message })
-					break
-				case "turn-end":
-					// Flush anything still streaming (e.g. on interrupt).
-					if (textBufferRef.current) {
-						pushRow({ kind: "assistant", text: textBufferRef.current })
-						textBufferRef.current = ""
-						setStreamingText("")
-					}
-					if (reasoningBufferRef.current) {
-						reasoningBufferRef.current = ""
-						setStreamingReasoning("")
-					}
-					setRunningTool(null)
-					setBusy(false)
-					maybeFetchTitle()
-					refreshUsage()
-					// Pop the next queued message and immediately start a new
-					// turn on top of the one that just ended. The agent's
-					// `runTurn` is fully resolved at this point (its
-					// `finally` emitted this event), so the new turn picks
-					// up the up-to-date conversation history. We use
-					// `agentRef` directly here to avoid a circular
-					// `handleEvent` ↔ `getAgent` reference; the ref is
-					// guaranteed populated because `runTurn` set it
-					// synchronously before emitting this event.
-					const nextQueued = drainQueue()
-					if (nextQueued !== null && agentRef.current) {
-						pushRow({ kind: "user", text: nextQueued })
-						setBusy(true)
-						setBusyLabel("Thinking")
-						void agentRef.current.runTurn(nextQueued)
-					}
-					break
-			}
-		},
-		[pushRow, maybeFetchTitle, refreshUsage, drainQueue],
-	)
+  const handleEvent = useCallback(
+    (event: AgentEvent) => {
+      switch (event.type) {
+        case "reasoning-delta":
+          reasoningBufferRef.current += event.text;
+          setStreamingReasoning(reasoningBufferRef.current);
+          setBusyLabel("Thinking");
+          break;
+        case "reasoning-done":
+          pushRow({
+            kind: "reasoning",
+            text: reasoningBufferRef.current,
+            durationMs: event.durationMs,
+            expanded: expandReasoningRef.current,
+          });
+          reasoningBufferRef.current = "";
+          setStreamingReasoning("");
+          break;
+        case "text-delta":
+          textBufferRef.current += event.text;
+          setStreamingText(textBufferRef.current);
+          setBusyLabel("Responding");
+          break;
+        case "text-done":
+          pushRow({ kind: "assistant", text: textBufferRef.current });
+          textBufferRef.current = "";
+          setStreamingText("");
+          break;
+        case "tool-start":
+          setRunningTool({
+            id: event.id,
+            name: event.name,
+            summary: event.summary,
+          });
+          setBusyLabel(`Running ${event.name}`);
+          break;
+        case "tool-end":
+          setRunningTool(null);
+          setBusyLabel("Thinking");
+          pushRow({
+            kind: "tool",
+            name: event.name,
+            summary: event.summary,
+            resultPreview: event.resultPreview,
+            isError: event.isError,
+            diff: event.diff,
+          });
+          break;
+        case "todos":
+          setTasks(event.todos);
+          break;
+        case "usage":
+          setContextTokens(event.inputTokens + event.outputTokens);
+          setTotalCost(event.totalCost);
+          // A usage chunk arrives once per LLM response, so the plan/usage
+          // shown below the chat box stays current mid-turn, not only
+          // after the turn finishes.
+          refreshUsage();
+          break;
+        case "completion":
+          pushRow({ kind: "completion", text: event.result });
+          break;
+        case "system":
+          pushRow({
+            kind: event.isError ? "error" : "info",
+            text: event.message,
+          });
+          break;
+        case "error":
+          pushRow({ kind: "error", text: event.message });
+          break;
+        case "turn-end":
+          // Flush anything still streaming (e.g. on interrupt).
+          if (textBufferRef.current) {
+            pushRow({ kind: "assistant", text: textBufferRef.current });
+            textBufferRef.current = "";
+            setStreamingText("");
+          }
+          if (reasoningBufferRef.current) {
+            reasoningBufferRef.current = "";
+            setStreamingReasoning("");
+          }
+          setRunningTool(null);
+          setBusy(false);
+          maybeFetchTitle();
+          refreshUsage();
+          // Pop the next queued message and immediately start a new
+          // turn on top of the one that just ended. The agent's
+          // `runTurn` is fully resolved at this point (its
+          // `finally` emitted this event), so the new turn picks
+          // up the up-to-date conversation history. We use
+          // `agentRef` directly here to avoid a circular
+          // `handleEvent` ↔ `getAgent` reference; the ref is
+          // guaranteed populated because `runTurn` set it
+          // synchronously before emitting this event.
+          const nextQueued = drainQueue();
+          if (nextQueued !== null && agentRef.current) {
+            pushRow({ kind: "user", text: nextQueued });
+            setBusy(true);
+            setBusyLabel("Thinking");
+            void agentRef.current.runTurn(nextQueued);
+          }
+          break;
+      }
+    },
+    [pushRow, maybeFetchTitle, refreshUsage, drainQueue],
+  );
 
-	const createAgent = useCallback(
-		(resume?: SessionData): Agent => {
-			const current = loadSettings()
-			// Create the MCP manager once per process and reuse it across agents
-			// (so /new and /resume keep the same server connections). It reads
-			// the enabled/disabled lists from settings and connects to approved
-			// servers lazily on start().
-			if (!mcpManagerRef.current) {
-				mcpManagerRef.current = new McpManager(
-					process.cwd(),
-					current.disabledMcpServers ?? [],
-					current.enabledMcpServers ?? [],
-				)
-			}
-			return new Agent({
-				cwd: process.cwd(),
-				token: getAuthToken(current)!,
-				modelId: current.model,
-				organizationId: current.organizationId,
-				baseUrl: current.baseUrl,
-				autoApproveEdits: current.autoApproveEdits,
-				autoApproveSafeCommands: current.autoApproveSafeCommands,
-				hooks: current.hooks,
-				mcp: mcpManagerRef.current,
-				resume,
-				callbacks: {
-					onEvent: handleEvent,
-					requestApproval: (request) =>
-						new Promise<ApprovalDecision>((resolve) => setPendingApproval({ request, resolve })),
-					requestFollowup: (question, suggestions) =>
-						new Promise<string>((resolve) => setPendingFollowup({ question, suggestions, resolve })),
-				},
-			})
-		},
-		[handleEvent],
-	)
+  const createAgent = useCallback(
+    (resume?: SessionData): Agent => {
+      const current = loadSettings();
+      // Create the MCP manager once per process and reuse it across agents
+      // (so /new and /resume keep the same server connections). It reads
+      // the enabled/disabled lists from settings and connects to approved
+      // servers lazily on start().
+      if (!mcpManagerRef.current) {
+        mcpManagerRef.current = new McpManager(
+          process.cwd(),
+          current.disabledMcpServers ?? [],
+          current.enabledMcpServers ?? [],
+        );
+      }
+      return new Agent({
+        cwd: process.cwd(),
+        token: getAuthToken(current)!,
+        modelId: current.model,
+        organizationId: current.organizationId,
+        baseUrl: current.baseUrl,
+        autoApproveEdits: current.autoApproveEdits,
+        autoApproveSafeCommands: current.autoApproveSafeCommands,
+        hooks: current.hooks,
+        mcp: mcpManagerRef.current,
+        resume,
+        callbacks: {
+          onEvent: handleEvent,
+          requestApproval: (request) =>
+            new Promise<ApprovalDecision>((resolve) =>
+              setPendingApproval({ request, resolve }),
+            ),
+          requestFollowup: (question, suggestions) =>
+            new Promise<string>((resolve) =>
+              setPendingFollowup({ question, suggestions, resolve }),
+            ),
+        },
+      });
+    },
+    [handleEvent],
+  );
 
-	const getAgent = useCallback((): Agent => {
-		if (!agentRef.current) {
-			agentRef.current = createAgent()
-		}
-		return agentRef.current
-	}, [createAgent])
+  const getAgent = useCallback((): Agent => {
+    if (!agentRef.current) {
+      agentRef.current = createAgent();
+    }
+    return agentRef.current;
+  }, [createAgent]);
 
-	const handleResume = useCallback(
-		(session: SessionData) => {
-			setResumableSessions(null)
-			agentRef.current = createAgent(session)
-			resetTranscript()
-			setTasks(session.todos ?? "")
-			setTotalCost(session.totalCost ?? 0)
-			// Repopulate the status bar immediately. Without this the context
-			// number only appears once the next streaming `usage` chunk arrives,
-			// which can be after several seconds of "ctx 0".
-			setContextTokens(session.contextTokens ?? 0)
-			if (session.title) {
-				// The stored title is already the backend one (or the prompt
-				// fallback); don't re-fetch for this task.
-				titleTaskRef.current = session.id
-				setSessionTitle(session.title)
-				setTerminalTitle(session.title)
-			}
-			// Replay the conversation into the transcript.
-			for (const message of session.messages) {
-				if (message.role === "user" && typeof message.content === "string") {
-					const match = /<user_query>\n?([\s\S]*?)\n?<\/user_query>/.exec(message.content)
-					if (match) pushRow({ kind: "user", text: match[1] })
-				} else if (message.role === "assistant" && typeof message.content === "string" && message.content.trim()) {
-					pushRow({ kind: "assistant", text: message.content })
-				}
-			}
-			pushRow({ kind: "info", text: `Resumed session: ${session.title || session.id}` })
-		},
-		[createAgent, pushRow, resetTranscript],
-	)
+  const handleResume = useCallback(
+    (session: SessionData) => {
+      setResumableSessions(null);
+      agentRef.current = createAgent(session);
+      resetTranscript();
+      setTasks(session.todos ?? "");
+      setTotalCost(session.totalCost ?? 0);
+      // Repopulate the status bar immediately. Without this the context
+      // number only appears once the next streaming `usage` chunk arrives,
+      // which can be after several seconds of "ctx 0".
+      setContextTokens(session.contextTokens ?? 0);
+      if (session.title) {
+        // The stored title is already the backend one (or the prompt
+        // fallback); don't re-fetch for this task.
+        titleTaskRef.current = session.id;
+        setSessionTitle(session.title);
+        setTerminalTitle(session.title);
+      }
+      // Replay the conversation into the transcript.
+      for (const message of session.messages) {
+        if (message.role === "user" && typeof message.content === "string") {
+          const match = /<user_query>\n?([\s\S]*?)\n?<\/user_query>/.exec(
+            message.content,
+          );
+          if (match) pushRow({ kind: "user", text: match[1] });
+        } else if (
+          message.role === "assistant" &&
+          typeof message.content === "string" &&
+          message.content.trim()
+        ) {
+          pushRow({ kind: "assistant", text: message.content });
+        }
+      }
+      pushRow({
+        kind: "info",
+        text: `Resumed session: ${session.title || session.id}`,
+      });
+    },
+    [createAgent, pushRow, resetTranscript],
+  );
 
-	const switchModel = useCallback(
-		(modelId: string) => {
-			const updated = { ...loadSettings(), model: modelId }
-			setSettings(updated)
-			saveSettings(updated)
-			agentRef.current?.setModel(modelId)
-			pushRow({ kind: "info", text: `Model switched to ${getModel(modelId).name}` })
-		},
-		[pushRow],
-	)
+  const switchModel = useCallback(
+    (modelId: string) => {
+      const updated = { ...loadSettings(), model: modelId };
+      setSettings(updated);
+      saveSettings(updated);
+      agentRef.current?.setModel(modelId);
+      pushRow({
+        kind: "info",
+        text: `Model switched to ${getModel(modelId).name}`,
+      });
+    },
+    [pushRow],
+  );
 
-	// Fire SessionEnd hooks (best-effort, capped at 3s) before quitting.
-	const endAndExit = useCallback(
-		(reason: string) => {
-			const agent = agentRef.current
-			if (!agent) {
-				// No agent yet, but the MCP manager may have started; tear it down.
-				void mcpManagerRef.current?.stop().catch(() => {})
-				exit()
-				return
-			}
-			// Guard against double-invocation (e.g. the user spamming Ctrl+D):
-			// the first call schedules the shutdown; subsequent calls are no-ops.
-			if (exitingRef.current) return
-			exitingRef.current = true
-			// Clear the cap timer when SessionEnd finishes first — Promise.race
-			// leaves the loser pending, and a ref'd setTimeout would otherwise
-			// keep the event loop alive (delaying the actual exit by up to 3s).
-			let capTimer: ReturnType<typeof setTimeout> | undefined
-			const cap = new Promise<void>((resolve) => {
-				capTimer = setTimeout(resolve, 3000)
-				capTimer.unref?.()
-			})
-			void Promise.race([agent.endSession(reason), cap]).finally(() => {
-				if (capTimer) clearTimeout(capTimer)
-				agent.abort()
-				exit()
-			})
-		},
-		[exit],
-	)
+  // Fire SessionEnd hooks (best-effort, capped at 3s) before quitting.
+  const endAndExit = useCallback(
+    (reason: string) => {
+      const agent = agentRef.current;
+      if (!agent) {
+        // No agent yet, but the MCP manager may have started; tear it down.
+        void mcpManagerRef.current?.stop().catch(() => {});
+        exit();
+        return;
+      }
+      // Guard against double-invocation (e.g. the user spamming Ctrl+D):
+      // the first call schedules the shutdown; subsequent calls are no-ops.
+      if (exitingRef.current) return;
+      exitingRef.current = true;
+      // Clear the cap timer when SessionEnd finishes first — Promise.race
+      // leaves the loser pending, and a ref'd setTimeout would otherwise
+      // keep the event loop alive (delaying the actual exit by up to 3s).
+      let capTimer: ReturnType<typeof setTimeout> | undefined;
+      const cap = new Promise<void>((resolve) => {
+        capTimer = setTimeout(resolve, 3000);
+        capTimer.unref?.();
+      });
+      void Promise.race([agent.endSession(reason), cap]).finally(() => {
+        if (capTimer) clearTimeout(capTimer);
+        agent.abort();
+        exit();
+      });
+    },
+    [exit],
+  );
 
-	const handleCommand = useCallback(
-		(command: string) => {
-			const [name, ...rest] = command.split(/\s+/)
-			const arg = rest.join(" ")
-			switch (name) {
-				case "/help":
-					pushRow({
-						kind: "info",
-						text: SLASH_COMMANDS.map((c) => `${c.name.padEnd(12)} ${c.description}`).join("\n"),
-					})
-					break
-				case "/model": {
-					// The interactive picker is restricted to Axon's own models for now.
-					// Third-party providers (Anthropic, OpenAI-compatible) are still
-					// usable headlessly via `orbcode -p "..." --model <id>` — see
-					// the README "Other providers" section.
-					const pickerIds = Object.keys(BUILTIN_AXON_MODELS)
-					if (arg && pickerIds.includes(arg)) {
-						switchModel(arg)
-					} else if (arg && isValidAxonModel(arg)) {
-						// Recognized id, but it's a third-party model: not selectable in the TUI.
-						pushRow({
-							kind: "info",
-							text: `Model "${arg}" is only available in non-interactive mode. Run: orbcode -p "..." --model ${arg}`,
-						})
-					} else if (arg) {
-						// Allow short suffixes like "pro" or "mini" to resolve to the
-						// latest matching registered id, so /model pro keeps working
-						// as new model generations are added.
-						const matches = pickerIds
-							.filter((id) => id.endsWith(`-${arg}`))
-							.sort()
-							.reverse()
-						if (matches.length > 0) {
-							switchModel(matches[0])
-						} else {
-							pushRow({ kind: "error", text: `Unknown model "${arg}". Available: ${pickerIds.join(", ")}` })
-						}
-					} else {
-						setModelPickerOpen(true)
-					}
-					break
-				}
-				case "/clear":
-					// Like the terminal's `clear`: wipe the view only. The
-					// conversation, session and context all continue.
-					resetTranscript()
-					break
-				case "/new":
-					// Drop the agent entirely so the next message starts a fresh session.
-					clearQueue()
-					agentRef.current = null
-					titleTaskRef.current = null
-					setSessionTitle("")
-					setTerminalTitle("orbcode")
-					setTasks("")
-					setContextTokens(0)
-					resetTranscript()
-					break
-				case "/analytics": {
-					const url = `${APP_URL}/orbital`
-					pushRow({ kind: "info", text: `Opening analytics: ${url}` })
-					void open(url).catch(() => {})
-					break
-				}
-				case "/resume": {
-					const sessions = listSessions(process.cwd()).filter((s) => s.id !== agentRef.current?.taskId)
-					if (sessions.length === 0) {
-						pushRow({ kind: "info", text: "No previous sessions found for this directory." })
-						break
-					}
-					setResumableSessions(sessions)
-					break
-				}
-				case "/compact":
-					if (!getAuthToken(settings)) {
-						setView("login")
-						break
-					}
-					setBusy(true)
-					setBusyLabel("Compacting")
-					void getAgent().compact()
-					break
-				case "/tasks":
-					pushRow({
-						kind: "info",
-						text: tasks.trim() ? `Tasks\n${tasks}` : "No tasks yet.",
-					})
-					break
-				case "/status": {
-					const model = getModel(settings.model)
-					const contextPct = Math.min(100, Math.round((contextTokens / model.contextWindow) * 100))
-					pushRow({
-						kind: "info",
-						text: [
-							`Version     ${VERSION}`,
-							`Model       ${model.name} (${model.id})`,
-							`Directory   ${process.cwd()}`,
-							`Account     ${getAuthToken(settings) ? (settings.apiKey || process.env.MATTERAI_TOKEN ? "API key" : "signed in") : "signed out"}${settings.organizationId ? ` · org ${settings.organizationId}` : ""}`,
-							`Gateway     ${settings.baseUrl ?? "MatterAI (default)"}`,
-							`Context     ${contextTokens.toLocaleString()} / ${model.contextWindow.toLocaleString()} tokens (${contextPct}%)`,
-							`Cost        $${totalCost.toFixed(4)} this session`,
-							`Approvals   edits ${settings.autoApproveEdits ? "auto" : "ask"} · safe commands ${settings.autoApproveSafeCommands ? "auto" : "ask"}`,
-							...(sessionTitle ? [`Task        ${sessionTitle}`] : []),
-						].join("\n"),
-					})
-					const statusToken = getAuthToken(settings)
-					if (statusToken) {
-						fetchProfile(statusToken)
-							.then((profile) => {
-								const lines = usageLines(profile)
-								if (lines.length > 0) pushRow({ kind: "info", text: lines.join("\n") })
-							})
-							.catch(() => {})
-					}
-					break
-				}
-				case "/init":
-					if (!getAuthToken(settings)) {
-						setView("login")
-						break
-					}
-					pushRow({ kind: "user", text: "/init" })
-					setBusy(true)
-					setBusyLabel("Thinking")
-					void getAgent().runTurn(INIT_PROMPT)
-					break
-				case "/mcp": {
-					const manager = mcpManagerRef.current
-					if (!manager) {
-						pushRow({ kind: "info", text: "MCP not initialized yet — send a message first." })
-						break
-					}
-					setMcpPickerOpen(true)
-					break
-				}
-				case "/commit":
-					if (!getAuthToken(settings)) {
-						setView("login")
-						break
-					}
-					pushRow({ kind: "user", text: command })
-					setBusy(true)
-					setBusyLabel("Thinking")
-					void getAgent().runTurn(buildCommitPrompt(arg))
-					break
-				case "/code-review":
-					if (!getAuthToken(settings)) {
-						setView("login")
-						break
-					}
-					pushRow({ kind: "user", text: command })
-					setBusy(true)
-					setBusyLabel("Reviewing")
-					void getAgent().runTurn(buildCodeReviewPrompt(arg))
-					break
-				case "/version":
-					pushRow({ kind: "info", text: `OrbCode CLI v${VERSION}` })
-					break
-				case "/cost": {
-					pushRow({ kind: "info", text: `Session cost: $${totalCost.toFixed(4)} (fetching balance…)` })
-					const token = getAuthToken(settings)
-					if (token) {
-						fetchBalance(token, settings.organizationId).then((balance) => {
-							if (balance !== undefined) {
-								pushRow({ kind: "info", text: `Account balance: $${balance.toFixed(2)}` })
-							}
-						})
-						fetchProfile(token)
-							.then((profile) => {
-								const lines = usageLines(profile)
-								if (lines.length > 0) pushRow({ kind: "info", text: lines.join("\n") })
-							})
-							.catch(() => {})
-					}
-					break
-				}
-				case "/login":
-					setView("login")
-					break
-				case "/logout": {
-					clearQueue()
-					void agentRef.current?.endSession("logout")
-					setPendingHookTrust(null)
-					deferredPromptRef.current = null
-					const updated = { ...settings, token: undefined }
-					setSettings(updated)
-					saveSettings(updated)
-					agentRef.current = null
-					setView("login")
-					break
-				}
-				case "/exit":
-					endAndExit("prompt_input_exit")
-					break
-				default:
-					pushRow({ kind: "error", text: `Unknown command: ${name}. Try /help.` })
-			}
-		},
-		[settings, tasks, contextTokens, totalCost, sessionTitle, endAndExit, pushRow, getAgent, switchModel, resetTranscript, clearQueue],
-	)
+  const handleCommand = useCallback(
+    (command: string) => {
+      const [name, ...rest] = command.split(/\s+/);
+      const arg = rest.join(" ");
+      switch (name) {
+        case "/help":
+          pushRow({
+            kind: "info",
+            text: SLASH_COMMANDS.map(
+              (c) => `${c.name.padEnd(12)} ${c.description}`,
+            ).join("\n"),
+          });
+          break;
+        case "/model": {
+          // The interactive picker is restricted to Axon's own models for now.
+          // Third-party providers (Anthropic, OpenAI-compatible) are still
+          // usable headlessly via `orbcode -p "..." --model <id>` — see
+          // the README "Other providers" section.
+          const pickerIds = Object.keys(BUILTIN_AXON_MODELS);
+          if (arg && pickerIds.includes(arg)) {
+            switchModel(arg);
+          } else if (arg && isValidAxonModel(arg)) {
+            // Recognized id, but it's a third-party model: not selectable in the TUI.
+            pushRow({
+              kind: "info",
+              text: `Model "${arg}" is only available in non-interactive mode. Run: orbcode -p "..." --model ${arg}`,
+            });
+          } else if (arg) {
+            // Allow short suffixes like "pro" or "mini" to resolve to the
+            // latest matching registered id, so /model pro keeps working
+            // as new model generations are added.
+            const matches = pickerIds
+              .filter((id) => id.endsWith(`-${arg}`))
+              .sort()
+              .reverse();
+            if (matches.length > 0) {
+              switchModel(matches[0]);
+            } else {
+              pushRow({
+                kind: "error",
+                text: `Unknown model "${arg}". Available: ${pickerIds.join(", ")}`,
+              });
+            }
+          } else {
+            setModelPickerOpen(true);
+          }
+          break;
+        }
+        case "/clear":
+          // Like the terminal's `clear`: wipe the view only. The
+          // conversation, session and context all continue.
+          resetTranscript();
+          break;
+        case "/new":
+          // Drop the agent entirely so the next message starts a fresh session.
+          clearQueue();
+          agentRef.current = null;
+          titleTaskRef.current = null;
+          setSessionTitle("");
+          setTerminalTitle("orbcode");
+          setTasks("");
+          setContextTokens(0);
+          resetTranscript();
+          break;
+        case "/analytics": {
+          const url = `${APP_URL}/orbital`;
+          pushRow({ kind: "info", text: `Opening analytics: ${url}` });
+          void open(url).catch(() => {});
+          break;
+        }
+        case "/resume": {
+          const sessions = listSessions(process.cwd()).filter(
+            (s) => s.id !== agentRef.current?.taskId,
+          );
+          if (sessions.length === 0) {
+            pushRow({
+              kind: "info",
+              text: "No previous sessions found for this directory.",
+            });
+            break;
+          }
+          setResumableSessions(sessions);
+          break;
+        }
+        case "/compact":
+          if (!getAuthToken(settings)) {
+            setView("login");
+            break;
+          }
+          setBusy(true);
+          setBusyLabel("Compacting");
+          void getAgent().compact();
+          break;
+        case "/tasks":
+          pushRow({
+            kind: "info",
+            text: tasks.trim() ? `Tasks\n${tasks}` : "No tasks yet.",
+          });
+          break;
+        case "/status": {
+          const model = getModel(settings.model);
+          const contextPct = Math.min(
+            100,
+            Math.round((contextTokens / model.contextWindow) * 100),
+          );
+          pushRow({
+            kind: "info",
+            text: [
+              `Version     ${VERSION}`,
+              `Model       ${model.name} (${model.id})`,
+              `Directory   ${process.cwd()}`,
+              `Account     ${getAuthToken(settings) ? (settings.apiKey || process.env.MATTERAI_TOKEN ? "API key" : "signed in") : "signed out"}${settings.organizationId ? ` · org ${settings.organizationId}` : ""}`,
+              `Gateway     ${settings.baseUrl ?? "MatterAI (default)"}`,
+              `Context     ${contextTokens.toLocaleString()} / ${model.contextWindow.toLocaleString()} tokens (${contextPct}%)`,
+              `Cost        $${totalCost.toFixed(4)} this session`,
+              `Approvals   edits ${settings.autoApproveEdits ? "auto" : "ask"} · safe commands ${settings.autoApproveSafeCommands ? "auto" : "ask"}`,
+              ...(sessionTitle ? [`Task        ${sessionTitle}`] : []),
+            ].join("\n"),
+          });
+          const statusToken = getAuthToken(settings);
+          if (statusToken) {
+            fetchProfile(statusToken)
+              .then((profile) => {
+                const lines = usageLines(profile);
+                if (lines.length > 0)
+                  pushRow({ kind: "info", text: lines.join("\n") });
+              })
+              .catch(() => {});
+          }
+          break;
+        }
+        case "/init":
+          if (!getAuthToken(settings)) {
+            setView("login");
+            break;
+          }
+          pushRow({ kind: "user", text: "/init" });
+          setBusy(true);
+          setBusyLabel("Thinking");
+          void getAgent().runTurn(INIT_PROMPT);
+          break;
+        case "/mcp": {
+          const manager = mcpManagerRef.current;
+          if (!manager) {
+            pushRow({
+              kind: "info",
+              text: "MCP not initialized yet — send a message first.",
+            });
+            break;
+          }
+          setMcpPickerOpen(true);
+          break;
+        }
+        case "/commit":
+          if (!getAuthToken(settings)) {
+            setView("login");
+            break;
+          }
+          pushRow({ kind: "user", text: command });
+          setBusy(true);
+          setBusyLabel("Thinking");
+          void getAgent().runTurn(buildCommitPrompt(arg));
+          break;
+        case "/code-review":
+          if (!getAuthToken(settings)) {
+            setView("login");
+            break;
+          }
+          pushRow({ kind: "user", text: command });
+          setBusy(true);
+          setBusyLabel("Reviewing");
+          void getAgent().runTurn(buildCodeReviewPrompt(arg));
+          break;
+        case "/version":
+          pushRow({ kind: "info", text: `OrbCode CLI v${VERSION}` });
+          break;
+        case "/usage": {
+          pushRow({ kind: "info", text: "Fetching plan usage…" });
+          const token = getAuthToken(settings);
+          if (token) {
+            fetchProfile(token)
+              .then((profile) => {
+                const lines = usageLines(profile);
+                if (lines.length > 0)
+                  pushRow({ kind: "info", text: lines.join("\n") });
+              })
+              .catch(() => {});
+          }
+          break;
+        }
+        case "/login":
+          setView("login");
+          break;
+        case "/logout": {
+          clearQueue();
+          void agentRef.current?.endSession("logout");
+          setPendingHookTrust(null);
+          deferredPromptRef.current = null;
+          const updated = { ...settings, token: undefined };
+          setSettings(updated);
+          saveSettings(updated);
+          agentRef.current = null;
+          setView("login");
+          break;
+        }
+        case "/exit":
+          endAndExit("prompt_input_exit");
+          break;
+        default:
+          pushRow({
+            kind: "error",
+            text: `Unknown command: ${name}. Try /help.`,
+          });
+      }
+    },
+    [
+      settings,
+      tasks,
+      contextTokens,
+      totalCost,
+      sessionTitle,
+      endAndExit,
+      pushRow,
+      getAgent,
+      switchModel,
+      resetTranscript,
+      clearQueue,
+    ],
+  );
 
-	const handleSubmit = useCallback(
-		(value: string) => {
-			if (value.startsWith("/")) {
-				handleCommand(value)
-				return
-			}
-			if (!getAuthToken(settings)) {
-				setView("login")
-				return
-			}
-			// While the LLM is still streaming, hold the message in a FIFO
-			// queue instead of dropping it on the floor. `handleEvent`'s
-			// `turn-end` case drains the queue and starts the next turn.
-			if (busy) {
-				enqueueMessage(value)
-				return
-			}
-			pushRow({ kind: "user", text: value })
-			setBusy(true)
-			setBusyLabel("Thinking")
-			void getAgent().runTurn(value)
-		},
-		[settings, busy, handleCommand, enqueueMessage, getAgent, pushRow],
-	)
+  const handleSubmit = useCallback(
+    (value: string) => {
+      if (value.startsWith("/")) {
+        handleCommand(value);
+        return;
+      }
+      if (!getAuthToken(settings)) {
+        setView("login");
+        return;
+      }
+      // While the LLM is still streaming, hold the message in a FIFO
+      // queue instead of dropping it on the floor. `handleEvent`'s
+      // `turn-end` case drains the queue and starts the next turn.
+      if (busy) {
+        enqueueMessage(value);
+        return;
+      }
+      pushRow({ kind: "user", text: value });
+      setBusy(true);
+      setBusyLabel("Thinking");
+      void getAgent().runTurn(value);
+    },
+    [settings, busy, handleCommand, enqueueMessage, getAgent, pushRow],
+  );
 
-	// Resolve the project-hook trust prompt: enable hooks for this workspace (and
-	// the live agent) on approval, then run any prompt we deferred while asking.
-	const resolveHookTrust = useCallback(
-		(trust: boolean) => {
-			setPendingHookTrust(null)
-			if (trust) {
-				trustProjectHooks(process.cwd())
-				const updated = loadSettings()
-				setSettings(updated)
-				agentRef.current?.setHooks(updated.hooks)
-				pushRow({ kind: "info", text: "Project hooks trusted — enabled for this workspace." })
-			} else {
-				pushRow({
-					kind: "info",
-					text: "Project hooks left disabled. Review .orbcode/settings.json and restart to re-decide.",
-				})
-			}
-			const deferred = deferredPromptRef.current
-			deferredPromptRef.current = null
-			if (deferred) handleSubmit(deferred)
-		},
-		[handleSubmit, pushRow],
-	)
+  // Resolve the project-hook trust prompt: enable hooks for this workspace (and
+  // the live agent) on approval, then run any prompt we deferred while asking.
+  const resolveHookTrust = useCallback(
+    (trust: boolean) => {
+      setPendingHookTrust(null);
+      if (trust) {
+        trustProjectHooks(process.cwd());
+        const updated = loadSettings();
+        setSettings(updated);
+        agentRef.current?.setHooks(updated.hooks);
+        pushRow({
+          kind: "info",
+          text: "Project hooks trusted — enabled for this workspace.",
+        });
+      } else {
+        pushRow({
+          kind: "info",
+          text: "Project hooks left disabled. Review .orbcode/settings.json and restart to re-decide.",
+        });
+      }
+      const deferred = deferredPromptRef.current;
+      deferredPromptRef.current = null;
+      if (deferred) handleSubmit(deferred);
+    },
+    [handleSubmit, pushRow],
+  );
 
-	// Resolve the MCP server approval prompt: connect to the approved project
-	// servers, persist the decision, and proceed with any deferred startup prompt.
-	const resolveMcpApproval = useCallback(
-		async (approved: string[]) => {
-			setPendingMcpApproval(null)
-			const manager = mcpManagerRef.current
-			if (manager) {
-				// Enable each approved server (connects immediately). Disapproved
-				// ones stay disabled and won't prompt again (persisted below).
-				await Promise.all(approved.map((name) => manager.enableServer(name).catch(() => {})))
-				saveMcpApproval(process.cwd(), manager.getEnabled(), manager.getDisabled())
-				const snap = manager.snapshot()
-				const connected = snap.servers.filter((s) => s.status === "connected").length
-				pushRow({
-					kind: "info",
-					text: `MCP: ${connected}/${snap.servers.length} server${snap.servers.length === 1 ? "" : "s"} connected${approved.length ? ` (approved: ${approved.join(", ")})` : ""}.`,
-				})
-			}
-			const deferred = deferredPromptRef.current
-			deferredPromptRef.current = null
-			if (deferred) handleSubmit(deferred)
-		},
-		[handleSubmit, pushRow],
-	)
+  // Resolve the MCP server approval prompt: connect to the approved project
+  // servers, persist the decision, and proceed with any deferred startup prompt.
+  const resolveMcpApproval = useCallback(
+    async (approved: string[]) => {
+      setPendingMcpApproval(null);
+      const manager = mcpManagerRef.current;
+      if (manager) {
+        // Enable each approved server (connects immediately). Disapproved
+        // ones stay disabled and won't prompt again (persisted below).
+        await Promise.all(
+          approved.map((name) => manager.enableServer(name).catch(() => {})),
+        );
+        saveMcpApproval(
+          process.cwd(),
+          manager.getEnabled(),
+          manager.getDisabled(),
+        );
+        const snap = manager.snapshot();
+        const connected = snap.servers.filter(
+          (s) => s.status === "connected",
+        ).length;
+        pushRow({
+          kind: "info",
+          text: `MCP: ${connected}/${snap.servers.length} server${snap.servers.length === 1 ? "" : "s"} connected${approved.length ? ` (approved: ${approved.join(", ")})` : ""}.`,
+        });
+      }
+      const deferred = deferredPromptRef.current;
+      deferredPromptRef.current = null;
+      if (deferred) handleSubmit(deferred);
+    },
+    [handleSubmit, pushRow],
+  );
 
-	// Apply --resume and an initial prompt (`orbcode "do something"`) on startup.
-	const bootedRef = useRef(false)
-	useEffect(() => {
-		if (bootedRef.current) return
-		bootedRef.current = true
-		if (initialSession) handleResume(initialSession)
-		// If this project ships untrusted hooks, ask before running anything; the
-		// startup prompt waits until the user decides.
-		const pending = getPendingProjectHooks(process.cwd())
-		if (pending) {
-			setPendingHookTrust(pending)
-			deferredPromptRef.current = initialPrompt ?? null
-		} else if (initialPrompt) {
-			handleSubmit(initialPrompt)
-		}
-		// Start the MCP manager and surface any project-scope servers that need
-		// approval. The approval prompt is non-blocking: the agent can start
-		// working while the user decides, and approved servers connect live.
-		const current = loadSettings()
-		if (getAuthToken(current)) {
-			const manager = new McpManager(
-				process.cwd(),
-				current.disabledMcpServers ?? [],
-				current.enabledMcpServers ?? [],
-			)
-			mcpManagerRef.current = manager
-			void manager.start().then(() => {
-				const pendingMcp = manager.getPendingApproval()
-				if (pendingMcp.length > 0) setPendingMcpApproval(pendingMcp)
-			})
-		}
-		refreshUsage()
-	}, [initialSession, initialPrompt, handleResume, handleSubmit, refreshUsage])
+  // Apply --resume and an initial prompt (`orbcode "do something"`) on startup.
+  const bootedRef = useRef(false);
+  useEffect(() => {
+    if (bootedRef.current) return;
+    bootedRef.current = true;
+    if (initialSession) handleResume(initialSession);
+    // If this project ships untrusted hooks, ask before running anything; the
+    // startup prompt waits until the user decides.
+    const pending = getPendingProjectHooks(process.cwd());
+    if (pending) {
+      setPendingHookTrust(pending);
+      deferredPromptRef.current = initialPrompt ?? null;
+    } else if (initialPrompt) {
+      handleSubmit(initialPrompt);
+    }
+    // Start the MCP manager and surface any project-scope servers that need
+    // approval. The approval prompt is non-blocking: the agent can start
+    // working while the user decides, and approved servers connect live.
+    const current = loadSettings();
+    if (getAuthToken(current)) {
+      const manager = new McpManager(
+        process.cwd(),
+        current.disabledMcpServers ?? [],
+        current.enabledMcpServers ?? [],
+      );
+      mcpManagerRef.current = manager;
+      void manager.start().then(() => {
+        const pendingMcp = manager.getPendingApproval();
+        if (pendingMcp.length > 0) setPendingMcpApproval(pendingMcp);
+      });
+    }
+    refreshUsage();
+  }, [initialSession, initialPrompt, handleResume, handleSubmit, refreshUsage]);
 
-	// Resolve the npm version check after first paint so the TUI shows up
-	// immediately and the upgrade banner fades in once we know the answer.
-	useEffect(() => {
-		if (!updateCheck) return
-		let cancelled = false
-		updateCheck.then((info) => {
-			if (!cancelled) setUpdateInfo(info)
-		})
-		return () => {
-			cancelled = true
-		}
-	}, [updateCheck])
+  // Resolve the npm version check after first paint so the TUI shows up
+  // immediately and the upgrade banner fades in once we know the answer.
+  useEffect(() => {
+    if (!updateCheck) return;
+    let cancelled = false;
+    updateCheck.then((info) => {
+      if (!cancelled) setUpdateInfo(info);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [updateCheck]);
 
-	useInput((input, key) => {
-		// Ctrl+D quits from any view (chat, login, busy, picker, approval,
-		// followup). InputBox swallows other Ctrl-combos, but this hook is a
-		// sibling of InputBox's hook, so it still sees the key.
-		if (key.ctrl && input === "d") {
-			endAndExit("prompt_input_exit")
-			return
-		}
-		if (key.escape && busy && !pendingApproval && !pendingFollowup) {
-			agentRef.current?.abort()
-		}
-		if (key.tab && key.shift) {
-			setApprovalMode((prev) => {
-				const next: ApprovalMode = prev === "ask" ? "edits" : prev === "edits" ? "auto" : "ask"
-				const autoApproveEdits = next !== "ask"
-				const autoApproveSafeCommands = next === "auto"
-				const updated = { ...loadSettings(), autoApproveEdits, autoApproveSafeCommands }
-				setSettings(updated)
-				saveSettings(updated)
-				agentRef.current?.setApprovalMode(autoApproveEdits, autoApproveSafeCommands)
-				return next
-			})
-		}
-		if (key.ctrl && input === "o") {
-			const expanded = !expandReasoningRef.current
-			expandReasoningRef.current = expanded
-			// Re-render the whole transcript (including past thinking) with the
-			// new expansion state: clear the screen and remount <Static>.
-			setRows((prev) => prev.map((row) => (row.kind === "reasoning" ? { ...row, expanded } : row)))
-			if (process.stdout.isTTY) {
-				process.stdout.write("\x1b[2J\x1b[H")
-			}
-			setStaticKey((k) => k + 1)
-		}
-	})
+  useInput((input, key) => {
+    // Ctrl+D quits from any view (chat, login, busy, picker, approval,
+    // followup). InputBox swallows other Ctrl-combos, but this hook is a
+    // sibling of InputBox's hook, so it still sees the key.
+    if (key.ctrl && input === "d") {
+      endAndExit("prompt_input_exit");
+      return;
+    }
+    if (key.escape && busy && !pendingApproval && !pendingFollowup) {
+      agentRef.current?.abort();
+    }
+    if (key.tab && key.shift) {
+      setApprovalMode((prev) => {
+        const next: ApprovalMode =
+          prev === "ask" ? "edits" : prev === "edits" ? "auto" : "ask";
+        const autoApproveEdits = next !== "ask";
+        const autoApproveSafeCommands = next === "auto";
+        const updated = {
+          ...loadSettings(),
+          autoApproveEdits,
+          autoApproveSafeCommands,
+        };
+        setSettings(updated);
+        saveSettings(updated);
+        agentRef.current?.setApprovalMode(
+          autoApproveEdits,
+          autoApproveSafeCommands,
+        );
+        return next;
+      });
+    }
+    if (key.ctrl && input === "o") {
+      const expanded = !expandReasoningRef.current;
+      expandReasoningRef.current = expanded;
+      // Re-render the whole transcript (including past thinking) with the
+      // new expansion state: clear the screen and remount <Static>.
+      setRows((prev) =>
+        prev.map((row) =>
+          row.kind === "reasoning" ? { ...row, expanded } : row,
+        ),
+      );
+      if (process.stdout.isTTY) {
+        process.stdout.write("\x1b[2J\x1b[H");
+      }
+      setStaticKey((k) => k + 1);
+    }
+  });
 
-	const handleLogin = useCallback(
-		(token: string, profile: ProfileData) => {
-			const updated = { ...loadSettings(), token }
-			setSettings(updated)
-			saveSettings(updated)
-			agentRef.current = null
-			setView("chat")
-			setUsage({ plan: profile.plan, usagePercentage: profile.usagePercentage, tieredUsage: profile.tieredUsage })
-			const who = profile.user?.name || profile.user?.email
-			pushRow({ kind: "info", text: `Signed in${who ? ` as ${who}` : ""}. Ready when you are.` })
-		},
-		[pushRow],
-	)
+  const handleLogin = useCallback(
+    (token: string, profile: ProfileData) => {
+      const updated = { ...loadSettings(), token };
+      setSettings(updated);
+      saveSettings(updated);
+      agentRef.current = null;
+      setView("chat");
+      setUsage({
+        plan: profile.plan,
+        usagePercentage: profile.usagePercentage,
+        tieredUsage: profile.tieredUsage,
+      });
+      const who = profile.user?.name || profile.user?.email;
+      pushRow({
+        kind: "info",
+        text: `Signed in${who ? ` as ${who}` : ""}. Ready when you are.`,
+      });
+    },
+    [pushRow],
+  );
 
-	const taskLines = useMemo(
-		() => tasks.split("\n").map((l) => l.trim()).filter(Boolean),
-		[tasks],
-	)
+  const taskLines = useMemo(
+    () =>
+      tasks
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean),
+    [tasks],
+  );
 
-	const inputActive =
-		view === "chat" &&
-		!pendingApproval &&
-		!pendingFollowup &&
-		!pendingHookTrust &&
-		!pendingMcpApproval &&
-		!modelPickerOpen &&
-		!mcpPickerOpen &&
-		!resumableSessions
+  const inputActive =
+    view === "chat" &&
+    !pendingApproval &&
+    !pendingFollowup &&
+    !pendingHookTrust &&
+    !pendingMcpApproval &&
+    !modelPickerOpen &&
+    !mcpPickerOpen &&
+    !resumableSessions;
 
-	return (
-		<Box flexDirection="column">
-			<Static key={staticKey} items={rows}>
-				{(row) => <RowView key={row.id} row={row} />}
-			</Static>
+  return (
+    <Box flexDirection="column">
+      <Static key={staticKey} items={rows}>
+        {(row) => <RowView key={row.id} row={row} />}
+      </Static>
 
-			{view === "login" ? (
-				<LoginSection onLogin={handleLogin} />
-			) : (
-				<Box flexDirection="column">
-					{updateInfo?.updateAvailable && updateInfo.latest && (
-						<Box
-							marginTop={1}
-							flexDirection="column"
-							borderStyle="round"
-							borderColor={COLORS.warning}
-							paddingX={2}
-							alignSelf="flex-start"
-						>
-							<Text color={COLORS.warning} bold>
-								↑ Update available: v{updateInfo.current} → v{updateInfo.latest}
-							</Text>
-							<Text>
-								Run <Text color={COLORS.accent}>orbcode update</Text> to install the latest version, then relaunch.
-							</Text>
-						</Box>
-					)}
-					{streamingReasoning && (
-						<Box flexDirection="column" marginTop={1}>
-							<Text color={COLORS.thinking} italic>
-								✦ Thinking…
-							</Text>
-							<Box paddingLeft={2}>
-								<Text dimColor italic>
-									{tail(streamingReasoning, expandReasoningRef.current ? 30 : 3)}
-								</Text>
-							</Box>
-						</Box>
-					)}
-					{streamingText && (
-						<Box marginTop={1}>
-							<Text>
-								<Text color={COLORS.primary}>● </Text>
-								{streamingText}
-							</Text>
-						</Box>
-					)}
-					{runningTool && (
-						<Box marginTop={1}>
-							<Text color={COLORS.warning}>
-								{formatToolName(runningTool.name)} <Text dimColor>{runningTool.summary}</Text>
-							</Text>
-						</Box>
-					)}
-					{taskLines.length > 0 && (
-						<Box flexDirection="column" marginTop={1} paddingLeft={1}>
-							<Text dimColor bold>
-								Tasks
-							</Text>
-							{taskLines.slice(0, 10).map((line, i) => (
-								<Text key={i} dimColor={/^[-*]\s*\[x\]/i.test(line)}>
-									{line
-										.replace(/^[-*]\s*\[x\]/i, "  ■")
-										.replace(/^[-*]\s*\[-\]/, "  ◧")
-										.replace(/^[-*]\s*\[ \]/, "  □")}
-								</Text>
-							))}
-							{taskLines.length > 10 && <Text dimColor> … {taskLines.length - 10} more</Text>}
-						</Box>
-					)}
-					{modelPickerOpen && (
-						<Box marginTop={1}>
-							<ModelPicker
-								currentId={settings.model}
-								onSelect={(modelId) => {
-									setModelPickerOpen(false)
-									switchModel(modelId)
-								}}
-								onCancel={() => setModelPickerOpen(false)}
-							/>
-						</Box>
-					)}
-					{resumableSessions && (
-						<Box marginTop={1}>
-							<SessionPicker
-								sessions={resumableSessions}
-								onSelect={handleResume}
-								onCancel={() => setResumableSessions(null)}
-							/>
-						</Box>
-					)}
-					{pendingHookTrust && (
-						<Box marginTop={1}>
-							<HookTrustPrompt
-								cwd={process.cwd()}
-								commands={pendingHookTrust.commands}
-								onDecision={resolveHookTrust}
-							/>
-						</Box>
-					)}
-					{pendingMcpApproval && (
-						<Box marginTop={1}>
-							<McpApprovalPrompt
-								serverNames={pendingMcpApproval}
-								onApprove={resolveMcpApproval}
-							/>
-						</Box>
-					)}
-					{mcpPickerOpen && mcpManagerRef.current && (
-						<Box marginTop={1}>
-							<McpPicker
-								manager={mcpManagerRef.current}
-								onChanged={() => {
-									const m = mcpManagerRef.current
-									if (m) saveMcpApproval(process.cwd(), m.getEnabled(), m.getDisabled())
-								}}
-								onCancel={() => setMcpPickerOpen(false)}
-							/>
-						</Box>
-					)}
-					{pendingApproval && (
-						<Box marginTop={1}>
-							<ApprovalPrompt
-								request={pendingApproval.request}
-								onDecision={(decision) => {
-									pendingApproval.resolve(decision)
-									setPendingApproval(null)
-								}}
-							/>
-						</Box>
-					)}
-					{pendingFollowup && (
-						<Box marginTop={1}>
-							<FollowupPrompt
-								question={pendingFollowup.question}
-								suggestions={pendingFollowup.suggestions}
-								onAnswer={(answer) => {
-									pushRow({ kind: "user", text: answer })
-									pendingFollowup.resolve(answer)
-									setPendingFollowup(null)
-								}}
-							/>
-						</Box>
-					)}
-					{busy && !pendingApproval && !pendingFollowup && !pendingHookTrust && !pendingMcpApproval && !mcpPickerOpen && !streamingText && (
-						<Box marginTop={1}>
-							<Spinner label={busyLabel} />
-						</Box>
-					)}
-					<Box marginTop={1} flexDirection="column">
-						{queuedMessages.length > 0 && (
-							<Box flexDirection="column" paddingLeft={1} marginBottom={1}>
-								<Text dimColor bold>
-									Queue ({queuedMessages.length})
-								</Text>
-								{queuedMessages.slice(0, 5).map((msg, i) => (
-									<Text key={i} dimColor>
-										{i + 1}. {truncateForQueue(msg).replace(/\n/g, "↵")}
-									</Text>
-								))}
-								{queuedMessages.length > 5 && (
-									<Text dimColor> … {queuedMessages.length - 5} more</Text>
-								)}
-							</Box>
-						)}
-						<InputBox active={inputActive} slashCommands={SLASH_COMMANDS} onSubmit={handleSubmit} />
-						<StatusBar
-							modelId={settings.model}
-							contextTokens={contextTokens}
-							totalCost={totalCost}
-							state={busy ? busyLabel : ""}
-							approvalMode={approvalMode}
-							busy={busy}
-							title={sessionTitle}
-							plan={usage?.plan}
-							usagePercentage={usage?.usagePercentage}
-							tieredUsage={usage?.tieredUsage}
-						/>
-					</Box>
-				</Box>
-			)}
-		</Box>
-	)
+      {view === "login" ? (
+        <LoginSection onLogin={handleLogin} />
+      ) : (
+        <Box flexDirection="column">
+          {updateInfo?.updateAvailable && updateInfo.latest && (
+            <Box
+              marginTop={1}
+              flexDirection="column"
+              borderStyle="round"
+              borderColor={COLORS.warning}
+              paddingX={2}
+              alignSelf="flex-start"
+            >
+              <Text color={COLORS.warning} bold>
+                ↑ Update available: v{updateInfo.current} → v{updateInfo.latest}
+              </Text>
+              <Text>
+                Run <Text color={COLORS.accent}>orbcode update</Text> to install
+                the latest version, then relaunch.
+              </Text>
+            </Box>
+          )}
+          {streamingReasoning && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text color={COLORS.thinking} italic>
+                ✦ Thinking…
+              </Text>
+              <Box paddingLeft={2}>
+                <Text dimColor italic>
+                  {tail(
+                    streamingReasoning,
+                    expandReasoningRef.current ? 30 : 3,
+                  )}
+                </Text>
+              </Box>
+            </Box>
+          )}
+          {streamingText && (
+            <Box marginTop={1}>
+              <Text>
+                <Text color={COLORS.primary}>● </Text>
+                {streamingText}
+              </Text>
+            </Box>
+          )}
+          {runningTool && (
+            <Box marginTop={1}>
+              <Text color={COLORS.warning}>
+                {formatToolName(runningTool.name)}{" "}
+                <Text dimColor>{runningTool.summary}</Text>
+              </Text>
+            </Box>
+          )}
+          {taskLines.length > 0 && (
+            <Box flexDirection="column" marginTop={1} paddingLeft={1}>
+              <Text dimColor bold>
+                Tasks
+              </Text>
+              {taskLines.slice(0, 10).map((line, i) => (
+                <Text key={i} dimColor={/^[-*]\s*\[x\]/i.test(line)}>
+                  {line
+                    .replace(/^[-*]\s*\[x\]/i, "  ■")
+                    .replace(/^[-*]\s*\[-\]/, "  ◧")
+                    .replace(/^[-*]\s*\[ \]/, "  □")}
+                </Text>
+              ))}
+              {taskLines.length > 10 && (
+                <Text dimColor> … {taskLines.length - 10} more</Text>
+              )}
+            </Box>
+          )}
+          {modelPickerOpen && (
+            <Box marginTop={1}>
+              <ModelPicker
+                currentId={settings.model}
+                onSelect={(modelId) => {
+                  setModelPickerOpen(false);
+                  switchModel(modelId);
+                }}
+                onCancel={() => setModelPickerOpen(false)}
+              />
+            </Box>
+          )}
+          {resumableSessions && (
+            <Box marginTop={1}>
+              <SessionPicker
+                sessions={resumableSessions}
+                onSelect={handleResume}
+                onCancel={() => setResumableSessions(null)}
+              />
+            </Box>
+          )}
+          {pendingHookTrust && (
+            <Box marginTop={1}>
+              <HookTrustPrompt
+                cwd={process.cwd()}
+                commands={pendingHookTrust.commands}
+                onDecision={resolveHookTrust}
+              />
+            </Box>
+          )}
+          {pendingMcpApproval && (
+            <Box marginTop={1}>
+              <McpApprovalPrompt
+                serverNames={pendingMcpApproval}
+                onApprove={resolveMcpApproval}
+              />
+            </Box>
+          )}
+          {mcpPickerOpen && mcpManagerRef.current && (
+            <Box marginTop={1}>
+              <McpPicker
+                manager={mcpManagerRef.current}
+                onChanged={() => {
+                  const m = mcpManagerRef.current;
+                  if (m)
+                    saveMcpApproval(
+                      process.cwd(),
+                      m.getEnabled(),
+                      m.getDisabled(),
+                    );
+                }}
+                onCancel={() => setMcpPickerOpen(false)}
+              />
+            </Box>
+          )}
+          {pendingApproval && (
+            <Box marginTop={1}>
+              <ApprovalPrompt
+                request={pendingApproval.request}
+                onDecision={(decision) => {
+                  pendingApproval.resolve(decision);
+                  setPendingApproval(null);
+                }}
+              />
+            </Box>
+          )}
+          {pendingFollowup && (
+            <Box marginTop={1}>
+              <FollowupPrompt
+                question={pendingFollowup.question}
+                suggestions={pendingFollowup.suggestions}
+                onAnswer={(answer) => {
+                  pushRow({ kind: "user", text: answer });
+                  pendingFollowup.resolve(answer);
+                  setPendingFollowup(null);
+                }}
+              />
+            </Box>
+          )}
+          {busy &&
+            !pendingApproval &&
+            !pendingFollowup &&
+            !pendingHookTrust &&
+            !pendingMcpApproval &&
+            !mcpPickerOpen &&
+            !streamingText && (
+              <Box marginTop={1}>
+                <Spinner label={busyLabel} />
+              </Box>
+            )}
+          <Box marginTop={1} flexDirection="column">
+            {queuedMessages.length > 0 && (
+              <Box flexDirection="column" paddingLeft={1} marginBottom={1}>
+                <Text dimColor bold>
+                  Queue ({queuedMessages.length})
+                </Text>
+                {queuedMessages.slice(0, 5).map((msg, i) => (
+                  <Text key={i} dimColor>
+                    {i + 1}. {truncateForQueue(msg).replace(/\n/g, "↵")}
+                  </Text>
+                ))}
+                {queuedMessages.length > 5 && (
+                  <Text dimColor> … {queuedMessages.length - 5} more</Text>
+                )}
+              </Box>
+            )}
+            <InputBox
+              active={inputActive}
+              slashCommands={SLASH_COMMANDS}
+              onSubmit={handleSubmit}
+            />
+            <StatusBar
+              modelId={settings.model}
+              contextTokens={contextTokens}
+              totalCost={totalCost}
+              state={busy ? busyLabel : ""}
+              approvalMode={approvalMode}
+              busy={busy}
+              title={sessionTitle}
+              plan={usage?.plan}
+              usagePercentage={usage?.usagePercentage}
+              tieredUsage={usage?.tieredUsage}
+            />
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
 }
 
 function tail(text: string, lines: number): string {
-	const all = text.split("\n").filter((l) => l.trim())
-	return all.slice(-lines).join("\n")
+  const all = text.split("\n").filter((l) => l.trim());
+  return all.slice(-lines).join("\n");
 }
 
-const QUEUE_PREVIEW_LIMIT = 80
+const QUEUE_PREVIEW_LIMIT = 80;
 function truncateForQueue(text: string): string {
-	if (text.length <= QUEUE_PREVIEW_LIMIT) return text
-	return text.slice(0, QUEUE_PREVIEW_LIMIT - 1) + "…"
+  if (text.length <= QUEUE_PREVIEW_LIMIT) return text;
+  return text.slice(0, QUEUE_PREVIEW_LIMIT - 1) + "…";
 }
 
-function LoginSection({ onLogin }: { onLogin: (token: string, profile: ProfileData) => void }) {
-	return <LoginView onLogin={onLogin} />
+function LoginSection({
+  onLogin,
+}: {
+  onLogin: (token: string, profile: ProfileData) => void;
+}) {
+  return <LoginView onLogin={onLogin} />;
 }

--- a/src/ui/components/McpApprovalPrompt.tsx
+++ b/src/ui/components/McpApprovalPrompt.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react"
+import { Box, Text, useInput } from "ink"
+
+import { COLORS } from "../../branding.js"
+
+const VISIBLE_ROWS = 8
+
+interface McpApprovalPromptProps {
+	/** Project-scope server names found in .mcp.json that need approval. */
+	serverNames: string[]
+	/** Called with the subset the user approved (may be empty). */
+	onApprove: (approved: string[]) => void
+}
+
+/**
+ * Shown at startup when the project's `.mcp.json` defines servers that haven't
+ * been approved yet. Project-scope servers ship in the repo and can spawn
+ * processes / open network connections, so they require explicit per-project
+ * approval — mirroring Claude Code's `.mcp.json` approval dialog.
+ *
+ * The user toggles servers with Space and confirms with Enter; Escape rejects
+ * all. Approved servers are persisted to `.orbcode/settings.json` so they
+ * auto-connect on future sessions in this project.
+ */
+export function McpApprovalPrompt({ serverNames, onApprove }: McpApprovalPromptProps) {
+	const [selected, setSelected] = useState(0)
+	const [checked, setChecked] = useState<Set<string>>(new Set(serverNames))
+
+	useInput((input, key) => {
+		if (key.upArrow) {
+			setSelected((s) => (s - 1 + serverNames.length) % serverNames.length)
+			return
+		}
+		if (key.downArrow || key.tab) {
+			setSelected((s) => (s + 1) % serverNames.length)
+			return
+		}
+		if (key.escape) {
+			onApprove([])
+			return
+		}
+		if (key.return) {
+			onApprove([...checked])
+			return
+		}
+		if (input === " ") {
+			const name = serverNames[selected]
+			if (!name) return
+			setChecked((prev) => {
+				const next = new Set(prev)
+				if (next.has(name)) next.delete(name)
+				else next.add(name)
+				return next
+			})
+		}
+	})
+
+	if (serverNames.length === 0) return null
+
+	const count = serverNames.length
+	const windowStart = Math.max(0, Math.min(selected - VISIBLE_ROWS + 1, count - VISIBLE_ROWS))
+	const visible = serverNames.slice(windowStart, windowStart + VISIBLE_ROWS)
+
+	return (
+		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.warning} paddingX={1}>
+			<Text bold color={COLORS.warning}>
+				{count} MCP server{count === 1 ? "" : "s"} found in .mcp.json
+			</Text>
+			<Text dimColor>Select any you wish to enable for this project.</Text>
+			{windowStart > 0 && <Text dimColor>  ↑ {windowStart} more</Text>}
+			{visible.map((name, i) => {
+				const index = windowStart + i
+				const isSelected = index === selected
+				const isChecked = checked.has(name)
+				return (
+					<Text key={name} color={isSelected ? COLORS.accent : undefined}>
+						{isSelected ? "❯ " : "  "}
+						{isChecked ? "☑" : "☐"} {name}
+					</Text>
+				)
+			})}
+			{windowStart + VISIBLE_ROWS < count && (
+				<Text dimColor>  ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
+			)}
+			<Text dimColor>space toggle · enter confirm · esc reject all</Text>
+		</Box>
+	)
+}

--- a/src/ui/components/McpAuthScreen.tsx
+++ b/src/ui/components/McpAuthScreen.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from "react"
+import { Box, Text, useInput } from "ink"
+
+import { COLORS } from "../../branding.js"
+import { copyToClipboard } from "../../utils/clipboard.js"
+
+interface McpAuthScreenProps {
+	/** The server name being authenticated. */
+	serverName: string
+	/** The authorization URL to display (may be empty until the flow captures it). */
+	authUrl: string
+	/** Called when the user provides an auth code (from paste). The callback
+	 *  server path resolves the same promise in the manager. */
+	onPasteCode: (code: string) => void
+	/** Called when the user presses Esc to abort. */
+	onCancel: () => void
+}
+
+/**
+ * Shown when the user triggers OAuth authentication for an MCP server. Mirrors
+ * Claude Code's auth screen:
+ *
+ *   - "Authenticating with <server>…"
+ *   - "A browser window will open for authentication"
+ *   - The authorization URL (with `c` to copy it)
+ *   - A paste fallback for when the browser redirect fails
+ *   - "Return here after authenticating. Press Esc to go back."
+ *
+ * The auth code can arrive two ways: the loopback callback server (automatic,
+ * handled by the manager) or a manual paste here. Both resolve the same
+ * promise, so whichever fires first wins.
+ */
+export function McpAuthScreen({ serverName, authUrl, onPasteCode, onCancel }: McpAuthScreenProps) {
+	const [pasted, setPasted] = useState("")
+	const [copied, setCopied] = useState(false)
+	const [mode, setMode] = useState<"waiting" | "paste">("waiting")
+
+	useInput((input, key) => {
+		if (key.escape) {
+			onCancel()
+			return
+		}
+		if (mode === "paste") {
+			if (key.return) {
+				if (pasted.trim()) onPasteCode(pasted.trim())
+				return
+			}
+			if (key.backspace || key.delete) {
+				setPasted((p) => p.slice(0, -1))
+				return
+			}
+			if (input && !key.ctrl && !key.meta) {
+				setPasted((p) => p + input)
+			}
+			return
+		}
+		// waiting mode
+		if (input.toLowerCase() === "c" && authUrl) {
+			const ok = copyToClipboard(authUrl)
+			setCopied(ok)
+			return
+		}
+		if (key.return) {
+			setMode("paste")
+		}
+	})
+
+	return (
+		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.warning} paddingX={1}>
+			<Text bold color={COLORS.warning}>
+				Authenticating with {serverName}…
+			</Text>
+			<Text> </Text>
+			<Text>
+				<Text color={COLORS.thinking}>✽ </Text>
+				<Text>A browser window will open for authentication</Text>
+			</Text>
+			<Text> </Text>
+			{authUrl ? (
+				<Box flexDirection="column">
+					<Text dimColor>
+						If your browser doesn't open automatically, copy this URL manually (c to copy)
+					</Text>
+					<Box paddingLeft={1} marginTop={0}>
+						<Text wrap="wrap" color={COLORS.accent}>
+							{authUrl}
+						</Text>
+					</Box>
+					{copied && <Text color={COLORS.success}>✓ Copied to clipboard</Text>}
+				</Box>
+			) : (
+				<Text dimColor>Waiting for the authorization URL…</Text>
+			)}
+			<Text> </Text>
+			{mode === "paste" ? (
+				<Box flexDirection="column">
+					<Text dimColor>If the redirect page shows a connection error, paste the URL from your browser's address bar:</Text>
+					<Text>
+						<Text dimColor>URL&gt; </Text>
+						{pasted}
+						<Text inverse> </Text>
+					</Text>
+					<Text dimColor>enter to submit · esc to go back</Text>
+				</Box>
+			) : (
+				<Text dimColor>
+					Press enter to paste a redirect URL manually · esc to go back
+				</Text>
+			)}
+			<Text> </Text>
+			<Text dimColor>Return here after authenticating in your browser. Press Esc to go back.</Text>
+		</Box>
+	)
+}

--- a/src/ui/components/McpPicker.tsx
+++ b/src/ui/components/McpPicker.tsx
@@ -1,0 +1,378 @@
+import React, { useRef, useState } from "react"
+import { Box, Text, useInput } from "ink"
+
+import { COLORS } from "../../branding.js"
+import type { AuthIntercept } from "../../mcp/auth.js"
+import type { McpManager } from "../../mcp/manager.js"
+import type { McpServerState } from "../../mcp/types.js"
+import { McpAuthScreen } from "./McpAuthScreen.js"
+
+const VISIBLE_ROWS = 8
+
+interface McpPickerProps {
+	manager: McpManager
+	onChanged: () => void
+	onCancel: () => void
+}
+
+function statusColor(state: McpServerState): string {
+	switch (state.status) {
+		case "connected":
+			return COLORS.success
+		case "connecting":
+			return COLORS.warning
+		case "failed":
+			return COLORS.error
+		case "needs-auth":
+			return COLORS.warning
+		case "disabled":
+			return COLORS.dim
+	}
+}
+
+function statusIcon(state: McpServerState): string {
+	switch (state.status) {
+		case "connected":
+			return "✓"
+		case "connecting":
+			return "⋯"
+		case "failed":
+			return "✗"
+		case "needs-auth":
+			return "△"
+		case "disabled":
+			return "○"
+	}
+}
+
+/** Build the action list for a server based on its current state. */
+function buildActions(state: McpServerState): string[] {
+	const actions: string[] = []
+	if (state.status === "needs-auth") actions.push("Authenticate")
+	if (state.disabled || state.status === "disabled") actions.push("Enable")
+	else actions.push("Disable")
+	actions.push("Reconnect")
+	return actions
+}
+
+/**
+ * Interactive MCP server manager, opened by the `/mcp` command.
+ *
+ * Two-level navigation (arrow keys + enter only, no shorthand keys):
+ *   - Server list: ↑/↓ to select a server, enter to open its action menu.
+ *   - Action menu: ↑/↓ to select an action, enter to execute, esc to go back.
+ *
+ * Actions adapt to the server's state: Authenticate (needs-auth), Enable
+ * (disabled), Disable (connected/failed), Reconnect (always).
+ */
+export function McpPicker({ manager, onChanged, onCancel }: McpPickerProps) {
+	const [snapshot, setSnapshot] = useState(() => manager.snapshot())
+	const [selected, setSelected] = useState(0)
+	const [busy, setBusy] = useState(false)
+	const [busyMessage, setBusyMessage] = useState("")
+	const [authingServer, setAuthingServer] = useState<string | null>(null)
+	const [authUrl, setAuthUrl] = useState("")
+	const [actionMode, setActionMode] = useState(false)
+	const [actionSelected, setActionSelected] = useState(0)
+	const codeResolveRef = useRef<((code: string) => void) | null>(null)
+	const codeRejectRef = useRef<((reason: Error) => void) | null>(null)
+
+	const servers = snapshot.servers
+	const count = servers.length
+	const current = servers[selected]
+	const actions = current ? buildActions(current) : []
+
+	useInput((_input, key) => {
+		if (authingServer || busy) return
+
+		if (actionMode) {
+			if (key.escape) {
+				setActionMode(false)
+				return
+			}
+			if (key.upArrow) {
+				setActionSelected((s) => (s - 1 + actions.length) % actions.length)
+				return
+			}
+			if (key.downArrow || key.tab) {
+				setActionSelected((s) => (s + 1) % actions.length)
+				return
+			}
+			if (key.return) {
+				void executeAction(actions[actionSelected])
+				return
+			}
+			return
+		}
+
+		// Server list navigation.
+		if (key.escape) {
+			onCancel()
+			return
+		}
+		if (key.upArrow) {
+			setSelected((s) => (s - 1 + count) % count)
+			return
+		}
+		if (key.downArrow || key.tab) {
+			setSelected((s) => (s + 1) % count)
+			return
+		}
+		if (key.return) {
+			setActionMode(true)
+			setActionSelected(0)
+			return
+		}
+	})
+
+	async function refresh(): Promise<void> {
+		setSnapshot(manager.snapshot())
+		onChanged()
+	}
+
+	async function executeAction(action: string | undefined): Promise<void> {
+		if (!action || !current) return
+		setActionMode(false)
+		if (action === "Authenticate") await reauthSelected()
+		else if (action === "Enable") await enableSelected()
+		else if (action === "Disable") await disableSelected()
+		else if (action === "Reconnect") await reconnectSelected()
+	}
+
+	async function enableSelected(): Promise<void> {
+		if (!current) return
+		setBusy(true)
+		setBusyMessage("Enabling…")
+		try {
+			await manager.enableServer(current.name)
+			await refresh()
+		} finally {
+			setBusy(false)
+			setBusyMessage("")
+		}
+	}
+
+	async function disableSelected(): Promise<void> {
+		if (!current) return
+		setBusy(true)
+		setBusyMessage("Disabling…")
+		try {
+			await manager.disableServer(current.name)
+			await refresh()
+		} finally {
+			setBusy(false)
+			setBusyMessage("")
+		}
+	}
+
+	async function reconnectSelected(): Promise<void> {
+		if (!current) return
+		setBusy(true)
+		setBusyMessage("Reconnecting…")
+		try {
+			await manager.disconnectOne(current.name)
+			await manager.connectOne(current.name)
+			await refresh()
+		} finally {
+			setBusy(false)
+			setBusyMessage("")
+		}
+	}
+
+	async function reauthSelected(): Promise<void> {
+		if (!current) return
+		const intercept: AuthIntercept = {
+			onAuthUrl: (url) => setAuthUrl(url),
+			getCode: () =>
+				new Promise<string>((resolve, reject) => {
+					codeResolveRef.current = resolve
+					codeRejectRef.current = reject
+				}),
+		}
+		setAuthingServer(current.name)
+		setAuthUrl("")
+		setBusy(true)
+		try {
+			await manager.reauthServer(current.name, intercept)
+			await refresh()
+		} catch {
+			// auth failed or cancelled; server stays needs-auth
+		} finally {
+			setAuthingServer(null)
+			setAuthUrl("")
+			codeResolveRef.current = null
+			codeRejectRef.current = null
+			setBusy(false)
+		}
+	}
+
+	function handlePasteCode(input: string): void {
+		try {
+			const url = new URL(input)
+			const code = url.searchParams.get("code")
+			if (code) {
+				codeResolveRef.current?.(code)
+				return
+			}
+		} catch {
+			// not a URL — treat as bare code
+		}
+		codeResolveRef.current?.(input)
+	}
+
+	function handleAuthCancel(): void {
+		codeRejectRef.current?.(new Error("Authentication cancelled."))
+	}
+
+	if (count === 0) {
+		return (
+			<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+				<Text bold color={COLORS.primary}>
+					MCP servers
+				</Text>
+				<Text dimColor>No MCP servers configured.</Text>
+				<Text dimColor>
+					Add servers with: orbcode mcp add &lt;name&gt; &lt;command&gt; [args...]
+				</Text>
+				<Text dimColor>esc to close</Text>
+			</Box>
+		)
+	}
+
+	if (authingServer) {
+		return (
+			<McpAuthScreen
+				serverName={authingServer}
+				authUrl={authUrl}
+				onPasteCode={handlePasteCode}
+				onCancel={handleAuthCancel}
+			/>
+		)
+	}
+
+	const windowStart = Math.max(0, Math.min(selected - VISIBLE_ROWS + 1, count - VISIBLE_ROWS))
+	const visible = servers.slice(windowStart, windowStart + VISIBLE_ROWS)
+
+	return (
+		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+			<Text bold color={COLORS.primary}>
+				Manage MCP servers ({count})
+			</Text>
+			{windowStart > 0 && <Text dimColor>  ↑ {windowStart} more</Text>}
+			{visible.map((state, i) => {
+				const index = windowStart + i
+				const isSelected = index === selected && !actionMode
+				return (
+					<Text key={state.name} color={isSelected ? COLORS.accent : undefined}>
+						{isSelected ? "❯ " : "  "}
+						{state.name}
+						{"  "}
+						<Text color={statusColor(state)}>
+							{statusIcon(state)} {state.status}
+						</Text>
+						{state.toolCount > 0 && <Text dimColor> · {state.toolCount} tools</Text>}
+					</Text>
+				)
+			})}
+			{windowStart + VISIBLE_ROWS < count && (
+				<Text dimColor>  ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
+			)}
+			{current && (
+				<DetailPanel
+					manager={manager}
+					state={current}
+					actions={actions}
+					actionMode={actionMode}
+					actionSelected={actionSelected}
+				/>
+			)}
+			<Text dimColor>
+				{busy
+					? busyMessage
+					: actionMode
+						? "↑/↓ select action · enter execute · esc back"
+						: "↑/↓ select server · enter open actions · esc close"}
+			</Text>
+		</Box>
+	)
+}
+
+function DetailPanel({
+	manager,
+	state,
+	actions,
+	actionMode,
+	actionSelected,
+}: {
+	manager: McpManager
+	state: McpServerState
+	actions: string[]
+	actionMode: boolean
+	actionSelected: number
+}) {
+	const cfg = manager.getConfig(state.name)
+	const configPath = manager.getConfigPath(state.name)
+	const isOAuth = manager.isOAuthServer(state.name)
+	const authenticated = manager.isAuthenticated(state.name)
+
+	const authText = !isOAuth
+		? "— (static / stdio)"
+		: authenticated
+			? "✓ authenticated"
+			: "✗ not authenticated"
+
+	let urlText: string
+	if (cfg && (cfg.type === "http" || cfg.type === "sse")) {
+		urlText = cfg.url
+	} else if (cfg) {
+		const cmd = cfg.command
+		const args = cfg.args ?? []
+		urlText = `stdio: ${cmd}${args.length ? " " + args.join(" ") : ""}`
+	} else {
+		urlText = ""
+	}
+
+	return (
+		<Box paddingLeft={1} marginTop={1} flexDirection="column">
+			<Text bold>
+				{state.name} MCP Server
+			</Text>
+			<Text>
+				<Text dimColor>Status:          </Text>
+				<Text color={statusColor(state)}>{statusIcon(state)} {state.status}</Text>
+			</Text>
+			<Text>
+				<Text dimColor>Auth:            </Text>
+				<Text color={isOAuth && !authenticated ? COLORS.error : isOAuth ? COLORS.success : COLORS.dim}>
+					{authText}
+				</Text>
+			</Text>
+			<Text>
+				<Text dimColor>URL:             </Text>
+				{urlText}
+			</Text>
+			{configPath && (
+				<Text>
+					<Text dimColor>Config location: </Text>
+					<Text dimColor>{configPath}</Text>
+				</Text>
+			)}
+			{state.detail && (
+				<Text color={state.status === "failed" ? COLORS.error : state.status === "needs-auth" ? COLORS.warning : COLORS.dim}>
+					{state.detail}
+				</Text>
+			)}
+			<Box marginTop={1} flexDirection="column">
+				{actions.map((action, i) => {
+					const isSelected = actionMode && i === actionSelected
+					return (
+						<Text key={action} color={isSelected ? COLORS.accent : undefined}>
+							{isSelected ? "❯ " : "  "}
+							{i + 1}. {action}
+						</Text>
+					)
+				})}
+			</Box>
+		</Box>
+	)
+}

--- a/src/ui/components/StatusBar.tsx
+++ b/src/ui/components/StatusBar.tsx
@@ -3,7 +3,10 @@ import { Box, Text } from "ink";
 
 import { COLORS } from "../../branding.js";
 import { getModel } from "../../api/models.js";
-import type { AxonCodeTieredUsage } from "../../auth/auth.js";
+import type {
+  AxonCodeTieredUsage,
+  AxonCodeWindowUsage,
+} from "../../auth/auth.js";
 
 export type ApprovalMode = "ask" | "edits" | "auto";
 
@@ -14,10 +17,10 @@ const MODE_LABELS: Record<ApprovalMode, string> = {
 };
 
 function formatRelativeTime(isoStr?: string): string {
-  if (!isoStr) return "???";
+  if (!isoStr) return "on session start";
   const now = Date.now();
   const target = new Date(isoStr).getTime();
-  if (Number.isNaN(target)) return "???";
+  if (Number.isNaN(target)) return "on session start";
   const diff = target - now;
   if (diff <= 0) return "now";
   const sec = Math.floor(diff / 1000);
@@ -48,13 +51,34 @@ function truncate(text: string, max: number): string {
 }
 
 /**
- * Formats the 5hr window as "5hr limit XX% · resets <relative>".
+ * Picks the usage window that currently constrains the agent and formats it as
+ * "<window> limit XX% · resets <relative>".
+ *
+ * The smallest window (5hr) is the one actively in use, so we show it by
+ * default. We only escalate to a larger window once it has hit its cap (100%):
+ * a capped larger window is the real blocker, since a smaller window resetting
+ * won't unblock you until the larger one does. When several are capped, the
+ * largest wins (it takes longest to recover).
  * Returns null when tiered usage is unavailable so the line can be hidden.
  */
-function fiveHourSummary(tu: AxonCodeTieredUsage | undefined): string | null {
-  if (!tu?.fiveHour) return null;
-  const { percentage, resetsAt } = tu.fiveHour;
-  return `5hr limit ${Math.round(percentage)}% · resets ${formatRelativeTime(resetsAt)}`;
+function usageSummary(tu: AxonCodeTieredUsage | undefined): string | null {
+  if (!tu) return null;
+  // Largest-to-smallest, so `find` returns the largest capped window and the
+  // last entry is the smallest available window.
+  const windows: Array<{ label: string; usage?: AxonCodeWindowUsage }> = [
+    { label: "monthly limit", usage: tu.monthly },
+    { label: "weekly limit", usage: tu.weekly },
+    { label: "5hr limit", usage: tu.fiveHour },
+  ];
+  const available = windows.filter(
+    (w): w is { label: string; usage: AxonCodeWindowUsage } => Boolean(w.usage),
+  );
+  if (available.length === 0) return null;
+  const binding =
+    available.find((w) => w.usage.percentage >= 100) ??
+    available[available.length - 1];
+  const { percentage, resetsAt } = binding.usage;
+  return `${binding.label} ${Math.round(percentage)}% · resets ${formatRelativeTime(resetsAt)}`;
 }
 
 export function StatusBar({
@@ -74,7 +98,7 @@ export function StatusBar({
     100,
     Math.round((contextTokens / model.contextWindow) * 100),
   );
-  const fiveHourLine = fiveHourSummary(tieredUsage);
+  const usageLine = usageSummary(tieredUsage);
   return (
     <Box flexDirection="column">
       <Box justifyContent="space-between">
@@ -91,9 +115,9 @@ export function StatusBar({
           {model.name} · ctx {contextTokens.toLocaleString()} ({contextPct}%)
         </Text>
       </Box>
-      {fiveHourLine && (
+      {usageLine && (
         <Box justifyContent="flex-end">
-          <Text dimColor>{fiveHourLine}</Text>
+          <Text dimColor>{usageLine}</Text>
         </Box>
       )}
     </Box>

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,41 @@
+import { execSync } from "node:child_process"
+import { platform } from "node:os"
+
+/**
+ * Copy text to the system clipboard. Uses the platform's native clipboard
+ * utility (pbcopy on macOS, xclip/xsel on Linux, clip on Windows). Returns
+ * true on success, false if no clipboard utility is available.
+ */
+export function copyToClipboard(text: string): boolean {
+	const cmd = clipboardCommand()
+	if (!cmd) return false
+	try {
+		execSync(cmd, { input: text, stdio: ["pipe", "ignore", "ignore"] })
+		return true
+	} catch {
+		return false
+	}
+}
+
+/** Detect the platform's clipboard command, or null if none is available. */
+function clipboardCommand(): string | null {
+	const p = platform()
+	if (p === "darwin") return "pbcopy"
+	if (p === "win32") return "clip"
+	// Linux: try xclip, then xsel. We can't check availability without spawning,
+	// so prefer xclip (more common on modern distros) and fall back to xsel.
+	if (p === "linux") {
+		try {
+			execSync("which xclip", { stdio: "ignore" })
+			return "xclip -selection clipboard"
+		} catch {
+			try {
+				execSync("which xsel", { stdio: "ignore" })
+				return "xsel --clipboard --input"
+			} catch {
+				return null
+			}
+		}
+	}
+	return null
+}


### PR DESCRIPTION
## release: v0.2.3

### Fixed
- **`orbcode mcp add` no longer swallows a `--` separator immediately after the server name.** `orbcode mcp add --scope user context7 -- npx -y @upstash/context7-mcp …` previously wrote `command: "--"`, so the server failed to spawn. A `--` directly after the server name is now consumed as the flag/command separator, matching Claude Code's `claude mcp add <name> -- <command>`. A later `--` is still passed through as a literal argument to the server command.

### Changed
- **`/cost` slash command renamed to `/usage`.** It now fetches and prints your plan usage from `/axoncode/profile` — the plan name (uppercased) and, for tiered accounts, the 5-hour / weekly / monthly windows with percentage used and reset time (or the credits reset date for non-tiered accounts) — instead of showing the session cost and fetching the account balance. Session cost remains in the status bar and `/status`. The usage block no longer prints the legacy `usagePercentage` and `remainingReviews` lines.

### Chore
- Remove stale `.orbital/AGENTS.md` reference; ignore per-developer `.orbcode/AGENTS.md` so local project memory isn't accidentally committed.

### Post-merge
After this PR is merged into `main`, push the tag to publish:

\`\`\`bash
git checkout main && git pull
git tag v0.2.3
git push origin v0.2.3
\`\`\`