### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-23
+
 ### Added
 
 - **MCP server migration from Claude Code / Claude Desktop.** A new
@@ -33,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   y/n confirmation before doing it. Unlike Disable, Delete is irreversible
   — the config entry is gone, and you'll need to re-add the server with
   `orbcode mcp add` to get it back.
+- **Styled OAuth callback page.** The local browser page that receives the
+  OAuth redirect now matches the matterai.so look (dark `#0d1117`
+  background, centered card, green/red circular icon, brand footer) for
+  success, error, and not-found paths, replacing the previous plain
+  `<h1>` strings.
 
 ## [0.2.4] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP server migration from Claude Code / Claude Desktop.** A new
+  `orbcode mcp migrate` subcommand (with `--all` and `--dry-run` flags) and
+  a `/migrate` slash command in the TUI scan well-known paths for MCP server
+  configs and copy them into `~/.orbcode/settings.json` (user scope). Sources
+  detected:
+  - `~/.claude/settings.json` (Claude Code, user scope)
+  - `~/.claude.json` → root `mcpServers` (Claude Code, user scope — the most
+    common location, written by `claude mcp add -s user …`)
+  - `~/.claude.json` → `projects.<cwd>.mcpServers` (Claude Code, this project)
+  - `claude_desktop_config.json` (Claude Desktop — platform-specific path)
+
+  When the same server name appears in both layers of `~/.claude.json`, the
+  root entry is shown and the project-layer duplicate is hidden (Claude's
+  own per-project override precedence). The TUI shows a combined checklist
+  across all sources; the CLI prints a preview by default and only writes
+  with `--all`. Servers whose name already exists in the destination are
+  silently skipped and counted in the summary. Codex support (TOML) is
+  intentionally deferred.
+
 ## [0.2.4] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with `--all`. Servers whose name already exists in the destination are
   silently skipped and counted in the summary. Codex support (TOML) is
   intentionally deferred.
+- **Delete action in the `/mcp` picker.** The interactive server manager
+  gained a "Delete" action (last in the list, red) that permanently removes
+  a server from its config file (whichever scope it lives in) and shows a
+  y/n confirmation before doing it. Unlike Disable, Delete is irreversible
+  — the config entry is gone, and you'll need to re-add the server with
+  `orbcode mcp add` to get it back.
 
 ## [0.2.4] - 2026-06-22
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -4,6 +4,14 @@ import {
 	loadMcpConfig,
 	removeMcpServerAnyScope,
 } from "../mcp/config.js"
+import {
+	applyMigration,
+	describeEntry,
+	discoverSources,
+	listMigrationEntries,
+	type MigrationEntry,
+} from "./migrate.js"
+import { loadSettings } from "../config/settings.js"
 import type { McpHttpServerConfig, McpScope, McpServerConfig, McpSseServerConfig, McpStdioServerConfig } from "../mcp/types.js"
 
 /**
@@ -18,6 +26,7 @@ import type { McpHttpServerConfig, McpScope, McpServerConfig, McpSseServerConfig
  *   orbcode mcp add --header KEY=value ... <name> <url>            http/sse headers
  *   orbcode mcp remove <name>                                      remove from any scope
  *   orbcode mcp list                                               list all servers
+ *   orbcode mcp migrate [--all] [--dry-run]                        import from Claude/Codex
  *
  * Flags:
  *   -s, --scope <user|project|local>   config scope (default: project)
@@ -48,6 +57,8 @@ Usage:
   orbcode mcp add [options] --transport sse <name> <url>   add an sse server
   orbcode mcp remove <name>                                remove a server
   orbcode mcp list                                         list all servers
+  orbcode mcp migrate [--all] [--dry-run]                  import MCP servers from
+                                                          Claude Code / Claude Desktop
 
 Options:
   -s, --scope <user|project|local>   config scope (default: project)
@@ -56,11 +67,34 @@ Options:
       --header KEY=value             HTTP header (repeatable, http/sse)
       --oauth                        enable OAuth for http/sse
       --oauth-scope <scope>          OAuth scope (implies --oauth)
+      --all                          (migrate) import every detected server
+      --dry-run                      (migrate) show what would be imported, don't write
 
 Scopes:
   project   .mcp.json in the current directory (shared, checked into git)
   user      ~/.orbcode/settings.json (applies to all projects on this machine)
-  local     .orbcode/settings.json (per-project, per-machine, not checked in)`)
+  local     .orbcode/settings.json (per-project, per-machine, not checked in)
+
+Migration sources:
+  orbcode mcp migrate scans these files and copies their mcpServers blocks
+  into ~/.orbcode/settings.json (user scope). Servers whose name already
+  exists in the destination are silently skipped.
+
+    Claude Code (user)         ~/.claude/settings.json
+    Claude Code (user, json)   ~/.claude.json -> root mcpServers
+                               (the most common location — this is where
+                               "claude mcp add -s user ..." writes)
+    Claude Code (this project) ~/.claude.json -> projects.<cwd>.mcpServers
+    Claude Desktop             ~/Library/Application Support/Claude/claude_desktop_config.json
+                               (macOS)  %APPDATA%\\Claude\\claude_desktop_config.json
+                               (Linux)  $XDG_CONFIG_HOME/Claude/claude_desktop_config.json
+
+  When the same name appears in both layers of ~/.claude.json, the
+  project-layer entry is treated as a per-project override (Claude's own
+  precedence) and is hidden from the picker — you'll only see the root
+  version, which is the one that applies across projects.
+
+  Use the /migrate slash command in the TUI for an interactive picker.`)
 }
 
 /** Handle `orbcode mcp ...`. Returns the process exit code. */
