### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@
 # rights for the `orbcode` package).
 
 name: Release
+# Per-run title: "Release v0.3.0" for tag pushes, and for manual dispatches
+# either "Release v<inputs.version>" (when supplied) or "Release manual".
+# `run-name` only sees github.* and inputs.* — package.json can't be read here,
+# so the dispatch flow relies on the `version` input to show the tag.
+run-name: "Release ${{ github.event_name == 'push' && github.ref_name || format('v{0}', inputs.version) || 'manual' }}"
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,43 @@
-# Auto-release to npm from version tags on main.
+# Auto-release to npm from version tags or release-branch merges on main.
 #
-# The publish step is gated on a `vX.Y.Z` tag push to `main` — that requires
-# both a merged commit on the protected default branch AND an explicit tag,
-# both of which need write access to main. Release branches, PR pushes, and
-# force-pushes to a release branch do NOT publish, even with valid npm creds.
+# The workflow publishes in three ways:
+#   1. A merged PR from a `release/vX.Y.Z` branch into `main` (the normal
+#      path — branch name and `package.json` are both validated against
+#      each other). `gh release create` pushes the tag as a side effect;
+#      the subsequent tag-push run is short-circuited by the "already on
+#      npm" check, so there is no infinite loop.
+#   2. A `vX.Y.Z` tag push to `main` (escape hatch / re-publish path —
+#      tag must match `package.json`).
+#   3. A manual `workflow_dispatch` (re-publish / same-version dry test).
+#
+# PR pushes to a `release/v*` branch, force-pushes, and merges of any
+# other branch do NOT publish.
 #
 # Required repo secret: NPM_TOKEN (npm "Automation" access token with publish
 # rights for the `orbcode` package).
 
 name: Release
-# Per-run title: "Release v0.3.0" for tag pushes, and for manual dispatches
-# either "Release v<inputs.version>" (when supplied) or "Release manual".
-# `run-name` only sees github.* and inputs.* — package.json can't be read here,
-# so the dispatch flow relies on the `version` input to show the tag.
-run-name: "Release ${{ github.event_name == 'push' && github.ref_name || format('v{0}', inputs.version) || 'manual' }}"
+# Per-run title:
+#   - tag push  → "Release v0.3.1"
+#   - PR merge  → "Release release/v0.3.1"
+#   - dispatch  → "Release v0.3.1" if `version` input set, else "Release manual"
+# `run-name` only sees github.* and inputs.* — package.json can't be read here.
+run-name: >-
+  Release ${{
+    github.event_name == 'push' && github.ref_name ||
+    github.event_name == 'pull_request' && github.event.pull_request.head.ref ||
+    (inputs.version && format('v{0}', inputs.version)) || 'manual'
+  }}
 
 on:
   push:
     tags:
       - "v*"
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
@@ -37,7 +56,13 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/v')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'pull_request'
+        && github.event.pull_request.merged == true
+        && github.event.pull_request.base.ref == 'main'
+        && startsWith(github.event.pull_request.head.ref, 'release/v')) ||
+      (github.event_name == 'workflow_dispatch')
     steps:
       - uses: actions/checkout@v4
 
@@ -56,7 +81,8 @@ jobs:
           set -euo pipefail
           PKG_VERSION=$(node -p "require('./package.json').version")
           NAME=$(node -p "require('./package.json').name")
-          if [ "${{ github.event_name }}" = "push" ]; then
+          EVENT="${{ github.event_name }}"
+          if [ "$EVENT" = "push" ]; then
             # Tag push: REF is refs/tags/vX.Y.Z
             TAG_VERSION=${GITHUB_REF#refs/tags/v}
             if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
@@ -65,6 +91,21 @@ jobs:
               exit 1
             fi
             VERSION="$TAG_VERSION"
+          elif [ "$EVENT" = "pull_request" ]; then
+            # Merged release branch: derive version from head_ref (release/vX.Y.Z)
+            # and require it to match the bumped package.json.
+            HEAD_REF="${{ github.event.pull_request.head.ref }}"
+            BRANCH_VERSION=${HEAD_REF#release/v}
+            if [ -z "$BRANCH_VERSION" ] || [ "$BRANCH_VERSION" = "$HEAD_REF" ]; then
+              echo "::error::PR head ref '$HEAD_REF' is not a release/vX.Y.Z branch."
+              exit 1
+            fi
+            if [ "$BRANCH_VERSION" != "$PKG_VERSION" ]; then
+              echo "::error::Branch version $BRANCH_VERSION does not match package.json version $PKG_VERSION."
+              echo "::error::Rename the branch to release/v$PKG_VERSION (or update package.json) so they agree."
+              exit 1
+            fi
+            VERSION="$BRANCH_VERSION"
           else
             # Manual dispatch: prefer the input, fall back to package.json.
             VERSION="${{ inputs.version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.1] - 2026-06-23
+
+### Changed
+
+- **Release workflow run title now shows the version.** The `Release` GitHub
+  Actions workflow gained a `run-name` (e.g. `Release v0.3.1`) so manual
+  dispatches and tag pushes are easier to tell apart in the Actions list. No
+  functional change to the publish flow.
 
 ## [0.3.0] - 2026-06-23
 
@@ -29,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with `--all`. Servers whose name already exists in the destination are
   silently skipped and counted in the summary. Codex support (TOML) is
   intentionally deferred.
+
 - **Delete action in the `/mcp` picker.** The interactive server manager
   gained a "Delete" action (last in the list, red) that permanently removes
   a server from its config file (whichever scope it lives in) and shows a
@@ -74,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`orbcode mcp add` no longer swallows a `--` separator after the server
   name as the command.** `orbcode mcp add --scope user context7 -- npx -y
-  @upstash/context7-mcp ...` previously wrote `command: "--"` (a literal
+@upstash/context7-mcp ...` previously wrote `command: "--"` (a literal
   `--`), so the server failed to spawn. A `--` immediately after the server
   name is now consumed as the flag/command separator, matching Claude Code's
   `claude mcp add <name> -- <command>`. A later `--` is still passed through

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bump version to 0.3.1, give the release workflow a 'Release vX.Y.Z' run-name, and make merging a release/vX.Y.Z PR into main auto-publish to npm + create the GitHub Release. No more 'git tag && git push tag' step.

**What you do now:** open a PR from release/vX.Y.Z and merge it. The workflow:

1. Verifies the branch version matches package.json (errors out otherwise).
2. Skips if v0.3.1 is already on npm.
3. Publishes to npm and creates the v0.3.1 GitHub Release. The release step pushes the tag as a side effect; the subsequent tag-triggered run sees the version is already live and exits cleanly, so there is no loop.

**Triggers kept:** tag pushes to main and manual workflow_dispatch still work as escape hatches / re-publish paths.

**Triggers ignored:** PR pushes to a release/v* branch, force-pushes, and merges of any other branch (enforced by the job-level `if`).