### PR TITLE
release: v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.2.4] - 2026-06-22
+
+### Added
+
+- **`-s` / `--system-prompt` flag to override the default system prompt.**
+  Pass `orbcode -s "<text>"` (or `--system-prompt "<text>"`, or
+  `--system-prompt="<text>"` for values that start with `-`) to replace the
+  built-in system prompt entirely for the session. Works in both the
+  interactive TUI and headless mode (`-p`); passing `-p "..." -s "..."` runs a
+  single non-interactive turn under your custom prompt. When the override is
+  active, AGENTS.md memory files and the skills catalog are skipped, since
+  they live inside the default prompt — the model receives only your text as
+  its system message. Useful for code-review or other specialized personas.
+- **"Working" spinner with elapsed timer.** After the model finishes thinking
+  (or streaming a response), a `⠋ Working (Xs · esc to interrupt)` spinner now
+  appears and stays visible through tool execution and any gap before the next
+  LLM response — covering the previously dead-air window where long synchronous
+  operations (e.g. writing a large file) showed no feedback at all. The spinner
+  is hidden while the "Thinking" or response-streaming indicators are active so
+  the two never overlap.
+
+### Changed
+
+- The per-tool running indicator (tool name + summary line) has been removed in
+  favour of the single "Working" spinner. Tool results are still shown as rows
+  in the transcript once each tool completes.
+
 ## [0.2.3] - 2026-06-19
 
 ### Fixed
@@ -306,7 +335,7 @@ non-interactive mode.
 - Cross-platform shell detection and path handling in
   `execute_command` (Windows vs POSIX, `cmd` vs `bash`, etc.).
 