@@ -76,6 +110,9 @@ export async function runMcpCommand(args: string[]): Promise<number> {
 		case "list":
 		case "ls":
 			return runList(rest)
+		case "migrate":
+		case "import":
+			return runMigrate(rest)
 		case "help":
 		case "--help":
 		case "-h":
@@ -271,4 +308,130 @@ function runList(_args: string[]): number {
 		console.log(`  ${name.padEnd(20)} ${scope.padEnd(8)} ${detail}`)
 	}
 	return 0
+}
+
+/** `orbcode mcp migrate [--all] [--dry-run]` — copy MCP servers from Claude
+ *  Code / Claude Desktop into `~/.orbcode/settings.json` (user scope).
+ *  Without `--all`, prints a preview and exits 0. `--dry-run` is a read-only
+ *  preview even with `--all`. Name conflicts are silently skipped. */
+function runMigrate(args: string[]): number {
+	let migrateAll = false
+	let dryRun = false
+	for (const arg of args) {
+		if (arg === "--all" || arg === "-a") migrateAll = true
+		else if (arg === "--dry-run" || arg === "-n") dryRun = true
+		else if (arg === "--help" || arg === "-h") {
+			console.log("orbcode mcp migrate [--all] [--dry-run]\n")
+			console.log("Import MCP servers from Claude Code / Claude Desktop into")
+			console.log("~/.orbcode/settings.json (user scope).")
+			console.log("")
+			console.log("  --all, -a      import every detected server (default: preview only)")
+			console.log("  --dry-run, -n  show what would be imported, never write")
+			return 0
+		} else {
+			console.error(`Unknown flag: ${arg}. Try: orbcode mcp migrate --help`)
+			return 1
+		}
+	}
+
+	const sources = discoverSources()
+	if (sources.length === 0) {
+		console.log("No MCP server sources found on this machine.")
+		console.log("")
+		console.log("Searched:")
+		console.log("  - ~/.claude/settings.json          (Claude Code, user scope)")
+		console.log("  - ~/.claude.json -> root mcpServers (Claude Code, user scope)")
+		console.log("  - ~/.claude.json -> projects.<cwd>.mcpServers (Claude Code, this project)")
+		console.log("  - Claude Desktop config            (claude_desktop_config.json)")
+		return 0
+	}
+
+	const entries = listMigrationEntries()
+	if (entries.length === 0) {
+		console.log("Found MCP server source files, but none contain server entries.")
+		return 0
+	}
+
+	// Always show what we found, so the user knows where the data is coming from.
+	console.log("Detected MCP server sources:")
+	for (const source of sources) {
+		const count = Object.keys(source.servers).length
+		console.log(`  ${source.label.padEnd(28)} ${count} server${count === 1 ? "" : "s"}`)
+		console.log(`    ${source.configPath}`)
+	}
+	console.log("")
+
+	// If `--all` was passed, copy everything. Otherwise preview and exit.
+	const toApply = migrateAll ? entries : []
+
+	// Always classify skipped (name conflicts) so the user sees the dry-run
+	// impact, not just the would-be additions.
+	const { skipped } = applyMigrationDryRun(entries)
+
+	if (!migrateAll) {
+		console.log("Preview — no files modified. Pass --all to apply.")
+		console.log("")
+		console.log("Servers that would be imported:")
+		for (const entry of entries) {
+			const conflict = skipped.some((s) => s.entry.key === entry.key)
+			const tag = conflict ? "skip" : "add "
+			console.log(`  [${tag}] ${entry.name.padEnd(24)} ${describeEntry(entry)}`)
+			console.log(`          ${entry.sourceLabel}`)
+		}
+		console.log("")
+		console.log(`Would add:    ${entries.length - skipped.length}`)
+		console.log(`Would skip:   ${skipped.length} (already exists in destination)`)
+		return 0
+	}
+
+	// migrateAll path. If also --dry-run, don't write.
+	if (dryRun) {
+		console.log("Dry run — no files modified.")
+		console.log("")
+		console.log("Servers that would be imported:")
+		for (const entry of toApply) {
+			const conflict = skipped.some((s) => s.entry.key === entry.key)
+			const tag = conflict ? "skip" : "add "
+			console.log(`  [${tag}] ${entry.name.padEnd(24)} ${describeEntry(entry)}`)
+			console.log(`          ${entry.sourceLabel}`)
+		}
+		console.log("")
+		console.log(`Would add:    ${toApply.length - skipped.length}`)
+		console.log(`Would skip:   ${skipped.length} (already exists in destination)`)
+		return 0
+	}
+
+	const result = applyMigration(toApply)
+	console.log(`Added ${result.added.length} MCP server${result.added.length === 1 ? "" : "s"} to ~/.orbcode/settings.json`)
+	for (const entry of result.added) {
+		console.log(`  + ${entry.name.padEnd(24)} ${describeEntry(entry)}`)
+	}
+	if (result.skipped.length > 0) {
+		console.log(`Skipped ${result.skipped.length} (already exists):`)
+		for (const { entry, reason } of result.skipped) {
+			console.log(`  - ${entry.name.padEnd(24)} ${reason}`)
+		}
+	}
+	return 0
+}
+
+/** Pure classification pass that mirrors `applyMigration` but never writes.
+ *  Used by `--dry-run` and the default preview to surface the skipped count
+ *  without touching the file. */
+function applyMigrationDryRun(entries: MigrationEntry[]): {
+	added: string[]
+	skipped: { entry: MigrationEntry; reason: string }[]
+} {
+	const settings = loadSettings()
+	const existing = settings.mcpServers ?? {}
+	const added: string[] = []
+	const skipped: { entry: MigrationEntry; reason: string }[] = []
+	for (const entry of entries) {
+		if (entry.name in existing) {
+			skipped.push({ entry, reason: "already exists in ~/.orbcode/settings.json" })
+		} else {
+			added.push(entry.key)
+		}
+	}
+	return { added, skipped }
 }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,396 @@