-[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.2.4...HEAD
 [0.2.3]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.2.3
 [0.2.0]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.2.0
 [0.1.14]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.1.14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -40,6 +40,13 @@ export interface AgentOptions {
 	hooks?: HooksConfig
 	/** MCP server manager (started externally; may be undefined when MCP is off). */
 	mcp?: McpManager
+	/**
+	 * Replace the default system prompt entirely. Set via `orbcode -s <text>`
+	 * / `--system-prompt <text>`. The user is responsible for preserving any
+	 * critical content (tool guide, environment info, etc.); the agent
+	 * receives only the override as its system message.
+	 */
+	systemPromptOverride?: string
 }
 
 interface PendingToolCall {
@@ -152,10 +159,13 @@ export class Agent {
 		this.mcp = options.mcp
 		// Build the system prompt with AGENTS.md memory files and the skills
 		// catalog injected, so the model sees project/user instructions and
-		// knows which skills it can invoke.
-		const memoryFiles = loadMemoryFiles(options.cwd)
-		const skills = loadSkills(options.cwd)
-		this.systemPrompt = buildSystemPrompt(options.cwd, { memoryFiles, skills })
+		// knows which skills it can invoke. An explicit override (from
+		// `orbcode -s <text>`) bypasses the default entirely.
+		const memoryFiles = options.systemPromptOverride ? [] : loadMemoryFiles(options.cwd)
+		const skills = options.systemPromptOverride ? new Map() : loadSkills(options.cwd)
+		this.systemPrompt = options.systemPromptOverride
+			? options.systemPromptOverride
+			: buildSystemPrompt(options.cwd, { memoryFiles, skills })
 		this.client = createLLMClient({
 			token: options.token,
 			modelId: options.modelId,
@@ -732,6 +742,9 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 			}
 		}
 
+		// Yield so the UI can paint the "Working" indicator before a
+		// potentially long synchronous tool call blocks the event loop.
+		await new Promise(resolve => setImmediate(resolve))
 		const result = await executeTool(toolCall.name, args, this.toolContext(), this.mcp)
 
 		// PostToolUse can feed extra context (or a block reason) back to the

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -5,7 +5,11 @@ import type { AgentEvent } from "./core/events.js"
 import { McpManager } from "./mcp/manager.js"
 
 /** Non-interactive `orbcode -p "prompt"` mode: prints the final response to stdout. */
-export async function runHeadless(prompt: string, yolo: boolean): Promise<void> {
+export async function runHeadless(
+	prompt: string,
+	yolo: boolean,
+	systemPromptOverride?: string,
+): Promise<void> {
 	const settings = loadSettings()
 
 	// An unknown --model (or MATTERAI_MODEL) silently resolves to the default; say
@@ -80,6 +84,7 @@ export async function runHeadless(prompt: string, yolo: boolean): Promise<void> 
 		autoApproveSafeCommands: yolo,
 		hooks: settings.hooks,
 		mcp,
+		systemPromptOverride,
 		callbacks: {
 			onEvent: (event: AgentEvent) => {
 				switch (event.type) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,6 +34,9 @@ Usage:
   orbcode -p "…" --yolo   non-interactive with auto-approved edits/commands
   orbcode --model <id>    use a specific model for this run
   orbcode --resume <id>   resume a previous session by id
+  orbcode -s "<prompt>"   override the default system prompt (replaces it entirely;
+                          accepts -s <text>, --system-prompt <text>, and
+                          --system-prompt=<text> for values that start with '-')
   orbcode --version       print version
   orbcode --help          show this help
 `)
@@ -88,6 +91,33 @@ function takeFlagValue(args: string[], name: string): string | undefined {
 	return value
 }
 
+/**
+ * Pop the `-s` / `--system-prompt` flag (and its value) out of `args`.
+ * Unlike `takeFlagValue` this accepts a value that starts with `-`, because
+ * a system-prompt override is free-form text. Supports three forms:
+ *   -s "<text>"             --value in next arg
+ *   --system-prompt "<text>"
+ *   --system-prompt="<text>"
+ *   --system-prompt=-<text>
+ */
+function takeSystemPrompt(args: string[]): string | undefined {
+	const longWithEq = args.findIndex((a) => a.startsWith("--system-prompt="))
+	if (longWithEq !== -1) {
+		const value = args[longWithEq].slice("--system-prompt=".length)
+		args.splice(longWithEq, 1)
+		return value.length > 0 ? value : undefined
+	}
+	const index = args.findIndex((a) => a === "-s" || a === "--system-prompt")
+	if (index === -1) return undefined
+	const value = args[index + 1]
+	if (value === undefined) {
+		console.error("Missing value after -s / --system-prompt")
+		process.exit(1)
+	}
+	args.splice(index, 2)
+	return value
+}
+
 async function main(): Promise<void> {
 	// Override Node's default process title so terminals (iTerm2 "current job
 	// name", VSCode terminal status, etc.) don't append " (node)" next to our
@@ -132,6 +162,11 @@ async function main(): Promise<void> {
 		}
 	}
 
+	// `-s` / `--system-prompt` lets the user replace the default prompt
+	// entirely. Accepts values starting with `-` (unlike other flags), so
+	// `orbcode -s '- you are a code reviewer'` works.
+	const systemPromptOverride = takeSystemPrompt(args)
+
 	const printIndex = args.findIndex((a) => a === "-p" || a === "--print")
 	if (printIndex !== -1) {
 		const prompt = args[printIndex + 1]
@@ -139,7 +174,7 @@ async function main(): Promise<void> {
 			console.error("Missing prompt after -p")
 			process.exit(1)
 		}
-		await runHeadless(prompt, args.includes("--yolo"))
+		await runHeadless(prompt, args.includes("--yolo"), systemPromptOverride)
 		return
 	}
 
@@ -161,6 +196,7 @@ async function main(): Promise<void> {
 			initialView={initialView}
 			initialPrompt={initialPrompt}
 			initialSession={initialSession}
+			systemPromptOverride={systemPromptOverride}
 			updateCheck={updateCheckPromise}
 		/>,
 	)

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -50,7 +50,7 @@ import { StatusBar, type ApprovalMode } from "./components/StatusBar.js";
 import { ModelPicker } from "./components/ModelPicker.js";
 import { SessionPicker } from "./components/SessionPicker.js";
 import { listSessions, type SessionData } from "../core/sessions.js";
-import { RowView, formatToolName, type Row } from "./components/rows.js";
+import { RowView, type Row } from "./components/rows.js";
 
 const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/help", description: "show available commands" },
@@ -207,12 +207,6 @@ interface PendingFollowup {
   resolve: (answer: string) => void;
 }
 
-interface RunningTool {
-  id: string;
-  name: string;
-  summary: string;
-}
-
 let rowCounter = 0;
 function rowId(): string {
   return `row-${rowCounter++}`;
@@ -226,11 +220,14 @@ export function App({
   initialView,
   initialPrompt,
   initialSession,
+  systemPromptOverride,
   updateCheck,
 }: {
   initialView?: "login" | "chat";
   initialPrompt?: string;
   initialSession?: SessionData;
+  /** Optional override replacing the default system prompt (from `-s`). */
+  systemPromptOverride?: string;
   /** Promise resolving to the latest-npm-version comparison; resolved after first paint. */
   updateCheck?: Promise<UpdateInfo>;
 }) {
@@ -255,7 +252,6 @@ export function App({
   const [busyLabel, setBusyLabel] = useState("Thinking");
   const [streamingReasoning, setStreamingReasoning] = useState("");
   const [streamingText, setStreamingText] = useState("");
-  const [runningTool, setRunningTool] = useState<RunningTool | null>(null);
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
   const [pendingFollowup, setPendingFollowup] =
@@ -329,6 +325,9 @@ export function App({
   const deferredPromptRef = useRef<string | null>(null);
   // Guards endAndExit against double-invocation (Ctrl+D spam).
   const exitingRef = useRef(false);
+  // Mirror of the `-s` override so a fresh agent (created mid-session via
+  // /new or /resume) keeps the override instead of falling back to default.
+  const systemPromptOverrideRef = useRef<string | undefined>(systemPromptOverride);
 
   const enqueueMessage = useCallback((text: string) => {
     queueRef.current = [...queueRef.current, text];
@@ -401,6 +400,7 @@ export function App({
           });
           reasoningBufferRef.current = "";
           setStreamingReasoning("");
+          setBusyLabel("Working");
           break;
         case "text-delta":
           textBufferRef.current += event.text;
@@ -411,18 +411,13 @@ export function App({
           pushRow({ kind: "assistant", text: textBufferRef.current });
           textBufferRef.current = "";
           setStreamingText("");
+          setBusyLabel("Working");
           break;
         case "tool-start":
-          setRunningTool({
-            id: event.id,
-            name: event.name,
-            summary: event.summary,
-          });
-          setBusyLabel(`Running ${event.name}`);
+          setBusyLabel("Working");
           break;
         case "tool-end":
-          setRunningTool(null);
-          setBusyLabel("Thinking");
+          setBusyLabel("Working");
           pushRow({
             kind: "tool",
             name: event.name,
@@ -466,7 +461,6 @@ export function App({
             reasoningBufferRef.current = "";
             setStreamingReasoning("");
           }
-          setRunningTool(null);
           setBusy(false);
           maybeFetchTitle();
           refreshUsage();
@@ -517,6 +511,9 @@ export function App({
         hooks: current.hooks,
         mcp: mcpManagerRef.current,
         resume,
+        // The override (from `-s`) is captured in a ref so a /new or /resume
+        // mid-session still applies it to the new agent.
+        systemPromptOverride: systemPromptOverrideRef.current,
         callbacks: {
           onEvent: handleEvent,
           requestApproval: (request) =>
@@ -1127,14 +1124,6 @@ export function App({
               </Text>
             </Box>
           )}
-          {runningTool && (
-            <Box marginTop={1}>
-              <Text color={COLORS.warning}>
-                {formatToolName(runningTool.name)}{" "}
-                <Text dimColor>{runningTool.summary}</Text>
-              </Text>
-            </Box>
-          )}
           {taskLines.length > 0 && (
             <Box flexDirection="column" marginTop={1} paddingLeft={1}>
               <Text dimColor bold>
@@ -1238,7 +1227,8 @@ export function App({
             !pendingHookTrust &&
             !pendingMcpApproval &&
             !mcpPickerOpen &&
-            !streamingText && (
+            !streamingText &&
+            !streamingReasoning && (
               <Box marginTop={1}>
                 <Spinner label={busyLabel} />
               </Box>


### PR DESCRIPTION
Cut the v0.2.4 release. Folds the new `-s` / `--system-prompt` flag into the 0.2.4 section of CHANGELOG.md alongside the 'Working' spinner (which was the original content of that section).

## What's in this release

### Added
- **`-s` / `--system-prompt` flag to override the default system prompt.** Pass `orbcode -s "<text>"` (or `--system-prompt "<text>"`, or `--system-prompt="<text>"` for values that start with `-`) to replace the built-in system prompt entirely for the session. Works in both the interactive TUI and headless mode (`-p`). When the override is active, AGENTS.md memory files and the skills catalog are skipped, since they live inside the default prompt.
- **'Working' spinner with elapsed timer.** A `⠋ Working (Xs · esc to interrupt)` spinner appears and stays visible through tool execution, covering the previously dead-air window.

## Files changed
- `src/core/agent.ts` — added `systemPromptOverride` to `AgentOptions`; constructor uses it instead of `buildSystemPrompt` when set.
- `src/headless.ts` — `runHeadless(prompt, yolo, systemPromptOverride?)` threads the override into the `Agent` constructor.
- `src/index.tsx` — added `takeSystemPrompt()` supporting the `=` form, parses the flag, passes it to `runHeadless` and the TUI `App`. Updated `printHelp`.
- `src/ui/App.tsx` — `App` accepts `systemPromptOverride`; `createAgent` reads it from a ref so regenerated agents keep the override.
- `CHANGELOG.md` — `-s` flag entry added to the existing 0.2.4 section.
- `package.json` — no version bump (already 0.2.4).

## Verification
- `npm run typecheck` → exit 0
- `npm run build` → exit 0

## After merge
Per `RELEASE.md`, after the PR is merged into `main`, push the v0.2.4 tag to trigger the publish workflow:
```
git checkout main && git pull
git tag v0.2.4
git push origin v0.2.4
```