+/**
+ * Migrate MCP server configurations from other CLI tools into OrbCode's
+ * `~/.orbcode/settings.json` (user scope, `mcpServers` block).
+ *
+ * Detected sources:
+ *   - Claude Code user-scope:   `~/.claude/settings.json` -> mcpServers
+ *   - Claude Code (user, top of ~/.claude.json): same file, root `mcpServers`.
+ *     Claude stores the user-scope servers here, at the file root, not under
+ *     a per-project key. This is the most common location on a fresh install
+ *     — `claude mcp add -s user …` writes to it.
+ *   - Claude Code per-project:  `~/.claude.json` -> projects.<cwd>.mcpServers
+ *     (and a fallback to the first project entry that has any servers, for
+ *     mismatched cwd paths).
+ *   - Claude Desktop:           `claude_desktop_config.json` (platform path)
+ *
+ * Both the TUI (`/migrate`) and the CLI (`orbcode mcp migrate`) call into this
+ * module. The TUI lets the user pick a subset; the CLI either does a dry-run
+ * preview or copies everything that doesn't conflict.
+ *
+ * Conflict policy: if a server with the same name already exists in the
+ * destination, the incoming entry is silently dropped. The summary at the
+ * end reports the skipped count.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { getConfigDir, loadSettings } from "../config/settings.js";
+import type {
+  McpHttpServerConfig,
+  McpServerConfig,
+  McpSseServerConfig,
+  McpStdioServerConfig,
+} from "../mcp/types.js";
+
+export type MigrationSourceId =
+	| "claude-code-user"
+	| "claude-code-json-user"
+	| "claude-code-project"
+	| "claude-desktop";
+
+export interface MigrationSource {
+  id: MigrationSourceId;
+  /** Human-readable label for the picker. */
+  label: string;
+  /** Absolute path to the config file we read. */
+  configPath: string;
+  /** Servers found at that path, in the order they appear in the file. */
+  servers: Record<string, McpServerConfig>;
+}
+
+export interface MigrationEntry {
+  /** Stable key for checkbox state and the result summary. */
+  key: string;
+  source: MigrationSourceId;
+  sourceLabel: string;
+  name: string;
+  config: McpServerConfig;
+}
+
+export interface MigrationResult {
+  added: MigrationEntry[];
+  skipped: { entry: MigrationEntry; reason: string }[];
+}
+
+/** A safe label for the picker (one per source). */
+function sourceLabel(id: MigrationSourceId): string {
+	switch (id) {
+		case "claude-code-user":
+			return "Claude Code (user)"
+		case "claude-code-json-user":
+			return "Claude Code (user, ~/.claude.json)"
+		case "claude-code-project":
+			return "Claude Code (this project)"
+		case "claude-desktop":
+			return "Claude Desktop"
+	}
+}
+
+/** Cross-platform location of Claude Desktop's MCP config file. */
+function claudeDesktopConfigPath(): string {
+  const home = os.homedir();
+  if (process.platform === "darwin") {
+    return path.join(
+      home,
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude_desktop_config.json",
+    );
+  }
+  if (process.platform === "win32") {
+    const appData =
+      process.env.APPDATA || path.join(home, "AppData", "Roaming");
+    return path.join(appData, "Claude", "claude_desktop_config.json");
+  }
+  // Linux/WSL — best-effort XDG location; Claude Desktop doesn't have an
+  // official Linux build, but some forks (e.g. open-source wrappers) use it.
+  const xdg = process.env.XDG_CONFIG_HOME || path.join(home, ".config");
+  return path.join(xdg, "Claude", "claude_desktop_config.json");
+}
+
+function readJson(filePath: string): Record<string, unknown> | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return undefined;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalize a single MCP server config from an external source. We do not run
+ * the full `normalizeServerConfig` from `mcp/config.ts` because it has side
+ * effects (env expansion) and Claude's shape is already a subset of ours.
+ * Only stdio / http / sse entries with the required fields survive.
+ */
+function normalizeExternalServer(raw: unknown): McpServerConfig | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  const type = typeof raw.type === "string" ? raw.type : "stdio";
+
+  if (type === "stdio") {
+    if (typeof raw.command !== "string" || !raw.command.trim())
+      return undefined;
+    const config: McpStdioServerConfig = {
+      type: "stdio",
+      command: raw.command,
+    };
+    if (Array.isArray(raw.args)) {
+      const args = raw.args.filter((a): a is string => typeof a === "string");
+      if (args.length > 0) config.args = args;
+    }
+    if (isPlainObject(raw.env)) {
+      const env: Record<string, string> = {};
+      for (const [k, v] of Object.entries(raw.env)) {
+        if (typeof v === "string") env[k] = v;
+      }
+      if (Object.keys(env).length > 0) config.env = env;
+    }
+    return config;
+  }
+
+  if (type === "http" || type === "sse") {
+    if (typeof raw.url !== "string" || !raw.url.trim()) return undefined;
+    const config: McpHttpServerConfig | McpSseServerConfig = {
+      type,
+      url: raw.url,
+    };
+    if (isPlainObject(raw.headers)) {
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries(raw.headers)) {
+        if (typeof v === "string") headers[k] = v;
+      }
+      if (Object.keys(headers).length > 0) config.headers = headers;
+    }
+    return config;
+  }
+
+  // `streamable-http` is Claude Code's preferred name for the modern HTTP
+  // transport; OrbCode aliases it as "http".
+  if (type === "streamable-http" || type === "streamable_http") {
+    if (typeof raw.url !== "string" || !raw.url.trim()) return undefined;
+    const config: McpHttpServerConfig = { type: "http", url: raw.url };
+    if (isPlainObject(raw.headers)) {
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries(raw.headers)) {
+        if (typeof v === "string") headers[k] = v;
+      }
+      if (Object.keys(headers).length > 0) config.headers = headers;
+    }
+    return config;
+  }
+
+  return undefined;
+}
+
+/** Read a `mcpServers` block, skipping any entry that fails to normalize. */
+function readMcpServers(filePath: string): Record<string, McpServerConfig> {
+  const json = readJson(filePath);
+  if (!json) return {};
+  const block = json.mcpServers;
+  if (!isPlainObject(block)) return {};
+  const out: Record<string, McpServerConfig> = {};
+  for (const [name, raw] of Object.entries(block)) {
+    if (!/^[A-Za-z0-9_-]+$/.test(name)) continue;
+    const config = normalizeExternalServer(raw);
+    if (config) out[name] = config;
+  }
+  return out;
+}
+
+/** Pull the user-scope MCP servers Claude Code stores at the top level of
+ *  `~/.claude.json`. This is where `claude mcp add -s user …` writes — the
+ *  root `mcpServers` block on the same file that also holds per-project
+ *  entries under `projects.<path>`. */
+function readClaudeCodeRootServers(): Record<string, McpServerConfig> {
+	const json = readJson(path.join(os.homedir(), ".claude.json"))
+	if (!json) return {}
+	return readMcpServersFromObject(json)
+}
+
+/** Pull the per-project MCP servers Claude Code stores in `~/.claude.json`. */
+function readClaudeCodeProjectServers(): Record<string, McpServerConfig> {
+  const json = readJson(path.join(os.homedir(), ".claude.json"));
+  if (!json) return {};
+  const projects = json.projects;
+  if (!isPlainObject(projects)) return {};
+  const cwd = process.cwd();
+  // Prefer the cwd entry, fall back to the first project entry that has
+  // any servers (helps when the cwd path doesn't match exactly, e.g. a
+  // symlinked or differently-cased home directory).
+  const entries = Object.entries(projects).filter(
+    (entry): entry is [string, Record<string, unknown>] =>
+      isPlainObject(entry[1]),
+  );
+  const direct = entries.find(([projectPath]) => projectPath === cwd);
+  const fallback = entries.find(([, project]) =>
+    isPlainObject(project.mcpServers),
+  );
+  const target = direct ?? fallback;
+  if (!target) return {};
+  return readMcpServersFromObject(target[1]);
+}
+
+/** Same as `readMcpServers` but takes a pre-parsed object. */
+function readMcpServersFromObject(
+  obj: Record<string, unknown>,
+): Record<string, McpServerConfig> {
+  const block = obj.mcpServers;
+  if (!isPlainObject(block)) return {};
+  const out: Record<string, McpServerConfig> = {};
+  for (const [name, raw] of Object.entries(block)) {
+    if (!/^[A-Za-z0-9_-]+$/.test(name)) continue;
+    const config = normalizeExternalServer(raw);
+    if (config) out[name] = config;
+  }
+  return out;
+}
+
+/** Discover every available migration source on the current machine. */
+export function discoverSources(): MigrationSource[] {
+  const sources: MigrationSource[] = [];
+
+  const claudeCodeUserPath = path.join(
+    os.homedir(),
+    ".claude",
+    "settings.json",
+  );
+  const claudeCodeUserServers = readMcpServers(claudeCodeUserPath);
+  if (Object.keys(claudeCodeUserServers).length > 0) {
+    sources.push({
+      id: "claude-code-user",
+      label: sourceLabel("claude-code-user"),
+      configPath: claudeCodeUserPath,
+      servers: claudeCodeUserServers,
+    });
+  }
+
+  // ~/.claude.json can hold entries in two layers: the root mcpServers block
+  // (user-scope, written by `claude mcp add -s user …`) and per-project
+  // entries under `projects.<path>.mcpServers`. Both can define a server with
+  // the same name; Claude treats the per-project one as the override. To
+  // avoid showing the same name twice in the picker, we collect both layers
+  // and drop any project-layer name that the root layer also has.
+  const claudeCodeJsonPath = path.join(os.homedir(), ".claude.json");
+  const rootServers = readClaudeCodeRootServers();
+  const projectServers = readClaudeCodeProjectServers();
+  const rootNames = new Set(Object.keys(rootServers));
+
+  if (Object.keys(rootServers).length > 0) {
+    sources.push({
+      id: "claude-code-json-user",
+      label: sourceLabel("claude-code-json-user"),
+      configPath: claudeCodeJsonPath,
+      servers: rootServers,
+    });
+  }
+
+  if (Object.keys(projectServers).length > 0) {
+    const deduped: Record<string, McpServerConfig> = {}
+    for (const [name, cfg] of Object.entries(projectServers)) {
+      if (rootNames.has(name)) continue
+      deduped[name] = cfg
+    }
+    if (Object.keys(deduped).length > 0) {
+      sources.push({
+        id: "claude-code-project",
+        label: sourceLabel("claude-code-project"),
+        configPath: claudeCodeJsonPath,
+        servers: deduped,
+      })
+    }
+  }
+
+  const claudeDesktopPath = claudeDesktopConfigPath();
+  const claudeDesktopServers = readMcpServers(claudeDesktopPath);
+  if (Object.keys(claudeDesktopServers).length > 0) {
+    sources.push({
+      id: "claude-desktop",
+      label: sourceLabel("claude-desktop"),
+      configPath: claudeDesktopPath,
+      servers: claudeDesktopServers,
+    });
+  }
+
+  return sources;
+}
+
+/** Flatten all sources into a single checklist. Stable order: source first,
+ *  then server name. */
+export function listMigrationEntries(): MigrationEntry[] {
+  const entries: MigrationEntry[] = [];
+  for (const source of discoverSources()) {
+    for (const [name, config] of Object.entries(source.servers)) {
+      entries.push({
+        key: `${source.id}::${name}`,
+        source: source.id,
+        sourceLabel: source.label,
+        name,
+        config,
+      });
+    }
+  }
+  return entries;
+}
+
+/** Short summary of a server for the picker / dry-run output. */
+export function describeEntry(entry: MigrationEntry): string {
+  const cfg = entry.config;
+  if (cfg.type === "http" || cfg.type === "sse") {
+    return `${cfg.type} ${cfg.url}`;
+  }
+  const args = cfg.args ?? [];
+  return `stdio ${cfg.command}${args.length ? " " + args.join(" ") : ""}`;
+}
+
+/** True when `name` already exists in the user-scope mcpServers block of
+ *  OrbCode's settings. This is the only conflict that matters — the CLI and
+ *  TUI both target user scope. */
+function destinationHas(name: string): boolean {
+  const settings = loadSettings();
+  return Boolean(settings.mcpServers && name in settings.mcpServers);
+}
+
+/**
+ * Apply a set of migration entries to `~/.orbcode/settings.json` (user scope).
+ * Returns the new entries plus the entries that were skipped (with a reason).
+ */
+export function applyMigration(entries: MigrationEntry[]): MigrationResult {
+  const filePath = path.join(getConfigDir(), "settings.json");
+  const existing = readJson(filePath) ?? {};
+  const servers = isPlainObject(existing.mcpServers)
+    ? { ...(existing.mcpServers as Record<string, McpServerConfig>) }
+    : {};
+
+  const added: MigrationEntry[] = [];
+  const skipped: { entry: MigrationEntry; reason: string }[] = [];
+
+  for (const entry of entries) {
+    if (entry.name in servers) {
+      skipped.push({
+        entry,
+        reason: "already exists in ~/.orbcode/settings.json",
+      });
+      continue;
+    }
+    if (destinationHas(entry.name)) {
+      // Race-safe double-check: the in-memory snapshot is the source of
+      // truth at write time, so if it changed between our read and now
+      // we still skip.
+      skipped.push({
+        entry,
+        reason: "already exists in ~/.orbcode/settings.json",
+      });
+      continue;
+    }
+    servers[entry.name] = entry.config;
+    added.push(entry);
+  }
+
+  if (added.length > 0) {
+    existing.mcpServers = servers;
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(existing, null, "\t") + "\n", {
+      mode: 0o600,
+    });
+  }
+
+  return { added, skipped };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ Usage:
   orbcode mcp add ...     add an MCP server (see: orbcode mcp help)
   orbcode mcp remove ...  remove an MCP server
   orbcode mcp list        list configured MCP servers
+  orbcode mcp migrate     import MCP servers from Claude Code / Claude Desktop
   orbcode -p "<prompt>"   run a single prompt non-interactively (prints only the final response)
   orbcode -p "…" --yolo   non-interactive with auto-approved edits/commands
   orbcode --model <id>    use a specific model for this run

--- a/src/mcp/auth.ts
+++ b/src/mcp/auth.ts
@@ -196,7 +196,8 @@ function startCallbackServer(
 	const server = http.createServer((req, res) => {
 		const url = new URL(req.url ?? "/", `http://localhost:${port}`)
 		if (url.pathname !== "/callback") {
-			res.writeHead(404).end("not found")
+			res.writeHead(404, { "Content-Type": "text/html" })
+			res.end(callbackPage("not-found"))
 			return
 		}
 		const code = url.searchParams.get("code")
@@ -204,19 +205,104 @@ function startCallbackServer(
 		if (code) {
 			onCode(code)
 			res.writeHead(200, { "Content-Type": "text/html" })
-			res.end("<h1>Authorized</h1><p>You can close this tab and return to OrbCode.</p>")
+			res.end(callbackPage("success"))
 		} else if (error) {
+			const desc = url.searchParams.get("error_description") ?? error
 			res.writeHead(400, { "Content-Type": "text/html" })
-			res.end(`<h1>Authorization failed</h1><p>${error}</p>`)
+			res.end(callbackPage("error", desc))
 		} else {
 			res.writeHead(400, { "Content-Type": "text/html" })
-			res.end("<h1>Missing code</h1>")
+			res.end(callbackPage("error", "Missing authorization code in the callback."))
 		}
 		// Close after responding so the port is freed immediately.
 		server.close()
 	})
 	server.listen(port, "127.0.0.1")
 	return server
+}
+
+/** Render the OAuth callback page. Styled to match matterai.so: dark
+ *  background, cyan/teal accents, centered card, clean typography. */
+function callbackPage(kind: "success" | "error" | "not-found", detail?: string): string {
+	const isSuccess = kind === "success"
+	const title = isSuccess ? "Authorized" : kind === "not-found" ? "Not Found" : "Authorization Failed"
+	const message = isSuccess
+		? "You can close this tab and return to OrbCode."
+		: kind === "not-found"
+			? "This page was not found."
+			: detail ?? "An unexpected error occurred during authentication."
+	const icon = isSuccess ? "&#10003;" : "&#10007;"
+	const accent = isSuccess ? "#43df94" : "#e86464"
+
+	return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OrbCode &middot; ${title}</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    background: #0d1117;
+    color: #e6edf3;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    -webkit-font-smoothing: antialiased;
+  }
+  .card {
+    text-align: center;
+    padding: 3rem 2.5rem;
+    max-width: 440px;
+    width: 90%;
+  }
+  .icon {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 1.75rem;
+    font-size: 36px;
+    font-weight: 700;
+    background: ${accent}1a;
+    border: 2px solid ${accent};
+    color: ${accent};
+  }
+  h1 {
+    font-size: 1.6rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.6rem;
+  }
+  p {
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: #8b949e;
+    margin-bottom: 2rem;
+  }
+  .brand {
+    margin-top: 2.5rem;
+    font-size: 0.8rem;
+    color: #484f58;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+  }
+  .brand span { color: #c4fdff; }
+</style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">${icon}</div>
+    <h1>${title}</h1>
+    <p>${message}</p>
+    <div class="brand">OrbCode CLI &middot; <span>powered by Axon</span></div>
+  </div>
+</body>
+</html>`
 }
 
 /** Pick an ephemeral loopback port for the callback server. */

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -1,7 +1,7 @@
 import type OpenAI from "openai"
 
 import { callMcpTool, connectMcpServer, type McpConnection } from "./client.js"
-import { configPathForScope, loadMcpConfig } from "./config.js"
+import { configPathForScope, loadMcpConfig, removeMcpServerAnyScope } from "./config.js"
 import { hasStoredAuth, isOAuthConfig, type AuthIntercept } from "./auth.js"
 import type { McpHttpServerConfig, McpServerConfig, McpServerState, McpSnapshot, McpTool, ScopedMcpServerConfig } from "./types.js"
 
@@ -159,6 +159,21 @@ export class McpManager {
 		const state = this.states.get(name)
 		if (state) state.disabled = true
 		await this.disconnectOne(name)
+	}
+
+	/** Permanently remove a server: disconnect, drop from the in-memory
+	 *  config/state, and remove from the on-disk config (whichever scope it
+	 *  lives in). Returns true if a config entry was actually removed. The
+	 *  caller is responsible for re-persisting the enabled/disabled lists
+	 *  (which no longer reference the removed name). */
+	async removeServer(name: string): Promise<boolean> {
+		await this.disconnectOne(name)
+		this.disabled.delete(name)
+		this.enabled.delete(name)
+		this.pendingApproval.delete(name)
+		this.configs.delete(name)
+		this.states.delete(name)
+		return removeMcpServerAnyScope(this.cwd, name) !== undefined
 	}
 
 	/** Re-authenticate a server in the needs-auth state: disconnect, clear

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -46,6 +46,8 @@ import { FollowupPrompt } from "./components/FollowupPrompt.js";
 import { HookTrustPrompt } from "./components/HookTrustPrompt.js";
 import { McpApprovalPrompt } from "./components/McpApprovalPrompt.js";
 import { McpPicker } from "./components/McpPicker.js";
+import { McpMigrationPicker } from "./components/McpMigrationPicker.js";
+import { applyMigration, listMigrationEntries, type MigrationEntry } from "../commands/migrate.js";
 import { StatusBar, type ApprovalMode } from "./components/StatusBar.js";
 import { ModelPicker } from "./components/ModelPicker.js";
 import { SessionPicker } from "./components/SessionPicker.js";
@@ -78,6 +80,10 @@ const SLASH_COMMANDS: SlashCommand[] = [
   {
     name: "/mcp",
     description: "manage MCP servers — enable, disable, reconnect, view status",
+  },
+  {
+    name: "/migrate",
+    description: "import MCP servers from Claude Code / Claude Desktop",
   },
   {
     name: "/commit",
@@ -273,6 +279,10 @@ export function App({
   // the first agent is created so we don't spawn servers before login.
   const mcpManagerRef = useRef<McpManager | null>(null);
   const [mcpPickerOpen, setMcpPickerOpen] = useState(false);
+  // Set when /migrate is open. Holds the entries to show in the picker; null
+  // means the picker isn't open. We cache the entries on first open so the
+  // picker shows a stable list even if the user cancels and reopens.
+  const [mcpMigrationEntries, setMcpMigrationEntries] = useState<MigrationEntry[] | null>(null);
   // Project-scope MCP servers awaiting the user's approval at startup.
   const [pendingMcpApproval, setPendingMcpApproval] = useState<string[] | null>(
     null,
@@ -776,6 +786,13 @@ export function App({
           setMcpPickerOpen(true);
           break;
         }
+        case "/migrate": {
+          // Scan for sources now (cheap — just file reads) and cache the list
+          // so the picker has a stable view. `applyMigration` re-reads the
+          // destination on confirm, so a stale snapshot is fine.
+          setMcpMigrationEntries(listMigrationEntries());
+          break;
+        }
         case "/commit":
           if (!getAuthToken(settings)) {
             setView("login");
@@ -938,6 +955,98 @@ export function App({
     [handleSubmit, pushRow],
   );
 
+  // Tear down the live MCP manager (if any), then create a fresh one from
+  // the current on-disk settings and start it. Used after /migrate (new
+  // servers added) and after a /mcp delete (server removed) so /mcp works
+  // immediately without needing to send a message first. The agent is also
+  // dropped so the next message rebuilds it against the new manager's tool
+  // list.
+  const rebuildMcpManager = useCallback(async () => {
+    const oldManager = mcpManagerRef.current;
+    mcpManagerRef.current = null;
+    if (oldManager) {
+      await oldManager.stop().catch(() => {});
+    }
+    agentRef.current = null;
+    const refreshed = loadSettings();
+    setSettings(refreshed);
+    if (getAuthToken(refreshed)) {
+      const manager = new McpManager(
+        process.cwd(),
+        refreshed.disabledMcpServers ?? [],
+        refreshed.enabledMcpServers ?? [],
+      );
+      mcpManagerRef.current = manager;
+      void manager.start().then(() => {
+        const pendingMcp = manager.getPendingApproval();
+        if (pendingMcp.length > 0) setPendingMcpApproval(pendingMcp);
+      });
+    }
+  }, []);
+
+  // Apply a user-confirmed migration selection: write the chosen entries to
+  // ~/.orbcode/settings.json, then rebuild the MCP manager so the new
+  // user-scope servers connect immediately. Skips (name conflicts)
+  // are reported but not fatal.
+  const resolveMcpMigration = useCallback(
+    async (selected: MigrationEntry[]) => {
+      if (selected.length === 0) {
+        pushRow({ kind: "info", text: "MCP migration cancelled (no servers selected)." })
+        return
+      }
+      const result = applyMigration(selected)
+      const addedNames = result.added.map((e) => e.name)
+      const skippedCount = result.skipped.length
+      if (result.added.length === 0) {
+        pushRow({
+          kind: "info",
+          text: `MCP migration: nothing added (${skippedCount} skipped — name${skippedCount === 1 ? "" : "s"} already in use).`,
+        })
+        return
+      }
+      pushRow({
+        kind: "info",
+        text: `MCP migration: added ${result.added.length} server${result.added.length === 1 ? "" : "s"} to ~/.orbcode/settings.json (${addedNames.join(", ")})${skippedCount > 0 ? `; skipped ${skippedCount} (name already in use).` : "."}`,
+      })
+      // Tear down the live manager + agent, then immediately rebuild the
+      // manager so /mcp works without needing to send a message first.
+      // The agent is dropped so the next message creates a fresh one that
+      // picks up the new manager's tool list.
+      await rebuildMcpManager()
+    },
+    [pushRow, rebuildMcpManager],
+  )
+
+  // Handle a permanent delete from the /mcp picker. The manager has already
+  // dropped the server from its in-memory state and from the on-disk config;
+  // we persist the cleaned enabled/disabled lists, rebuild the manager so
+  // /mcp reflects the deletion immediately, and surface a one-line
+  // confirmation.
+  const handleMcpServerDeleted = useCallback(
+    async (name: string) => {
+      const manager = mcpManagerRef.current
+      if (manager) {
+        // `removeServer` already removed the name from both lists, but
+        // `saveMcpApproval` needs the post-removal snapshot so the
+        // per-project settings don't keep a dangling reference.
+        saveMcpApproval(
+          process.cwd(),
+          manager.getEnabled(),
+          manager.getDisabled(),
+        )
+      }
+      pushRow({
+        kind: "info",
+        text: `MCP: removed "${name}" from the config. Use \`orbcode mcp add ${name} …\` to re-add it.`,
+      })
+      // Rebuild the manager from the now-trimmed on-disk config so /mcp
+      // works immediately and the next message gets a fresh agent with the
+      // correct tool list.
+      await rebuildMcpManager()
+    },
+    [pushRow, rebuildMcpManager],
+  )
+
   // Apply --resume and an initial prompt (`orbcode "do something"`) on startup.
   const bootedRef = useRef(false);
   useEffect(() => {
@@ -1071,6 +1180,7 @@ export function App({
     !pendingMcpApproval &&
     !modelPickerOpen &&
     !mcpPickerOpen &&
+    !mcpMigrationEntries &&
     !resumableSessions;
 
   return (
@@ -1194,6 +1304,19 @@ export function App({
                     );
                 }}
                 onCancel={() => setMcpPickerOpen(false)}
+                onDeleted={handleMcpServerDeleted}
+              />
+            </Box>
+          )}
+          {mcpMigrationEntries && (
+            <Box marginTop={1}>
+              <McpMigrationPicker
+                entries={mcpMigrationEntries}
+                onCancel={() => setMcpMigrationEntries(null)}
+                onConfirm={(selected) => {
+                  setMcpMigrationEntries(null);
+                  resolveMcpMigration(selected);
+                }}
               />
             </Box>
           )}
@@ -1227,6 +1350,7 @@ export function App({
             !pendingHookTrust &&
             !pendingMcpApproval &&
             !mcpPickerOpen &&
+            !mcpMigrationEntries &&
             !streamingText &&
             !streamingReasoning && (
               <Box marginTop={1}>

--- a/src/ui/components/McpMigrationPicker.tsx
+++ b/src/ui/components/McpMigrationPicker.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from "react";
+import { Box, Text, useInput } from "ink";
+
+import { COLORS } from "../../branding.js";
+import { describeEntry, type MigrationEntry } from "../../commands/migrate.js";
+
+const VISIBLE_ROWS = 10;
+
+interface McpMigrationPickerProps {
+  entries: MigrationEntry[];
+  /** Called with the subset the user confirmed. */
+  onConfirm: (selected: MigrationEntry[]) => void;
+  /** User cancelled (esc). */
+  onCancel: () => void;
+}
+
+/**
+ * Combined checklist of all detected MCP servers across Claude Code (user),
+ * Claude Code (this project), and Claude Desktop. Each row shows the source
+ * as a dim label. Space toggles, enter confirms, esc cancels.
+ *
+ * Default state: every entry pre-checked, matching the CLI's `--all` flag.
+ * The user unchecks the ones they don't want; the confirmation runs the
+ * real `applyMigration` and reports the skipped count from conflicts.
+ */
+export function McpMigrationPicker({
+  entries,
+  onConfirm,
+  onCancel,
+}: McpMigrationPickerProps) {
+  const [selected, setSelected] = useState(0);
+  const [checked, setChecked] = useState<Set<string>>(
+    () => new Set(entries.map((e) => e.key)),
+  );
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    if (key.upArrow) {
+      setSelected((s) => (s - 1 + entries.length) % entries.length);
+      return;
+    }
+    if (key.downArrow || key.tab) {
+      setSelected((s) => (s + 1) % entries.length);
+      return;
+    }
+    if (key.return) {
+      const picked: MigrationEntry[] = [];
+      for (const entry of entries) {
+        if (checked.has(entry.key)) picked.push(entry);
+      }
+      onConfirm(picked);
+      return;
+    }
+    if (input === " ") {
+      const entry = entries[selected];
+      if (!entry) return;
+      setChecked((prev) => {
+        const next = new Set(prev);
+        if (next.has(entry.key)) next.delete(entry.key);
+        else next.add(entry.key);
+        return next;
+      });
+    }
+  });
+
+  if (entries.length === 0) {
+    return (
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor={COLORS.primary}
+        paddingX={1}
+      >
+        <Text bold color={COLORS.primary}>
+          Migrate MCP servers
+        </Text>
+        <Text dimColor>No MCP servers found on this machine to migrate.</Text>
+        <Text dimColor>
+          Install Claude Code or Claude Desktop, or add servers with `orbcode
+          mcp add`.
+        </Text>
+        <Text dimColor>esc to close</Text>
+      </Box>
+    );
+  }
+
+  const count = entries.length;
+  const windowStart = Math.max(
+    0,
+    Math.min(selected - VISIBLE_ROWS + 1, count - VISIBLE_ROWS),
+  );
+  const visible = entries.slice(windowStart, windowStart + VISIBLE_ROWS);
+  const checkedCount = entries.reduce(
+    (n, e) => (checked.has(e.key) ? n + 1 : n),
+    0,
+  );
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={COLORS.primary}
+      paddingX={1}
+    >
+      <Text bold color={COLORS.primary}>
+        Migrate MCP servers from Claude Code / Desktop
+      </Text>
+      <Text dimColor>
+        Servers will be copied to ~/.orbcode/settings.json. Conflicts (same name
+        already exists) are skipped.
+      </Text>
+      {windowStart > 0 && <Text dimColor> ↑ {windowStart} more</Text>}
+      {visible.map((entry, i) => {
+        const isSelected = windowStart + i === selected;
+        return (
+          <Box key={entry.key} flexDirection="column">
+            <Text color={isSelected ? COLORS.accent : undefined}>
+              {isSelected ? "❯ " : "  "}
+              {checked.has(entry.key) ? "☑" : "☐"} {entry.name}
+              <Text dimColor> · {describeEntry(entry)}</Text>
+            </Text>
+            <Box paddingLeft={5}>
+              <Text dimColor>{entry.sourceLabel}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+      {windowStart + VISIBLE_ROWS < count && (
+        <Text dimColor> ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
+      )}
+      <Text dimColor>
+        space toggle · enter confirm ({checkedCount}/{count}) · esc cancel
+      </Text>
+    </Box>
+  );
+}

--- a/src/ui/components/McpPicker.tsx
+++ b/src/ui/components/McpPicker.tsx
@@ -13,6 +13,10 @@ interface McpPickerProps {
 	manager: McpManager
 	onChanged: () => void
 	onCancel: () => void
+	/** Called after a server is permanently deleted so the parent can
+	 *  re-persist the enabled/disabled lists (which no longer contain the
+	 *  removed name) and rebuild the agent. */
+	onDeleted: (name: string) => void
 }
 
 function statusColor(state: McpServerState): string {
@@ -52,6 +56,11 @@ function buildActions(state: McpServerState): string[] {
 	if (state.disabled || state.status === "disabled") actions.push("Enable")
 	else actions.push("Disable")
 	actions.push("Reconnect")
+	// Delete is last so it's a deliberate choice past the everyday toggles.
+	// It's always available — disabling and re-enabling a server still leaves
+	// the config entry, which is the right behaviour when you might want it
+	// back. Delete is the explicit "I don't want this server here at all" path.
+	actions.push("Delete")
 	return actions
 }
 
@@ -63,9 +72,9 @@ function buildActions(state: McpServerState): string[] {
  *   - Action menu: ↑/↓ to select an action, enter to execute, esc to go back.
  *
  * Actions adapt to the server's state: Authenticate (needs-auth), Enable
- * (disabled), Disable (connected/failed), Reconnect (always).
+ * (disabled), Disable (connected/failed), Reconnect (always), Delete (always).
  */
-export function McpPicker({ manager, onChanged, onCancel }: McpPickerProps) {
+export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPickerProps) {
 	const [snapshot, setSnapshot] = useState(() => manager.snapshot())
 	const [selected, setSelected] = useState(0)
 	const [busy, setBusy] = useState(false)
@@ -74,6 +83,13 @@ export function McpPicker({ manager, onChanged, onCancel }: McpPickerProps) {
 	const [authUrl, setAuthUrl] = useState("")
 	const [actionMode, setActionMode] = useState(false)
 	const [actionSelected, setActionSelected] = useState(0)
+	// Pending destructive confirmation. The resolve ref unblocks the awaiting
+	// `deleteSelected` call when the user picks y/n at the prompt.
+	const [pendingConfirm, setPendingConfirm] = useState<{
+		title: string
+		body: string
+		resolve: (ok: boolean) => void
+	} | null>(null)
 	const codeResolveRef = useRef<((code: string) => void) | null>(null)
 	const codeRejectRef = useRef<((reason: Error) => void) | null>(null)
 
@@ -82,8 +98,43 @@ export function McpPicker({ manager, onChanged, onCancel }: McpPickerProps) {
 	const current = servers[selected]
 	const actions = current ? buildActions(current) : []
 
-	useInput((_input, key) => {
+	/** Show a yes/no confirmation and resolve when the user picks one. Used
+	 *  for destructive actions like deleting a server. */
+	function confirmDangerousAction(title: string, body: string): Promise<boolean> {
+		return new Promise<boolean>((resolve) => {
+			setPendingConfirm({ title, body, resolve })
+		})
+	}
+
+	useInput((input, key) => {
 		if (authingServer || busy) return
+
+		// A destructive confirmation is in flight. Eat every key except the
+		// explicit y/n + enter / esc — matches the rest of the picker's
+		// "no shorthand" rule.
+		if (pendingConfirm) {
+			if (key.escape) {
+				pendingConfirm.resolve(false)
+				setPendingConfirm(null)
+				return
+			}
+			if (key.return) {
+				pendingConfirm.resolve(true)
+				setPendingConfirm(null)
+				return
+			}
+			if (input === "y" || input === "Y") {
+				pendingConfirm.resolve(true)
+				setPendingConfirm(null)
+				return
+			}
+			if (input === "n" || input === "N") {
+				pendingConfirm.resolve(false)
+				setPendingConfirm(null)
+				return
+			}
+			return
+		}
 
 		if (actionMode) {
 			if (key.escape) {
@@ -137,6 +188,7 @@ export function McpPicker({ manager, onChanged, onCancel }: McpPickerProps) {
 		else if (action === "Enable") await enableSelected()
 		else if (action === "Disable") await disableSelected()
 		else if (action === "Reconnect") await reconnectSelected()
+		else if (action === "Delete") await deleteSelected()
 	}
 
 	async function enableSelected(): Promise<void> {
@@ -158,6 +210,40 @@ export function McpPicker({ manager, onChanged, onCancel }: McpPickerProps) {
 		setBusyMessage("Disabling…")
 		try {
 			await manager.disableServer(current.name)
+			await refresh()
+		} finally {
+			setBusy(false)
+			setBusyMessage("")
+		}
+	}
+
+	async function deleteSelected(): Promise<void> {
+		if (!current) return
+		const name = current.name
+		// Pull the config path so the confirmation can show what file gets
+		// modified — without this, the user has to remember the scope rules.
+		const configPath = manager.getConfigPath(name) ?? "~/.orbcode/settings.json"
+		const confirmed = await confirmDangerousAction(
+			`Delete MCP server "${name}"?`,
+			`This removes the entry from ${configPath}. You'll have to re-add it manually.`,
+		)
+		if (!confirmed) return
+		setBusy(true)
+		setBusyMessage("Deleting…")
+		try {
+			const removed = await manager.removeServer(name)
+			if (!removed) {
+				// Race: someone else removed it between opening the picker and
+				// confirming. Refresh and bail — the user can see it's gone.
+				await refresh()
+				return
+			}
+			// Move the cursor to a safe position before the snapshot shrinks.
+			// `setSelected` runs before the next render commits, so clamping
+			// here is correct.
+			const next = manager.snapshot().servers
+			setSelected((s) => Math.min(s, Math.max(0, next.length - 1)))
+			onDeleted(name)
 			await refresh()
 		} finally {
 			setBusy(false)
@@ -247,6 +333,18 @@ export function McpPicker({ manager, onChanged, onCancel }: McpPickerProps) {
 				onPasteCode={handlePasteCode}
 				onCancel={handleAuthCancel}
 			/>
+		)
+	}
+
+	if (pendingConfirm) {
+		return (
+			<Box flexDirection="column" borderStyle="round" borderColor={COLORS.error} paddingX={1}>
+				<Text bold color={COLORS.error}>
+					{pendingConfirm.title}
+				</Text>
+				<Text>{pendingConfirm.body}</Text>
+				<Text dimColor>y confirm · n / esc cancel</Text>
+			</Box>
 		)
 	}
 
@@ -365,8 +463,18 @@ function DetailPanel({
 			<Box marginTop={1} flexDirection="column">
 				{actions.map((action, i) => {
 					const isSelected = actionMode && i === actionSelected
+					// Color destructive actions red so they read differently
+					// from the everyday toggles. Keeps the affordance visually
+					// separate from the harmless enable/disable/reconnect
+					// choices right above it.
+					const isDestructive = action === "Delete"
+					const color = isSelected
+						? COLORS.accent
+						: isDestructive
+							? COLORS.error
+							: undefined
 					return (
-						<Text key={action} color={isSelected ? COLORS.accent : undefined}>
+						<Text key={action} color={color}>
 							{isSelected ? "❯ " : "  "}
 							{i + 1}. {action}
 						</Text>


### PR DESCRIPTION
Branches `release/v0.2.4` -> `release/v0.3.0` to match the version bump in `package.json`. Bumps the minor version for the new MCP migration feature.

## What's in this release

### Added
- **`orbcode mcp migrate` / `/migrate` slash command** — scan Claude Code (`~/.claude/settings.json`, `~/.claude.json` root + per-project layers) and Claude Desktop (`claude_desktop_config.json`) for MCP server configs and copy them into `~/.orbcode/settings.json` (user scope). TUI shows a combined checklist; CLI prints a preview by default and only writes with `--all`. Name conflicts are silently skipped. Codex support (TOML) is intentionally deferred.
- **Delete action in the `/mcp` picker** — permanent, irreversible removal of a server from its config file (any scope) with an explicit y/n confirmation. Distinct from Disable, which leaves the entry in place.
- **Styled OAuth callback page** — the local `/callback` page now matches the matterai.so look (dark `#0d1117` background, centered card, colored icon, brand footer) for success, error, and not-found paths.

## Commits
- `032d585` feat(mcp): migrate servers from Claude Code / Claude Desktop
- `4613a0f` feat(mcp): add delete action to /mcp picker
- `dd55cba` feat(mcp): style OAuth callback page
- `bd2799f` chore(release): finalize v0.3.0 changelog