### PR TITLE
feat: neutral greyscale theme with fullscreen TUI, virtual scrolling, and UI redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Diff background colors are now 50% transparent.** Added/removed line
+  backgrounds in the diff view are alpha-blended against the terminal
+  background (`#1a1a1a`), producing a muted green (`#2C5E40`) and muted red
+  (`#7E3045`) that are less visually aggressive while preserving the red/green
+  semantic.
+
+### Fixed
+
+- **Resumed sessions now restore reasoning and tool history.** New sessions
+  persist the exact visible transcript, including thinking durations, tool
+  summaries, result previews, errors, and diffs. Older sessions reconstruct
+  tool calls, results, and edit fragments from their stored model messages
+  when possible.
+- **@-file autocomplete now shows files created during the session.**
+  The file list was computed once on mount (via `useMemo([], [])`), so new
+  files created by editing or manually never appeared in the `@` popup.
+  Changed to re-scan the workspace each time the `@` popup opens.
+
 ## [0.4.2] - 2026-07-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,98 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-13
+
+### Changed
+
+- **Default theme now uses a neutral base with consistent semantic accents.**
+  The explicit palette uses `#ffffff` primary, `#d0d0d0` accent,
+  `#a8a8a8` thinking, `#7a7a7a` dim, and `#1a1a1a` background, while errors
+  and removals use `#E34671`, successes and additions use `#3FA266`, and
+  approval warnings use `#E2CE76`. All `<Text dimColor>` usages were replaced
+  with explicit `color={COLORS.dim}`. Code blocks follow `COLORS.accent`, and
+  edit-tool diff backgrounds now use the shared error/success colors.
+- **TUI now runs in the alternate screen buffer as an independent surface.**
+  On startup the app enters `\x1b[?1049h` (alternate screen) and sets the
+  terminal's default foreground/background via OSC 10/11 to the greyscale
+  palette, so every cell — including text without an explicit color prop —
+  follows the theme. The terminal scrollback is no longer affected; on
+  exit the original screen and colors are restored (`\x1b]110\x07`,
+  `\x1b]111\x07`, `\x1b[?1049l`).
+- **All content has horizontal margin.** The root container in `App.tsx`
+  now carries `marginX={2}` so the header, conversation rows, pickers,
+  prompts, input box, and status bar all sit inset from the terminal edge
+  consistently. The per-component `marginX` that was previously on the
+  input box was removed to avoid double margin.
+- **Input box is now a fully-bordered rounded box with quieter chrome.** The
+  previous chrome drew only top/bottom rules (`borderLeft/Right={false}`); it
+  now draws all four sides with `borderStyle="round"`, using a 50%-brightness
+  border so the input remains visually anchored without dominating the chat.
+- **The initial OrbCode header is top-anchored with a stable margin.** The
+  borderless intro uses a half-size cyan/white ASCII interpretation of the
+  `orbital.svg` brand mark alongside a metadata column, followed by a compact
+  two-column command grid and shortcut row. Temporary command and picker UI
+  grows below it without recentering or shifting the brand surface.
+- **User messages render as full-width borderless highlighted blocks.** A
+  subtle neutral background spans the transcript width inside the global
+  margins with two-cell horizontal and one-row vertical padding,
+  distinguishing prompts without adding more terminal chrome.
+- **Command and file-completion popups use padded rounded surfaces.** Slash
+  commands and `@file` results now share a solid neutral background with
+  same-color half-cell corner caps and padded content, without a contrasting
+  border.
+- **Approval modes have semantic highlighting again.** Ask mode is white,
+  edit approval is yellow, and auto-approval is green.
+
+### Fixed
+
+- **Diff add/remove lines now render with explicit foreground color.**
+  Previously the added/removed lines in `DiffView` set only
+  `backgroundColor`, leaving the text color at the terminal default — on
+  some terminals the text was invisible against the dark green/red
+  backgrounds. Both now set `color={COLORS.primary}` so the text is
+  always readable.
+- **Spinner no longer causes the input box to flicker.** The spinner is
+  wrapped in `<Box marginTop={1}>` (2 terminal lines), but the viewport
+  budget only reserved 1 line for it. This made the spacer over-allocate
+  by one line, so every time the spinner's second counter changed width
+  the input box shifted up and back down. The middle-height estimate now
+  correctly accounts for 2 lines.
+- **Fullscreen TUI no longer leaves duplicate frames in the scrollback.**
+  The root now always matches the real terminal dimensions, forcing Ink's
+  full-redraw path. Full frames are converted from newline-delimited output
+  to retained, cursor-addressed row replacements inside a synchronized
+  terminal update. Neither linefeeds nor per-frame display clears are emitted,
+  so renders cannot advance or archive terminal history. Fullscreen activation
+  also follows any interactive stdin/stdout/stderr stream instead of relying
+  only on `stdout.isTTY`, which is absent in some terminal wrappers. The TUI
+  captures the same complete set of mouse modes as
+  OpenTUI (`1000`, `1002`, `1003`, and `1006`), preventing wheel/trackpad
+  gestures from scrolling the terminal itself. Only the clipped chat
+  transcript handles wheel and page scrolling; login and other non-chat views
+  ignore it. The transcript is the sole shrinking region while the input and
+  status controls remain fixed at the bottom, including during terminal
+  resizes.
+- **Scrolling is smoother and fixed controls no longer flicker.** Wheel input
+  is coalesced to Ink's render cadence instead of creating a backlog of tiny
+  animated steps. Completed transcript rows are memoized, and long histories
+  mount only the visible rows plus overscan instead of re-rendering and laying
+  out the entire conversation on every wheel event. The terminal adapter also
+  keeps a retained row cache and only writes rows whose rendered content
+  changed, so spinner/streaming timers do not repaint the input or status area.
+- **The thinking animation remains visible during reasoning streams.** The
+  first reasoning token no longer replaces the animated activity indicator
+  with a static label; the spinner stays mounted above the live preview until
+  reasoning completes.
+- **Ctrl+D now requires confirmation.** The first press shows a three-second
+  `Press Ctrl+D again to exit` warning in the status bar; only a second press
+  exits the session. Escape now clears a non-empty chat input, including any
+  open slash-command or file-completion state.
+- **Live AI output is no longer clipped in resumed or narrow-terminal chats.**
+  Transcript virtualization now accounts for every committed row's margins
+  and borders, while status-bar fields remain single-line. Streaming text
+  therefore retains its reserved viewport rows and paints before completion.
+
 ## [0.4.1] - 2026-07-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.2.2",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matterailab/orbcode",
-      "version": "0.2.2",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/branding.ts
+++ b/src/branding.ts
@@ -15,21 +15,44 @@ export const VERSION = (() => {
 })();
 export const TAGLINE = "powered by Axon models by MatterAI";
 
+// Neutral black/white/grey foundation with explicit semantic accents. All
+// values are hex so the TUI never falls back to terminal-defined colors.
+// Hierarchy:
+//   primary  #ffffff  — main text, header chrome
+//   accent   #d0d0d0  — secondary emphasis (header model, selected rows)
+//   thinking #a8a8a8  — model-reasoning text
+//   dim      #7a7a7a  — supporting / hint text
+//   error    #E34671  — errors, removals, dangerous actions
+//   success  #3FA266  — success states, additions, auto-approval
+//   warning  #E2CE76  — confirmations and edit approval
 export const COLORS = {
-  primary: "#c4fdff",
-  accent: "#4EC9B0",
-  dim: "gray",
-  error: "#e86464",
-  warning: "#e2ce76",
-  success: "#43df94",
-  thinking: "#8cd3de",
-  user: "#569CD6",
+  primary: "#ffffff",
+  accent: "#d0d0d0",
+  dim: "#7a7a7a",
+  error: "#E34671",
+  warning: "#E2CE76",
+  success: "#3FA266",
+  thinking: "#a8a8a8",
+  user: "#ffffff",
+  userBg: "#2a2a2a",
+  popupBg: "#242424",
+  inputBorder: "#808080",
+  inputBorderInactive: "#3d3d3d",
+  orbitalOuter: "#06E1E7",
+  orbitalInner: "#8BF4F7",
+  bg: "#1a1a1a",
 } as const;
 
-export const LOGO = `
-  ___       _                   _
- / _ \\ _ __| |__   ___ ___   __| | ___
-| | | | '__| '_ \\ / __/ _ \\ / _\` |/ _ \\
-| |_| | |  | |_) | (_| (_) | (_| |  __/
- \\___/|_|  |_.__/ \\___\\___/ \\__,_|\\___|
-`;
+/**
+ * Terminal-sized interpretation of design/orbital.svg. Characters identify
+ * its outer cyan field, inner orbit, and white core; Header maps them to
+ * solid block cells using the source artwork's colors.
+ */
+export const ORBITAL_MARK = [
+  "    ooooo",
+  "  ooooooooo",
+  "oooooiiiooooo",
+  "oiiiiwwwwiiii",
+  " oiiwwwwwwiio",
+  "   oiwwwwio",
+] as const;

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -15,13 +15,19 @@ import {
 } from "../tools/index.js"
 import { walkFiles } from "../tools/executors/listFiles.js"
 import { previewFileChange } from "../tools/executors/files.js"
-import type { AgentCallbacks, ApprovalDecision } from "./events.js"
-import { getSessionFilePath, saveSession, type SessionData } from "./sessions.js"
+import type { AgentCallbacks, AgentEvent, ApprovalDecision } from "./events.js"
+import {
+	getSessionFilePath,
+	saveSession,
+	type SessionData,
+	type SessionTranscriptEntry,
+} from "./sessions.js"
 import { HookRunner, type HooksConfig } from "./hooks.js"
 import { McpManager } from "../mcp/manager.js"
 import { loadMemoryFiles } from "../memory/loader.js"
 import { loadSkills } from "../skills/loader.js"
 import { renderLinkedReposSection } from "../config/links.js"
+import { unifiedDiff } from "../utils/diff.js"
 
 const MAX_STEPS_PER_TURN = 50
 const RESULT_PREVIEW_LINES = 6
@@ -142,11 +148,159 @@ function wrapHookContext(source: string, text: string): string {
 	return `<hook_context source="${source}">\n${text}\n</hook_context>`
 }
 
+function contentToText(content: unknown): string {
+	if (typeof content === "string") return content
+	if (!Array.isArray(content)) return ""
+	return content
+		.map((part) =>
+			part && typeof part === "object" && "text" in part
+				? String((part as { text?: unknown }).text ?? "")
+				: "",
+		)
+		.join("")
+}
+
+function resultPreview(text: string): string {
+	const lines = text.split("\n")
+	return (
+		lines.slice(0, RESULT_PREVIEW_LINES).join("\n") +
+		(lines.length > RESULT_PREVIEW_LINES ? `\n… (${lines.length} lines)` : "")
+	)
+}
+
+/**
+ * Sessions written before display transcripts did not store the full-file diff
+ * produced immediately before an edit. The requested old/new fragments are
+ * still present in the tool arguments, so use those as an honest best-effort
+ * fallback instead of dropping the diff entirely.
+ */
+function legacyEditDiff(toolName: string, args: Record<string, unknown>): string | undefined {
+	const fragment = (filePath: string, oldText: string, newText: string, label: string): string | undefined => {
+		const diff = unifiedDiff(oldText, newText)
+		return diff ? `${filePath} (${label})\n${diff}` : undefined
+	}
+
+	if (toolName === "file_edit") {
+		return fragment(
+			String(args.file_path ?? "unknown file"),
+			String(args.old_string ?? ""),
+			String(args.new_string ?? ""),
+			"restored edit fragment",
+		)
+	}
+
+	if (toolName === "file_write") {
+		return fragment(
+			String(args.file_path ?? "unknown file"),
+			"",
+			String(args.content ?? ""),
+			"restored write; previous contents unavailable",
+		)
+	}
+
+	if (toolName === "multi_file_edit") {
+		const parts = (Array.isArray(args.edits) ? args.edits : []).flatMap((value) => {
+			if (!value || typeof value !== "object") return []
+			const edit = value as Record<string, unknown>
+			const diff = fragment(
+				String(edit.file_path ?? "unknown file"),
+				String(edit.old_string ?? ""),
+				String(edit.new_string ?? ""),
+				"restored edit fragment",
+			)
+			return diff ? [diff] : []
+		})
+		return parts.length > 0 ? parts.join("\n") : undefined
+	}
+
+	return undefined
+}
+
+/** Best-effort visible history for sessions written before `transcript`. */
+function legacyTranscript(messages: OpenAI.Chat.ChatCompletionMessageParam[]): SessionTranscriptEntry[] {
+	const entries: SessionTranscriptEntry[] = []
+	const pendingTools = new Map<
+		string,
+		{ name: string; summary: string; diff?: string }
+	>()
+
+	for (const message of messages) {
+		if (message.role === "user") {
+			const text = contentToText(message.content)
+			const match = /<user_query>\n?([\s\S]*?)\n?<\/user_query>/.exec(text)
+			if (match) entries.push({ kind: "user", text: match[1] })
+			continue
+		}
+
+		if (message.role === "assistant") {
+			const details = (message as unknown as Record<string, unknown>)[REASONING_DETAILS_FIELD]
+			if (Array.isArray(details)) {
+				const reasoning = details
+					.map((part) =>
+						part && typeof part === "object" && "text" in part
+							? String((part as { text?: unknown }).text ?? "")
+							: "",
+					)
+					.join("")
+				if (reasoning.trim()) entries.push({ kind: "reasoning", text: reasoning, durationMs: 0 })
+			}
+
+			const text = contentToText(message.content)
+			if (text.trim()) entries.push({ kind: "assistant", text })
+			for (const call of message.tool_calls ?? []) {
+				if (call.type !== "function") continue
+				let args: Record<string, unknown> = {}
+				try {
+					args = JSON.parse(call.function.arguments || "{}") as Record<string, unknown>
+				} catch {
+					// Keep an empty argument object; the call name is still useful history.
+				}
+				if (call.function.name === "attempt_completion") {
+					entries.push({ kind: "completion", text: String(args.result ?? "") })
+					continue
+				}
+				pendingTools.set(call.id, {
+					name: call.function.name,
+					summary: describeToolCall(call.function.name, args),
+					diff: legacyEditDiff(call.function.name, args),
+				})
+			}
+			continue
+		}
+
+		if (message.role === "tool") {
+			const tool = pendingTools.get(message.tool_call_id)
+			if (!tool) continue
+			pendingTools.delete(message.tool_call_id)
+			const text = contentToText(message.content)
+			if (tool.name === "ask_followup_question") {
+				const answer = /<answer>\n?([\s\S]*?)\n?<\/answer>/.exec(text)?.[1]
+				if (answer) entries.push({ kind: "user", text: answer })
+				continue
+			}
+			const isError = /^(error|failed|tool error|the user denied)\b/i.test(text.trim())
+			entries.push({
+				kind: "tool",
+				name: tool.name,
+				summary: tool.summary,
+				resultPreview: resultPreview(text),
+				isError,
+				diff: isError ? undefined : tool.diff,
+			})
+		}
+	}
+
+	return entries
+}
+
 export class Agent {
 	private options: AgentOptions
 	private client: LLMClient
 	private systemPrompt: string
 	private messages: OpenAI.Chat.ChatCompletionMessageParam[] = []
+	private transcript: SessionTranscriptEntry[] = []
+	private transcriptReasoning = ""
+	private transcriptText = ""
 	private todos = ""
 	private firstMessageSent = false
 	private sessionApproveEdits: boolean
@@ -175,7 +329,20 @@ export class Agent {
 	readonly taskId: string
 
 	constructor(options: AgentOptions) {
-		this.options = options
+		this.transcript = options.resume?.transcript
+			? options.resume.transcript.map((entry) => ({ ...entry }))
+			: legacyTranscript(options.resume?.messages ?? [])
+		const onEvent = options.callbacks.onEvent
+		this.options = {
+			...options,
+			callbacks: {
+				...options.callbacks,
+				onEvent: (event) => {
+					this.recordTranscriptEvent(event)
+					onEvent(event)
+				},
+			},
+		}
 		this.taskId = options.resume?.id ?? randomUUID()
 		this.hooks = new HookRunner({
 			cwd: options.cwd,
@@ -183,7 +350,7 @@ export class Agent {
 			transcriptPath: getSessionFilePath(this.taskId),
 			config: options.hooks,
 			onSystemMessage: (message, isError) =>
-				options.callbacks.onEvent({ type: "system", message, isError }),
+				this.options.callbacks.onEvent({ type: "system", message, isError }),
 			getSignal: () => this.abortController?.signal,
 		})
 		if (options.resume) {
@@ -242,6 +409,78 @@ export class Agent {
 		return this.contextTokens
 	}
 
+	/** Visible history restored by the TUI, including reasoning and tools. */
+	get displayTranscript(): SessionTranscriptEntry[] {
+		return this.transcript.map((entry) => ({ ...entry }))
+	}
+
+	private recordTranscriptEvent(event: AgentEvent): void {
+		switch (event.type) {
+			case "reasoning-delta":
+				this.transcriptReasoning += event.text
+				break
+			case "reasoning-done":
+				if (this.transcriptReasoning) {
+					this.transcript.push({
+						kind: "reasoning",
+						text: this.transcriptReasoning,
+						durationMs: event.durationMs,
+					})
+				}
+				this.transcriptReasoning = ""
+				break
+			case "text-delta":
+				this.transcriptText += event.text
+				break
+			case "text-done":
+				if (this.transcriptText) {
+					this.transcript.push({ kind: "assistant", text: this.transcriptText })
+				}
+				this.transcriptText = ""
+				break
+			case "stream-reset":
+				this.transcriptReasoning = ""
+				this.transcriptText = ""
+				break
+			case "tool-end":
+				this.transcript.push({
+					kind: "tool",
+					name: event.name,
+					summary: event.summary,
+					resultPreview: event.resultPreview,
+					isError: event.isError,
+					diff: event.diff,
+				})
+				break
+			case "completion":
+				this.transcript.push({ kind: "completion", text: event.result })
+				break
+			case "system":
+				this.transcript.push({
+					kind: event.isError ? "error" : "info",
+					text: event.message,
+				})
+				break
+			case "error":
+				this.transcript.push({ kind: "error", text: event.message })
+				break
+			case "turn-end":
+				if (this.transcriptText) {
+					this.transcript.push({ kind: "assistant", text: this.transcriptText })
+					this.transcriptText = ""
+				}
+				if (this.transcriptReasoning) {
+					this.transcript.push({
+						kind: "reasoning",
+						text: this.transcriptReasoning,
+						durationMs: 0,
+					})
+					this.transcriptReasoning = ""
+				}
+				break
+		}
+	}
+
 	/** Replace the prompt-derived title with the backend-generated one. */
 	setTitle(title: string): void {
 		this.title = title
@@ -264,6 +503,9 @@ export class Agent {
 
 	clear(): void {
 		this.messages = []
+		this.transcript = []
+		this.transcriptReasoning = ""
+		this.transcriptText = ""
 		this.todos = ""
 		this.firstMessageSent = false
 		this.totalCost = 0
@@ -289,6 +531,7 @@ export class Agent {
 				contextTokens: this.contextTokens,
 				todos: this.todos,
 				messages: this.messages,
+				transcript: this.transcript,
 			})
 		} catch {
 			// persistence is best-effort; never break the session over it
@@ -350,6 +593,7 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 	async runTurn(userText: string): Promise<void> {
 		const { onEvent } = this.options.callbacks
 		this.abortController = new AbortController()
+		this.transcript.push({ kind: "user", text: userText })
 
 		await this.maybeFireSessionStart()
 
@@ -410,6 +654,7 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 			}
 		} finally {
 			this.abortController = undefined
+			this.recordTranscriptEvent({ type: "turn-end" })
 			this.persist()
 			onEvent({ type: "turn-end" })
 		}
@@ -564,6 +809,7 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 			}
 		} finally {
 			this.abortController = undefined
+			this.recordTranscriptEvent({ type: "turn-end" })
 			this.persist()
 			onEvent({ type: "turn-end" })
 		}
@@ -786,6 +1032,7 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 				}))
 			}
 			const answer = await requestFollowup(question, suggestions)
+			this.transcript.push({ kind: "user", text: answer })
 			return `<answer>\n${answer}\n</answer>`
 		}
 

--- a/src/core/sessions.ts
+++ b/src/core/sessions.ts
@@ -4,6 +4,22 @@ import type OpenAI from "openai"
 
 import { getConfigDir } from "../config/settings.js"
 
+export type SessionTranscriptEntry =
+	| { kind: "user"; text: string }
+	| { kind: "assistant"; text: string }
+	| { kind: "reasoning"; text: string; durationMs: number }
+	| {
+			kind: "tool"
+			name: string
+			summary: string
+			resultPreview: string
+			isError: boolean
+			diff?: string
+	  }
+	| { kind: "info"; text: string }
+	| { kind: "error"; text: string }
+	| { kind: "completion"; text: string }
+
 export interface SessionData {
 	id: string
 	cwd: string
@@ -21,6 +37,8 @@ export interface SessionData {
 	contextTokens: number
 	todos: string
 	messages: OpenAI.Chat.ChatCompletionMessageParam[]
+	/** Exact visible TUI history. Optional for sessions written before v0.4.2. */
+	transcript?: SessionTranscriptEntry[]
 }
 
 const MAX_SESSIONS_LISTED = 25

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { render } from "ink"
 
-import { PRODUCT_NAME, VERSION } from "./branding.js"
+import { COLORS, PRODUCT_NAME, VERSION } from "./branding.js"
 import { App } from "./ui/App.js"
 import { runHeadless } from "./headless.js"
 import { runMcpCommand } from "./commands/mcp.js"
@@ -17,6 +17,86 @@ import {
 } from "./utils/updateCheck.js"
 
 const PACKAGE_NAME = "@matterailab/orbcode"
+const INK_CLEAR_TERMINAL = "\x1b[2J\x1b[3J\x1b[H"
+const BEGIN_SYNCHRONIZED_UPDATE = "\x1b[?2026h"
+const END_SYNCHRONIZED_UPDATE = "\x1b[?2026l"
+// Match OpenTUI's mouse capture: button events, drag events, all movement,
+// and SGR coordinates. Capturing all four modes prevents the terminal itself
+// from interpreting a wheel/trackpad gesture as scrollback navigation.
+const ENABLE_MOUSE_TRACKING = "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h"
+const DISABLE_MOUSE_TRACKING = "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l"
+
+function terminalRows(stdout: NodeJS.WriteStream): number {
+	return stdout.rows ?? process.stderr.rows ?? 24
+}
+
+function terminalColumns(stdout: NodeJS.WriteStream): number {
+	return stdout.columns ?? process.stderr.columns ?? 80
+}
+
+/**
+ * Ink normally serializes a frame as newline-delimited text. Even when the
+ * frame is terminal-height, some terminals can treat those linefeeds as
+ * scrollable output. OpenTUI avoids that class of bug by drawing at explicit
+ * screen coordinates. This adapter keeps Ink's real dimensions/event stream,
+ * but converts every full redraw into cursor-addressed rows with no linefeeds.
+ */
+function createFullscreenStdout(stdout: NodeJS.WriteStream): NodeJS.WriteStream {
+	let previousLines: string[] = []
+	let previousRows = 0
+
+	const writeFrame = (frame: string): boolean => {
+		const rows = Math.max(1, terminalRows(stdout))
+		const lines = frame.split("\n").slice(0, rows)
+		while (lines.length < rows) lines.push("")
+		if (rows !== previousRows) previousLines = []
+
+		let output = BEGIN_SYNCHRONIZED_UPDATE
+		// Do not clear the display here. Several terminals preserve each ED 2
+		// operation as scrollback even in the alternate buffer. OpenTUI keeps a
+		// retained screen and replaces cells in place; replacing every row with
+		// EL 2 gives Ink the same behavior and cannot advance terminal history.
+		let changed = false
+		for (let row = 0; row < rows; row++) {
+			if (lines[row] === previousLines[row]) continue
+			changed = true
+			output += `\x1b[${row + 1};1H\x1b[2K${lines[row]}`
+		}
+		previousLines = lines
+		previousRows = rows
+		if (!changed) return true
+		output += END_SYNCHRONIZED_UPDATE
+		return stdout.write(output)
+	}
+
+	return new Proxy(stdout, {
+		get(target, property) {
+			// Ink uses these properties to choose its renderer and compute layout.
+			// Integrated terminal wrappers do not always expose them on stdout even
+			// though stdin/stderr are attached to the same interactive terminal.
+			if (property === "rows") return terminalRows(stdout)
+			if (property === "columns") return terminalColumns(stdout)
+			if (property === "isTTY") return true
+			if (property === "write") {
+				return (
+					chunk: string | Uint8Array,
+					encoding?: BufferEncoding | ((error?: Error | null) => void),
+					callback?: (error?: Error | null) => void,
+				) => {
+					if (typeof chunk === "string" && chunk.startsWith(INK_CLEAR_TERMINAL)) {
+						const written = writeFrame(chunk.slice(INK_CLEAR_TERMINAL.length))
+						const done = typeof encoding === "function" ? encoding : callback
+						if (done) process.nextTick(done)
+						return written
+					}
+					return stdout.write(chunk, encoding as BufferEncoding, callback)
+				}
+			}
+			const value = Reflect.get(target, property, target) as unknown
+			return typeof value === "function" ? value.bind(target) : value
+		},
+	})
+}
 
 function printHelp(): void {
 	console.log(`${PRODUCT_NAME} v${VERSION}
@@ -183,12 +263,46 @@ async function main(): Promise<void> {
 	// Any other bare argument starts the TUI with that text as the first prompt.
 	const initialPrompt = initialView ? undefined : args.find((a) => !a.startsWith("-"))
 
-	// Take over the full terminal: clear the visible screen and home the cursor
-	// so the TUI always starts at the top (prior output stays in scrollback).
-	if (process.stdout.isTTY) {
-		process.stdout.write("\x1b[2J\x1b[H")
+	// OpenTUI treats its TUI command as a terminal application regardless of
+	// stdout.isTTY. Some integrated/wrapped terminals expose TTY only on stdin
+	// or stderr; gating on stdout alone leaves the app in the primary buffer.
+	const isInteractiveTerminal = Boolean(
+		process.stdin.isTTY || process.stdout.isTTY || process.stderr.isTTY,
+	)
+
+	// Take over the full terminal as an independent surface:
+	//   1. Enter the alternate screen buffer (\x1b[?1049h) so the TUI owns
+	//      the full terminal and prior output stays untouched in the primary
+	//      buffer — the terminal scrollback is not affected.
+	//   2. Set default foreground / background via OSC 10/11 to our greyscale
+	//      palette so text without an explicit color prop still follows the
+	//      theme instead of falling back to the terminal's default colors.
+	// OpenTUI relies on 1049 to create the clean alternate buffer and then
+	// updates retained rows; do not issue ED 2 here because some terminals save
+	// cleared displays into history even while switching buffers.
+	if (isInteractiveTerminal) {
+		process.stdout.write("\x1b[?25l\x1b[s\x1b[?1049h")
+		process.stdout.write(`\x1b]10;${COLORS.primary}\x07`)
+		process.stdout.write(`\x1b]11;${COLORS.bg}\x07`)
+		process.stdout.write(ENABLE_MOUSE_TRACKING)
 		process.stdout.write("\x1b]0;orbcode\x07")
 	}
+
+	// Restore the terminal on exit: reset default colors and leave the
+	// alternate screen buffer so the user's prior terminal state is restored.
+	function restoreTerminal(): void {
+		if (isInteractiveTerminal && process.stdout.writable) {
+			process.stdout.write(DISABLE_MOUSE_TRACKING)
+			process.stdout.write("\x1b]110\x07")
+			process.stdout.write("\x1b]111\x07")
+			process.stdout.write("\x1b[?1049l")
+		}
+	}
+	process.on("exit", restoreTerminal)
+	const fullscreenStdout = isInteractiveTerminal
+		? createFullscreenStdout(process.stdout)
+		: process.stdout
+
 	// Fire-and-forget: a stale or no-network state just means the header shows
 	// the "current version" line instead of an upgrade prompt.
 	const updateCheckPromise = getUpdateInfo(PACKAGE_NAME, VERSION)
@@ -200,6 +314,7 @@ async function main(): Promise<void> {
 			systemPromptOverride={systemPromptOverride}
 			updateCheck={updateCheckPromise}
 		/>,
+		{ stdout: fullscreenStdout },
 	)
 }
 

--- a/src/mcp/auth.ts
+++ b/src/mcp/auth.ts
@@ -232,7 +232,7 @@ function callbackPage(kind: "success" | "error" | "not-found", detail?: string):
 			? "This page was not found."
 			: detail ?? "An unexpected error occurred during authentication."
 	const icon = isSuccess ? "&#10003;" : "&#10007;"
-	const accent = isSuccess ? "#43df94" : "#e86464"
+	const accent = isSuccess ? "#3FA266" : "#E34671"
 
 	return `<!DOCTYPE html>
 <html lang="en">

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -9,7 +9,13 @@ import { Box, Text, useApp, useInput, useStdout } from "ink";
 import open from "open";
 import * as path from "node:path";
 
-import { COLORS, VERSION } from "../branding.js";
+import {
+  COLORS,
+  ORBITAL_MARK,
+  PRODUCT_NAME,
+  TAGLINE,
+  VERSION,
+} from "../branding.js";
 import {
   BUILTIN_AXON_MODELS,
   getModel,
@@ -53,8 +59,14 @@ import { StatusBar, type ApprovalMode } from "./components/StatusBar.js";
 import { ModelPicker } from "./components/ModelPicker.js";
 import { SessionPicker } from "./components/SessionPicker.js";
 import { listSessions, type SessionData } from "../core/sessions.js";
-import { RowView, type Row } from "./components/rows.js";
+import {
+  formatToolName,
+  formatUserBlock,
+  RowView,
+  type Row,
+} from "./components/rows.js";
 import { LinkManager } from "./components/LinkManager.js";
+import { isMouseInput, mouseScrollDelta } from "./terminal.js";
 import {
   addLink,
   loadLinks,
@@ -117,6 +129,12 @@ const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/version", description: "show the OrbCode CLI version" },
   { name: "/exit", description: "quit OrbCode CLI" },
 ];
+
+const WHEEL_SCROLL_LINES = 3;
+const SCROLL_FRAME_MS = 32;
+const SCROLL_MAX_PENDING_LINES = 24;
+const EXIT_CONFIRM_TIMEOUT_MS = 3000;
+const INTRO_TOP_MARGIN = 2;
 
 function setTerminalTitle(title: string): void {
   if (process.stdout.isTTY) {
@@ -308,8 +326,23 @@ export function App({
 }) {
   const { exit } = useApp();
   const { stdout } = useStdout();
-  const termRows = stdout?.rows ?? 24;
-  const termCols = stdout?.columns ?? 80;
+  // A frame exactly as tall as the real terminal makes Ink use its
+  // clear-and-redraw path instead of log-update's newline-based rendering.
+  // Keep these values tied to the real stream so resize cannot break that
+  // invariant or move the prompt out of the viewport.
+  const [termRows, setTermRows] = useState(() => stdout?.rows ?? 24);
+  const [termCols, setTermCols] = useState(() => stdout?.columns ?? 80);
+
+  useEffect(() => {
+    const onResize = () => {
+      setTermRows(stdout?.rows ?? 24);
+      setTermCols(stdout?.columns ?? 80);
+    };
+    // Ink also listens for resize. Run our state update first so it never
+    // redraws an old, taller frame into an already-shrunken terminal.
+    stdout?.prependListener("resize", onResize);
+    return () => { stdout?.off("resize", onResize); };
+  }, [stdout]);
   const [settings, setSettings] = useState<OrbCodeSettings>(() =>
     loadSettings(),
   );
@@ -328,8 +361,14 @@ export function App({
   ]);
   const [busy, setBusy] = useState(false);
   const [busyLabel, setBusyLabel] = useState("Thinking");
+  const [exitConfirmationActive, setExitConfirmationActive] = useState(false);
   const [streamingReasoning, setStreamingReasoning] = useState("");
   const [streamingText, setStreamingText] = useState("");
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const smoothScrollPendingRef = useRef(0);
+  const smoothScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const [pendingApproval, setPendingApproval] =
     useState<PendingApproval | null>(null);
   const [pendingFollowup, setPendingFollowup] =
@@ -412,6 +451,10 @@ export function App({
   const deferredPromptRef = useRef<string | null>(null);
   // Guards endAndExit against double-invocation (Ctrl+D spam).
   const exitingRef = useRef(false);
+  const exitConfirmationRef = useRef(false);
+  const exitConfirmationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   // Mirror of the `-s` override so a fresh agent (created mid-session via
   // /new or /resume) keeps the override instead of falling back to default.
   const systemPromptOverrideRef = useRef<string | undefined>(systemPromptOverride);
@@ -434,6 +477,55 @@ export function App({
     setQueuedMessages([]);
   }, []);
 
+  const scrollTranscriptBy = useCallback((lines: number) => {
+    setScrollOffset((current) => Math.max(0, current + lines));
+  }, []);
+
+  const flushWheelScroll = useCallback(() => {
+    const pending = smoothScrollPendingRef.current;
+    smoothScrollPendingRef.current = 0;
+    if (pending !== 0) scrollTranscriptBy(pending);
+
+    // Ink paints at roughly 30 fps. Hold further wheel events until its next
+    // frame, then apply all of them in one state/layout update.
+    smoothScrollTimerRef.current = setTimeout(() => {
+      smoothScrollTimerRef.current = null;
+      if (smoothScrollPendingRef.current !== 0) flushWheelScroll();
+    }, SCROLL_FRAME_MS);
+  }, [scrollTranscriptBy]);
+
+  const queueSmoothScroll = useCallback(
+    (lines: number) => {
+      const pending = smoothScrollPendingRef.current;
+      // A direction reversal should respond immediately instead of first
+      // draining momentum left over from the previous gesture.
+      const next =
+        pending !== 0 && Math.sign(pending) !== Math.sign(lines)
+          ? lines
+          : pending + lines;
+      smoothScrollPendingRef.current = Math.max(
+        -SCROLL_MAX_PENDING_LINES,
+        Math.min(SCROLL_MAX_PENDING_LINES, next),
+      );
+      if (smoothScrollTimerRef.current === null) {
+        flushWheelScroll();
+      }
+    },
+    [flushWheelScroll],
+  );
+
+  useEffect(
+    () => () => {
+      if (smoothScrollTimerRef.current !== null) {
+        clearTimeout(smoothScrollTimerRef.current);
+      }
+      if (exitConfirmationTimerRef.current !== null) {
+        clearTimeout(exitConfirmationTimerRef.current);
+      }
+    },
+    [],
+  );
+
   const maybeFetchTitle = useCallback(() => {
     const agent = agentRef.current;
     if (!agent || titleTaskRef.current === agent.taskId) return;
@@ -453,12 +545,12 @@ export function App({
     setRows((prev) => [...prev, { ...row, id: rowId() } as Row]);
   }, []);
 
-  // Wipe the visible transcript and remount <Static> with just the header —
-  // a clean slate for /clear, /new and /resume.
+  // Wipe the visible transcript — a clean slate for /clear, /new and /resume.
+  // No manual screen clear is needed because the root always renders one
+  // complete terminal-height frame.
   const resetTranscript = useCallback(() => {
-    if (process.stdout.isTTY) {
-      process.stdout.write("\x1b[2J\x1b[H");
-    }
+    smoothScrollPendingRef.current = 0;
+    setScrollOffset(0);
     setRows([
       {
         kind: "header",
@@ -1001,6 +1093,8 @@ export function App({
 
   const handleSubmit = useCallback(
     (value: string) => {
+      smoothScrollPendingRef.current = 0;
+      setScrollOffset(0);
       if (value.startsWith("/")) {
         handleCommand(value);
         return;
@@ -1224,11 +1318,45 @@ export function App({
   }, [updateCheck]);
 
   useInput((input, key) => {
-    // Ctrl+D quits from any view (chat, login, busy, picker, approval,
-    // followup). InputBox swallows other Ctrl-combos, but this hook is a
-    // sibling of InputBox's hook, so it still sees the key.
+    const wheelDelta = mouseScrollDelta(input);
+    if (wheelDelta !== 0) {
+      if (view === "chat") {
+        queueSmoothScroll(wheelDelta * WHEEL_SCROLL_LINES);
+      }
+      return;
+    }
+    if (isMouseInput(input)) return;
+    if (view === "chat" && key.pageUp) {
+      smoothScrollPendingRef.current = 0;
+      scrollTranscriptBy(Math.max(1, contentHeight - 2));
+      return;
+    }
+    if (view === "chat" && key.pageDown) {
+      smoothScrollPendingRef.current = 0;
+      scrollTranscriptBy(-Math.max(1, contentHeight - 2));
+      return;
+    }
+    // Require two presses so an accidental Ctrl+D cannot discard the session.
+    // The ref makes rapid repeated presses reliable before React re-renders.
     if (key.ctrl && input === "d") {
-      endAndExit("prompt_input_exit");
+      if (exitConfirmationRef.current) {
+        exitConfirmationRef.current = false;
+        setExitConfirmationActive(false);
+        if (exitConfirmationTimerRef.current !== null) {
+          clearTimeout(exitConfirmationTimerRef.current);
+          exitConfirmationTimerRef.current = null;
+        }
+        endAndExit("prompt_input_exit");
+      } else {
+        exitConfirmationRef.current = true;
+        setExitConfirmationActive(true);
+        exitConfirmationTimerRef.current = setTimeout(() => {
+          exitConfirmationRef.current = false;
+          exitConfirmationTimerRef.current = null;
+          setExitConfirmationActive(false);
+        }, EXIT_CONFIRM_TIMEOUT_MS);
+        exitConfirmationTimerRef.current.unref?.();
+      }
       return;
     }
     if (key.escape && busy && !pendingApproval && !pendingFollowup) {
@@ -1258,15 +1386,13 @@ export function App({
       const expanded = !expandReasoningRef.current;
       expandReasoningRef.current = expanded;
       // Re-render the whole transcript (including past thinking) with the
-      // new expansion state: clear the screen and remount <Static>.
+      // new expansion state.
       setRows((prev) =>
         prev.map((row) =>
           row.kind === "reasoning" ? { ...row, expanded } : row,
         ),
       );
-      if (process.stdout.isTTY) {
-        process.stdout.write("\x1b[2J\x1b[H");
-      }
+      // The terminal adapter replaces the retained screen rows in place.
     }
   });
 
@@ -1319,12 +1445,51 @@ export function App({
   // only show the rows that fit above the pinned input box + status bar.
   // This keeps the input box always at the bottom of the terminal.
 
-  // Height of the fixed bottom chrome (input box border + text + status bar +
-  // margins). Intentionally slightly overestimated so we never push the
-  // input box off-screen.
-  let bottomHeight = 8;
-  if (queuedMessages.length > 0)
-    bottomHeight += 2 + Math.min(5, queuedMessages.length);
+  // This is only used for scroll-range/page-size calculations. Layout itself
+  // is handled by flexbox below: the transcript shrinks while this bottom
+  // region never does, which is what actually pins the prompt to the bottom.
+  const hasUsageLine = Boolean(
+    usage?.tieredUsage?.fiveHour ||
+    usage?.tieredUsage?.weekly ||
+    usage?.tieredUsage?.monthly,
+  );
+  let bottomControlsHeight = 4 + (hasUsageLine ? 1 : 0);
+  if (queuedMessages.length > 0) {
+    bottomControlsHeight +=
+      2 + Math.min(5, queuedMessages.length) +
+      (queuedMessages.length > 5 ? 1 : 0);
+  }
+
+  const contentHeight = Math.max(1, termRows - bottomControlsHeight);
+  const wrapWidth = Math.max(20, termCols - 4);
+
+  const rowLayout = useMemo(() => {
+    let top = 0;
+    const items = rows.map((row) => {
+      const height = Math.max(1, estimateRowLines(row, wrapWidth));
+      const item = { row, top, bottom: top + height };
+      top += height;
+      return item;
+    });
+    return { items, height: top };
+  }, [rows, wrapWidth]);
+  const rowsHeight = rowLayout.height;
+
+  let dynamicHeight = 0;
+  if (updateInfo?.updateAvailable && updateInfo.latest) dynamicHeight += 6;
+  const reasoningWrapWidth = Math.max(20, wrapWidth - 2);
+  const streamingReasoningDisplay = streamingReasoning
+    ? tailForHeight(streamingReasoning, 3, reasoningWrapWidth)
+    : "";
+  if (streamingReasoning) {
+    dynamicHeight +=
+      2 + wrapHeight(streamingReasoningDisplay, reasoningWrapWidth);
+  }
+  if (streamingText) {
+    dynamicHeight += 1 + wrapHeight(`● ${streamingText}`, wrapWidth);
+  }
+  if (taskLines.length > 0)
+    dynamicHeight += 2 + Math.min(10, taskLines.length);
   if (
     pendingApproval ||
     pendingFollowup ||
@@ -1337,273 +1502,302 @@ export function App({
     taskPickerSessions ||
     linkManagerOpen
   )
-    bottomHeight += 10;
+    dynamicHeight += 10;
+  if (busy && !streamingText && !streamingReasoning) dynamicHeight += 2;
 
-  // Height of the middle dynamic elements (between rows and input box).
-  let middleHeight = 0;
-  if (streamingReasoning) middleHeight += 4;
-  if (taskLines.length > 0)
-    middleHeight += 1 + Math.min(10, taskLines.length);
-  if (busy && !streamingText && !streamingReasoning) middleHeight += 1;
-  if (updateInfo?.updateAvailable && updateInfo.latest) middleHeight += 4;
+  const transcriptHeight = Math.max(1, rowsHeight + dynamicHeight);
+  const maxScrollOffset = Math.max(0, transcriptHeight - contentHeight);
+  const effectiveScrollOffset = Math.min(scrollOffset, maxScrollOffset);
+  const introHeaderOnly = rows.length === 1 && rows[0]?.kind === "header";
+  const transcriptMarginTop = introHeaderOnly
+    ? INTRO_TOP_MARGIN
+    : transcriptHeight <= contentHeight
+      ? contentHeight - transcriptHeight
+      : -(maxScrollOffset - effectiveScrollOffset);
 
-  // Available height for committed rows + streaming text.
-  const availableHeight = Math.max(3, termRows - bottomHeight - middleHeight);
-
-  // Estimate how many terminal lines a row will occupy.
-  const wrapWidth = Math.max(20, termCols - 4);
-  const visibleRows = useMemo(() => {
-    let used = 0;
-    let start = rows.length;
-    for (let i = rows.length - 1; i >= 0; i--) {
-      const h = estimateRowLines(rows[i], wrapWidth);
-      if (used + h > availableHeight) break;
-      used += h;
-      start = i;
+  const viewportTop =
+    !introHeaderOnly && transcriptHeight > contentHeight
+      ? maxScrollOffset - effectiveScrollOffset
+      : 0;
+  const virtualRows = useMemo(() => {
+    const items = rowLayout.items;
+    if (items.length === 0) {
+      return { rows: [] as Row[], startY: 0, endY: 0 };
     }
-    return rows.slice(start);
-  }, [rows, availableHeight, wrapWidth]);
+    if (introHeaderOnly || transcriptHeight <= contentHeight) {
+      return {
+        rows: items.map((item) => item.row),
+        startY: 0,
+        endY: rowsHeight,
+      };
+    }
 
-  // Cap streaming text to the space left after committed rows.
-  const rowsHeight = useMemo(
-    () => visibleRows.reduce((s, r) => s + estimateRowLines(r, wrapWidth), 0),
-    [visibleRows, wrapWidth],
-  );
-  const streamingMaxLines = Math.max(3, availableHeight - rowsHeight);
-  const streamingDisplay = streamingText
-    ? tailForHeight(streamingText, streamingMaxLines, wrapWidth)
-    : "";
-  const streamingReasoningDisplay = streamingReasoning
-    ? tailForHeight(streamingReasoning, 3, wrapWidth)
-    : "";
+    // Keep a full viewport mounted on either side. The overscan hides small
+    // differences between estimated wrapped heights and Yoga's final layout.
+    const from = Math.max(0, viewportTop - contentHeight);
+    const to = Math.min(rowsHeight, viewportTop + contentHeight * 2);
 
-  // Spacer to push the input box to the bottom when content is short.
-  const streamingHeight = streamingDisplay
-    ? Math.min(streamingMaxLines, wrapHeight(streamingDisplay, wrapWidth))
-    : 0;
-  const spacerHeight = Math.max(
-    0,
-    availableHeight - rowsHeight - streamingHeight,
-  );
+    let low = 0;
+    let high = items.length;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (items[mid]!.bottom <= from) low = mid + 1;
+      else high = mid;
+    }
+    const start = low;
 
+    low = start;
+    high = items.length;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (items[mid]!.top < to) low = mid + 1;
+      else high = mid;
+    }
+    const end = low;
+    const startY = items[start]?.top ?? rowsHeight;
+    const endY = end > start ? items[end - 1]!.bottom : startY;
+
+    return {
+      rows: items.slice(start, end).map((item) => item.row),
+      startY,
+      endY,
+    };
+  }, [contentHeight, introHeaderOnly, rowLayout, rowsHeight, transcriptHeight, viewportTop]);
+  const virtualTranscriptMarginTop =
+    transcriptMarginTop + virtualRows.startY;
+  const rowBottomSpacerHeight = Math.max(0, rowsHeight - virtualRows.endY);
+
+  useEffect(() => {
+    setScrollOffset((current) => Math.min(current, maxScrollOffset));
+  }, [maxScrollOffset]);
+
+  // The root is exactly one terminal tall. Ink sees outputHeight >=
+  // stdout.rows and clears/redraws in place on every frame, so no render can
+  // append to terminal scrollback. Only the transcript is clipped/translated;
+  // the prompt and status region never shrink or leave the viewport.
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width={termCols} height={termRows} paddingX={2} overflow="hidden">
       {view === "login" ? (
         <LoginSection onLogin={handleLogin} />
       ) : (
-        <Box flexDirection="column">
-          {visibleRows.map((row) => (
-            <RowView key={row.id} row={row} />
-          ))}
-          {updateInfo?.updateAvailable && updateInfo.latest && (
-            <Box
-              marginTop={1}
-              flexDirection="column"
-              borderStyle="round"
-              borderColor={COLORS.warning}
-              paddingX={2}
-              alignSelf="flex-start"
-            >
-              <Text color={COLORS.warning} bold>
-                ↑ Update available: v{updateInfo.current} → v{updateInfo.latest}
-              </Text>
-              <Text>
-                Run <Text color={COLORS.accent}>orbcode update</Text> to install
-                the latest version, then relaunch.
-              </Text>
-            </Box>
-          )}
-          {streamingReasoning && (
-            <Box flexDirection="column" marginTop={1}>
-              <Text color={COLORS.thinking} italic>
-                ✦ Thinking…
-              </Text>
-              <Box paddingLeft={2}>
-                <Text dimColor italic>
-                  {streamingReasoningDisplay}
-                </Text>
-              </Box>
-            </Box>
-          )}
-          {streamingDisplay && (
-            <Box marginTop={1}>
-              <Text>
-                <Text color={COLORS.primary}>● </Text>
-                {streamingDisplay}
-              </Text>
-            </Box>
-          )}
-          {spacerHeight > 0 && <Box height={spacerHeight} />}
-          {taskLines.length > 0 && (
-            <Box flexDirection="column" marginTop={1} paddingLeft={1}>
-              <Text dimColor bold>
-                Tasks
-              </Text>
-              {taskLines.slice(0, 10).map((line, i) => (
-                <Text key={i} dimColor={/^[-*]\s*\[x\]/i.test(line)}>
-                  {line
-                    .replace(/^[-*]\s*\[x\]/i, "  ■")
-                    .replace(/^[-*]\s*\[-\]/, "  ◧")
-                    .replace(/^[-*]\s*\[ \]/, "  □")}
-                </Text>
+        <Box flexDirection="column" flexGrow={1} minHeight={0} overflow="hidden">
+          <Box flexDirection="column" flexGrow={1} flexShrink={1} minHeight={0} overflow="hidden">
+            <Box flexDirection="column" flexShrink={0} marginTop={virtualTranscriptMarginTop}>
+              {virtualRows.rows.map((row) => (
+                <RowView key={row.id} row={row} width={wrapWidth} />
               ))}
-              {taskLines.length > 10 && (
-                <Text dimColor> … {taskLines.length - 10} more</Text>
+              {rowBottomSpacerHeight > 0 && (
+                <Box height={rowBottomSpacerHeight} flexShrink={0} />
               )}
-            </Box>
-          )}
-          {modelPickerOpen && (
-            <Box marginTop={1}>
-              <ModelPicker
-                currentId={settings.model}
-                onSelect={(modelId) => {
-                  setModelPickerOpen(false);
-                  switchModel(modelId);
-                }}
-                onCancel={() => setModelPickerOpen(false)}
-              />
-            </Box>
-          )}
-          {resumableSessions && (
-            <Box marginTop={1}>
-              <SessionPicker
-                sessions={resumableSessions}
-                onSelect={handleResume}
-                onCancel={() => setResumableSessions(null)}
-              />
-            </Box>
-          )}
-          {taskPickerSessions && (
-            <Box marginTop={1}>
-              <SessionPicker
-                sessions={taskPickerSessions}
-                title="Reference a previous task"
-                onSelect={handleTaskSelect}
-                onCancel={() => setTaskPickerSessions(null)}
-              />
-            </Box>
-          )}
-          {linkManagerOpen && (
-            <Box marginTop={1}>
-              <LinkManager
-                links={links}
-                status={linkStatus}
-                onAdd={(input) => {
-                  const result = addLink(process.cwd(), input);
-                  setLinkStatus(result.message);
-                  if (result.ok) setLinks(loadLinks(process.cwd()));
-                }}
-                onRemove={(link) => {
-                  removeLink(process.cwd(), link.path);
-                  setLinks(loadLinks(process.cwd()));
-                  setLinkStatus(`Unlinked ${path.basename(link.path)}`);
-                }}
-                onClose={() => setLinkManagerOpen(false)}
-              />
-            </Box>
-          )}
-          {pendingHookTrust && (
-            <Box marginTop={1}>
-              <HookTrustPrompt
-                cwd={process.cwd()}
-                commands={pendingHookTrust.commands}
-                onDecision={resolveHookTrust}
-              />
-            </Box>
-          )}
-          {pendingMcpApproval && (
-            <Box marginTop={1}>
-              <McpApprovalPrompt
-                serverNames={pendingMcpApproval}
-                onApprove={resolveMcpApproval}
-              />
-            </Box>
-          )}
-          {mcpPickerOpen && mcpManagerRef.current && (
-            <Box marginTop={1}>
-              <McpPicker
-                manager={mcpManagerRef.current}
-                onChanged={() => {
-                  const m = mcpManagerRef.current;
-                  if (m)
-                    saveMcpApproval(
-                      process.cwd(),
-                      m.getEnabled(),
-                      m.getDisabled(),
-                    );
-                }}
-                onCancel={() => setMcpPickerOpen(false)}
-                onDeleted={handleMcpServerDeleted}
-              />
-            </Box>
-          )}
-          {mcpMigrationEntries && (
-            <Box marginTop={1}>
-              <McpMigrationPicker
-                entries={mcpMigrationEntries}
-                onCancel={() => setMcpMigrationEntries(null)}
-                onConfirm={(selected) => {
-                  setMcpMigrationEntries(null);
-                  resolveMcpMigration(selected);
-                }}
-              />
-            </Box>
-          )}
-          {pendingApproval && (
-            <Box marginTop={1}>
-              <ApprovalPrompt
-                request={pendingApproval.request}
-                onDecision={(decision) => {
-                  pendingApproval.resolve(decision);
-                  setPendingApproval(null);
-                }}
-              />
-            </Box>
-          )}
-          {pendingFollowup && (
-            <Box marginTop={1}>
-              <FollowupPrompt
-                question={pendingFollowup.question}
-                suggestions={pendingFollowup.suggestions}
-                onAnswer={(answer) => {
-                  pushRow({ kind: "user", text: answer });
-                  pendingFollowup.resolve(answer);
-                  setPendingFollowup(null);
-                }}
-              />
-            </Box>
-          )}
-          {busy &&
-            !pendingApproval &&
-            !pendingFollowup &&
-            !pendingHookTrust &&
-            !pendingMcpApproval &&
-            !mcpPickerOpen &&
-            !mcpMigrationEntries &&
-            !streamingText &&
-            !streamingReasoning && (
-              <Box marginTop={1}>
-                <Spinner label={busyLabel} />
+            {updateInfo?.updateAvailable && updateInfo.latest && (
+              <Box
+                marginTop={1}
+                flexDirection="column"
+                borderStyle="round"
+                borderColor={COLORS.warning}
+                paddingX={2}
+                alignSelf="flex-start"
+              >
+                <Text color={COLORS.warning} bold>
+                  ↑ Update available: v{updateInfo.current} → v{updateInfo.latest}
+                </Text>
+                <Text>
+                  Run <Text color={COLORS.accent}>orbcode update</Text> to install
+                  the latest version, then relaunch.
+                </Text>
               </Box>
             )}
-          <Box marginTop={1} flexDirection="column">
+            {streamingReasoning && (
+              <Box flexDirection="column" marginTop={1}>
+                <Spinner label="Thinking" />
+                <Box paddingLeft={2}>
+                  <Text color={COLORS.dim} italic>
+                    {streamingReasoningDisplay}
+                  </Text>
+                </Box>
+              </Box>
+            )}
+            {streamingText && (
+              <Box marginTop={1}>
+                <Text>
+                  <Text color={COLORS.primary}>● </Text>
+                  {streamingText}
+                </Text>
+              </Box>
+            )}
+            {taskLines.length > 0 && (
+              <Box flexDirection="column" marginTop={1} paddingLeft={1}>
+                <Text color={COLORS.dim} bold>
+                  Tasks
+                </Text>
+                {taskLines.slice(0, 10).map((line, i) => (
+                  <Text key={i} color={/^[-*]\s*\[x\]/i.test(line) ? COLORS.dim : COLORS.primary}>
+                    {line
+                      .replace(/^[-*]\s*\[x\]/i, "  ■")
+                      .replace(/^[-*]\s*\[-\]/, "  ◧")
+                      .replace(/^[-*]\s*\[ \]/, "  □")}
+                  </Text>
+                ))}
+                {taskLines.length > 10 && (
+                  <Text color={COLORS.dim}> … {taskLines.length - 10} more</Text>
+                )}
+              </Box>
+            )}
+            {modelPickerOpen && (
+              <Box marginTop={1}>
+                <ModelPicker
+                  currentId={settings.model}
+                  onSelect={(modelId) => {
+                    setModelPickerOpen(false);
+                    switchModel(modelId);
+                  }}
+                  onCancel={() => setModelPickerOpen(false)}
+                />
+              </Box>
+            )}
+            {resumableSessions && (
+              <Box marginTop={1}>
+                <SessionPicker
+                  sessions={resumableSessions}
+                  onSelect={handleResume}
+                  onCancel={() => setResumableSessions(null)}
+                />
+              </Box>
+            )}
+            {taskPickerSessions && (
+              <Box marginTop={1}>
+                <SessionPicker
+                  sessions={taskPickerSessions}
+                  title="Reference a previous task"
+                  onSelect={handleTaskSelect}
+                  onCancel={() => setTaskPickerSessions(null)}
+                />
+              </Box>
+            )}
+            {linkManagerOpen && (
+              <Box marginTop={1}>
+                <LinkManager
+                  links={links}
+                  status={linkStatus}
+                  onAdd={(input) => {
+                    const result = addLink(process.cwd(), input);
+                    setLinkStatus(result.message);
+                    if (result.ok) setLinks(loadLinks(process.cwd()));
+                  }}
+                  onRemove={(link) => {
+                    removeLink(process.cwd(), link.path);
+                    setLinks(loadLinks(process.cwd()));
+                    setLinkStatus(`Unlinked ${path.basename(link.path)}`);
+                  }}
+                  onClose={() => setLinkManagerOpen(false)}
+                />
+              </Box>
+            )}
+            {pendingHookTrust && (
+              <Box marginTop={1}>
+                <HookTrustPrompt
+                  cwd={process.cwd()}
+                  commands={pendingHookTrust.commands}
+                  onDecision={resolveHookTrust}
+                />
+              </Box>
+            )}
+            {pendingMcpApproval && (
+              <Box marginTop={1}>
+                <McpApprovalPrompt
+                  serverNames={pendingMcpApproval}
+                  onApprove={resolveMcpApproval}
+                />
+              </Box>
+            )}
+            {mcpPickerOpen && mcpManagerRef.current && (
+              <Box marginTop={1}>
+                <McpPicker
+                  manager={mcpManagerRef.current}
+                  onChanged={() => {
+                    const m = mcpManagerRef.current;
+                    if (m)
+                      saveMcpApproval(
+                        process.cwd(),
+                        m.getEnabled(),
+                        m.getDisabled(),
+                      );
+                  }}
+                  onCancel={() => setMcpPickerOpen(false)}
+                  onDeleted={handleMcpServerDeleted}
+                />
+              </Box>
+            )}
+            {mcpMigrationEntries && (
+              <Box marginTop={1}>
+                <McpMigrationPicker
+                  entries={mcpMigrationEntries}
+                  onCancel={() => setMcpMigrationEntries(null)}
+                  onConfirm={(selected) => {
+                    setMcpMigrationEntries(null);
+                    resolveMcpMigration(selected);
+                  }}
+                />
+              </Box>
+            )}
+            {pendingApproval && (
+              <Box marginTop={1}>
+                <ApprovalPrompt
+                  request={pendingApproval.request}
+                  onDecision={(decision) => {
+                    pendingApproval.resolve(decision);
+                    setPendingApproval(null);
+                  }}
+                />
+              </Box>
+            )}
+            {pendingFollowup && (
+              <Box marginTop={1}>
+                <FollowupPrompt
+                  question={pendingFollowup.question}
+                  suggestions={pendingFollowup.suggestions}
+                  onAnswer={(answer) => {
+                    pushRow({ kind: "user", text: answer });
+                    pendingFollowup.resolve(answer);
+                    setPendingFollowup(null);
+                  }}
+                />
+              </Box>
+            )}
+            {busy &&
+              !pendingApproval &&
+              !pendingFollowup &&
+              !pendingHookTrust &&
+              !pendingMcpApproval &&
+              !mcpPickerOpen &&
+              !mcpMigrationEntries &&
+              !streamingText &&
+              !streamingReasoning && (
+                <Box marginTop={1}>
+                  <Spinner label={busyLabel} />
+                </Box>
+              )}
+            </Box>
+          </Box>
+          <Box flexDirection="column" flexShrink={0}>
             {queuedMessages.length > 0 && (
               <Box flexDirection="column" paddingLeft={1} marginBottom={1}>
-                <Text dimColor bold>
+                <Text color={COLORS.dim} bold>
                   Queue ({queuedMessages.length})
                 </Text>
                 {queuedMessages.slice(0, 5).map((msg, i) => (
-                  <Text key={i} dimColor>
+                  <Text key={i} color={COLORS.dim}>
                     {i + 1}. {truncateForQueue(msg).replace(/\n/g, "↵")}
                   </Text>
                 ))}
                 {queuedMessages.length > 5 && (
-                  <Text dimColor> … {queuedMessages.length - 5} more</Text>
+                  <Text color={COLORS.dim}> … {queuedMessages.length - 5} more</Text>
                 )}
               </Box>
             )}
             <InputBox
               active={inputActive}
+              width={wrapWidth}
               slashCommands={SLASH_COMMANDS}
               onSubmit={handleSubmit}
             />
@@ -1614,6 +1808,7 @@ export function App({
               state={busy ? busyLabel : ""}
               approvalMode={approvalMode}
               busy={busy}
+              exitConfirmationActive={exitConfirmationActive}
               title={sessionTitle}
               plan={usage?.plan}
               usagePercentage={usage?.usagePercentage}
@@ -1671,29 +1866,63 @@ function estimateRowLines(row: Row, width: number): number {
     );
   }
   switch (row.kind) {
-    case "header":
-      return 9;
+    case "header": {
+      const panelWidth = Math.max(20, w - 4);
+      const infoWidth = Math.max(10, panelWidth - 17);
+      const firstCellWidth = Math.min(30, panelWidth);
+      const secondCellWidth = Math.max(10, panelWidth - firstCellWidth - 2);
+      const wrappedAt = (text: string, lineWidth: number) =>
+        text.split("\n").reduce(
+          (sum, line) =>
+            sum +
+            Math.max(1, Math.ceil(Math.max(1, line.length) / lineWidth)),
+          0,
+        );
+      const heroTextHeight =
+        wrappedAt(`${PRODUCT_NAME} / v${VERSION}`, infoWidth) +
+        wrappedAt(TAGLINE, infoWidth) +
+        1 +
+        wrappedAt(`MODEL      ${row.modelName}`, infoWidth) +
+        wrappedAt(`WORKSPACE  ${row.cwd}`, infoWidth);
+      const heroHeight = Math.max(ORBITAL_MARK.length, heroTextHeight);
+      const firstActionRow = Math.max(
+        wrappedAt("/new      fresh conversation", firstCellWidth),
+        wrappedAt("/resume   continue a session", secondCellWidth),
+      );
+      const secondActionRow = Math.max(
+        wrappedAt("/model    switch active model", firstCellWidth),
+        wrappedAt("/help     all commands", secondCellWidth),
+      );
+      const shortcuts = wrappedAt(
+        "shift+tab approvals · ctrl+o thinking · esc interrupt · ctrl+d exit",
+        panelWidth,
+      );
+      // Action/footer top margins plus Header's bottom margin add three rows.
+      return heroHeight + firstActionRow + secondActionRow + shortcuts + 3;
+    }
     case "user":
-      return 1 + wrapped(row.text);
+      return 1 + formatUserBlock(row.text, w).split("\n").length;
     case "assistant":
-      return 1 + wrapped(row.text);
+      return 1 + wrapped(`● ${row.text}`);
     case "reasoning":
-      return row.expanded ? 1 + wrapped(row.text) : 1;
+      return row.expanded ? 2 + wrapped(row.text) : 2;
     case "tool": {
-      let h = 1;
+      const heading = `${formatToolName(row.name)} ${row.summary}`;
+      let h = 1 + wrapped(heading);
       if (row.diff) {
-        h += Math.min(62, row.diff.split("\n").length) + 1;
+        const diffLines = row.diff.split("\n").length;
+        h += 1 + Math.min(60, diffLines) + (diffLines > 60 ? 1 : 0);
       } else if (row.resultPreview) {
         h += wrapped(row.resultPreview);
       }
       return h;
     }
     case "info":
-      return Math.max(1, wrapped(row.text));
+      return 1 + wrapped(row.text);
     case "error":
-      return Math.max(1, wrapped(row.text));
+      return 1 + wrapped(`✗ ${row.text}`);
     case "completion":
-      return 2 + wrapped(row.text);
+      return 4 + wrapped(row.text);
     default:
       return 1;
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -729,7 +729,8 @@ export function App({
   const handleResume = useCallback(
     (session: SessionData) => {
       setResumableSessions(null);
-      agentRef.current = createAgent(session);
+      const resumedAgent = createAgent(session);
+      agentRef.current = resumedAgent;
       resetTranscript();
       setTasks(session.todos ?? "");
       setTotalCost(session.totalCost ?? 0);
@@ -744,19 +745,16 @@ export function App({
         setSessionTitle(session.title);
         setTerminalTitle(session.title);
       }
-      // Replay the conversation into the transcript.
-      for (const message of session.messages) {
-        if (message.role === "user" && typeof message.content === "string") {
-          const match = /<user_query>\n?([\s\S]*?)\n?<\/user_query>/.exec(
-            message.content,
-          );
-          if (match) pushRow({ kind: "user", text: match[1] });
-        } else if (
-          message.role === "assistant" &&
-          typeof message.content === "string" &&
-          message.content.trim()
-        ) {
-          pushRow({ kind: "assistant", text: message.content });
+      // Replay the exact display transcript when available. Agent also builds
+      // a best-effort tool/result history for sessions from the legacy schema.
+      for (const entry of resumedAgent.displayTranscript) {
+        if (entry.kind === "reasoning") {
+          pushRow({
+            ...entry,
+            expanded: expandReasoningRef.current,
+          });
+        } else {
+          pushRow(entry);
         }
       }
       pushRow({

--- a/src/ui/LoginView.tsx
+++ b/src/ui/LoginView.tsx
@@ -103,11 +103,11 @@ export function LoginView({ onLogin }: LoginViewProps) {
 					<Box marginTop={1}>
 						<Spinner label="Waiting for authorization in your browser" />
 					</Box>
-					<Text dimColor>
+					<Text color={COLORS.dim}>
 						Approve the &quot;Authorize OrbCode CLI&quot; dialog at:
 					</Text>
-					<Text dimColor> {authorizeUrl}</Text>
-					<Text dimColor>Esc to cancel</Text>
+					<Text color={COLORS.dim}> {authorizeUrl}</Text>
+					<Text color={COLORS.dim}>Esc to cancel</Text>
 				</>
 			) : (
 				<Text>
@@ -117,7 +117,7 @@ export function LoginView({ onLogin }: LoginViewProps) {
 			{phase === "starting" && <Text color={COLORS.thinking}>Contacting sign-in service…</Text>}
 			{phase === "verifying" && <Text color={COLORS.thinking}>Verifying…</Text>}
 			{error && <Text color={COLORS.error}>✗ {error}</Text>}
-			<Text dimColor>
+			<Text color={COLORS.dim}>
 				To use a token instead, set apiKey in ~/.orbcode/settings.json or the MATTERAI_TOKEN env var.
 			</Text>
 		</Box>

--- a/src/ui/components/ApprovalPrompt.tsx
+++ b/src/ui/components/ApprovalPrompt.tsx
@@ -44,7 +44,7 @@ export function ApprovalPrompt({ request, onDecision }: ApprovalPromptProps) {
 					<Text>{request.detail}</Text>
 				</Box>
 			)}
-			<Text dimColor>
+			<Text color={COLORS.dim}>
 				(y) yes · (n) no{!request.isDangerous && " · (a) always for this session"}
 			</Text>
 		</Box>

--- a/src/ui/components/FollowupPrompt.tsx
+++ b/src/ui/components/FollowupPrompt.tsx
@@ -62,7 +62,7 @@ export function FollowupPrompt({ question, suggestions, onAnswer }: FollowupProm
 				type your own: {custom}
 				{isCustomSelected && <Text inverse> </Text>}
 			</Text>
-			<Text dimColor>↑/↓ select · enter confirm · 1-{Math.min(suggestions.length, 9)} quick pick</Text>
+			<Text color={COLORS.dim}>↑/↓ select · enter confirm · 1-{Math.min(suggestions.length, 9)} quick pick</Text>
 		</Box>
 	)
 }

--- a/src/ui/components/Header.tsx
+++ b/src/ui/components/Header.tsx
@@ -2,53 +2,92 @@ import * as os from "node:os"
 import React from "react"
 import { Box, Text } from "ink"
 
-import { COLORS, LOGO, PRODUCT_NAME, TAGLINE, VERSION } from "../../branding.js"
+import { COLORS, ORBITAL_MARK, PRODUCT_NAME, TAGLINE, VERSION } from "../../branding.js"
+
+const MARK_WIDTH = 13
+const META_LABEL_WIDTH = 11
+const ACTION_LABEL_WIDTH = 10
+const FIRST_ACTION_COLUMN_WIDTH = 30
 
 function shortenPath(cwd: string): string {
 	const home = os.homedir()
 	return cwd.startsWith(home) ? `~${cwd.slice(home.length)}` : cwd
 }
 
-export function Header({ cwd, modelName }: { cwd: string; modelName: string }) {
-	const logoLines = LOGO.split("\n").filter((line) => line.trim().length > 0)
+function OrbitalMark() {
 	return (
-		<Box flexDirection="column" marginBottom={1}>
-			<Box
-				flexDirection="column"
-				borderStyle="round"
-				borderColor={COLORS.accent}
-				paddingX={2}
-				alignSelf="flex-start"
-			>
-				{logoLines.map((line, i) => (
-					<Text key={i} bold color={COLORS.primary}>
-						{line}
-					</Text>
-				))}
-				<Text> </Text>
-				<Text>
-					<Text bold color={COLORS.primary}>
-						{PRODUCT_NAME}
-					</Text>
-					<Text dimColor> v{VERSION}</Text>
-					<Text color={COLORS.thinking}> ✦ </Text>
-					<Text dimColor italic>
-						{TAGLINE}
-					</Text>
+		<Box flexDirection="column" width={MARK_WIDTH} alignItems="flex-start">
+			{ORBITAL_MARK.map((line, row) => (
+				<Text key={row}>
+					{Array.from(line.matchAll(/(.)\1*/g), ([run]) => run).map((run, index) => {
+						const pixel = run[0]
+						if (pixel === " ") return <Text key={index}>{run}</Text>
+						const color =
+							pixel === "o"
+								? COLORS.orbitalOuter
+								: pixel === "i"
+									? COLORS.orbitalInner
+									: COLORS.primary
+						const glyph = row === 0 ? "▄" : row === ORBITAL_MARK.length - 1 ? "▀" : "█"
+						return <Text key={index} color={color}>{glyph.repeat(run.length)}</Text>
+					})}
 				</Text>
-				<Text> </Text>
-				<Text>
-					<Text dimColor>model </Text>
-					<Text color={COLORS.accent}>{modelName}</Text>
-				</Text>
-				<Text>
-					<Text dimColor>cwd </Text>
-					<Text>{shortenPath(cwd)}</Text>
-				</Text>
-			</Box>
-			<Text dimColor>
-				{"  "}/help commands · shift+tab approvals · ctrl+o thinking · esc interrupt · ctrl+c quit
+			))}
+		</Box>
+	)
+}
+
+function MetadataRow({ label, value }: { label: string; value: string }) {
+	return (
+		<Text>
+			<Text color={COLORS.dim}>{label.toUpperCase().padEnd(META_LABEL_WIDTH)}</Text>
+			<Text color={COLORS.accent}>{value}</Text>
+		</Text>
+	)
+}
+
+function ActionCell({ command, label, width }: { command: string; label: string; width?: number }) {
+	return (
+		<Box width={width}>
+			<Text>
+				<Text color={COLORS.primary}>{command.padEnd(ACTION_LABEL_WIDTH)}</Text>
+				<Text color={COLORS.dim}>{label}</Text>
 			</Text>
+		</Box>
+	)
+}
+
+export function Header({ cwd, modelName }: { cwd: string; modelName: string }) {
+	return (
+		<Box flexDirection="column" width="100%" alignItems="center" marginBottom={1}>
+			<Box flexDirection="column" width="100%" paddingX={2}>
+				<Box flexDirection="row" columnGap={4}>
+					<OrbitalMark />
+					<Box flexDirection="column" flexGrow={1} minWidth={0}>
+						<Text>
+							<Text bold color={COLORS.primary}>{PRODUCT_NAME}</Text>
+							<Text color={COLORS.dim}> / v{VERSION}</Text>
+						</Text>
+						<Text color={COLORS.dim} italic>{TAGLINE}</Text>
+						<Text> </Text>
+						<MetadataRow label="model" value={modelName} />
+						<MetadataRow label="workspace" value={shortenPath(cwd)} />
+					</Box>
+				</Box>
+				<Box flexDirection="row" columnGap={2} marginTop={1}>
+					<ActionCell command="/new" label="fresh conversation" width={FIRST_ACTION_COLUMN_WIDTH} />
+					<ActionCell command="/resume" label="continue a session" />
+				</Box>
+				<Box flexDirection="row" columnGap={2}>
+					<ActionCell command="/model" label="switch active model" width={FIRST_ACTION_COLUMN_WIDTH} />
+					<ActionCell command="/help" label="all commands" />
+				</Box>
+				<Box marginTop={1}>
+					<Text color={COLORS.dim}>
+						shift+tab approvals · ctrl+o thinking · esc interrupt · ctrl+d exit
+					</Text>
+				</Box>
+			</Box>
 		</Box>
 	)
 }

--- a/src/ui/components/HookTrustPrompt.tsx
+++ b/src/ui/components/HookTrustPrompt.tsx
@@ -34,7 +34,7 @@ export function HookTrustPrompt({ cwd, commands, onDecision }: HookTrustPromptPr
 				⚠ This project defines {commands.length} hook command{commands.length === 1 ? "" : "s"}
 			</Text>
 			<Box paddingLeft={2} flexDirection="column">
-				<Text dimColor>{cwd}/.orbcode/settings.json</Text>
+				<Text color={COLORS.dim}>{cwd}/.orbcode/settings.json</Text>
 				<Text>Project hooks run these shell commands automatically during the session:</Text>
 				{shown.map((command, i) => (
 					<Text key={i} color={COLORS.warning}>
@@ -42,9 +42,9 @@ export function HookTrustPrompt({ cwd, commands, onDecision }: HookTrustPromptPr
 						{command.length > 100 ? command.slice(0, 99) + "…" : command}
 					</Text>
 				))}
-				{extra > 0 && <Text dimColor> … {extra} more</Text>}
+				{extra > 0 && <Text color={COLORS.dim}> … {extra} more</Text>}
 			</Box>
-			<Text dimColor>
+			<Text color={COLORS.dim}>
 				Only trust hooks from a repository you trust. (y) trust &amp; enable · (n or Enter) keep disabled
 			</Text>
 		</Box>

--- a/src/ui/components/InputBox.tsx
+++ b/src/ui/components/InputBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import { Box, Text, useInput } from "ink"
 import chalk from "chalk"
 
@@ -94,18 +94,24 @@ export function InputBox({ active, width, slashCommands, onSubmit }: InputBoxPro
 	const [slashIndex, setSlashIndex] = useState(0)
 	const [dismissedValue, setDismissedValue] = useState<string | null>(null)
 
-	// Workspace file list for @-references, computed once per session.
-	const files = useMemo(
-		() => walkFiles(process.cwd(), true, 3000).filter((f) => !f.endsWith("/")),
-		[],
-	)
-
 	const showSlashMenu = active && value.startsWith("/") && !value.includes(" ")
 	const slashMatches = showSlashMenu
 		? slashCommands.filter((c) => c.name.startsWith(value)).slice(0, 8)
 		: []
 
 	const atToken = active ? findAtToken(value, cursor) : null
+
+	// Workspace file list for @-references, re-scanned each time the popup opens.
+	// Files created during the session (by editing or manually) become visible.
+	const [files, setFiles] = useState<string[]>([])
+	const wasClosed = useRef(true)
+	if (atToken && wasClosed.current) {
+		wasClosed.current = false
+		setFiles(walkFiles(process.cwd(), true, 3000).filter((f) => !f.endsWith("/")))
+	} else if (!atToken) {
+		wasClosed.current = true
+	}
+
 	const fileMatches = useMemo(() => {
 		if (!atToken || value === dismissedValue) return []
 		return files

--- a/src/ui/components/InputBox.tsx
+++ b/src/ui/components/InputBox.tsx
@@ -5,6 +5,7 @@ import chalk from "chalk"
 import { COLORS } from "../../branding.js"
 import { walkFiles } from "../../tools/executors/listFiles.js"
 import { appendPromptHistory, loadPromptHistory } from "../../config/promptHistory.js"
+import { isMouseInput } from "../terminal.js"
 
 export interface SlashCommand {
 	name: string
@@ -13,11 +14,49 @@ export interface SlashCommand {
 
 interface InputBoxProps {
 	active: boolean
+	width: number
 	slashCommands: SlashCommand[]
 	onSubmit: (value: string) => void
 }
 
 const MAX_FILE_MATCHES = 8
+const POPUP_PADDING_X = 2
+
+function fitText(text: string, maxWidth: number): string {
+	if (text.length <= maxWidth) return text
+	if (maxWidth <= 1) return text.slice(0, Math.max(0, maxWidth))
+	return text.slice(0, maxWidth - 1) + "…"
+}
+
+function PopupEdge({ width, position }: { width: number; position: "top" | "bottom" }) {
+	const innerWidth = Math.max(0, width - 2)
+	return (
+		<Text color={COLORS.popupBg}>
+			{position === "top"
+				? `▗${"▄".repeat(innerWidth)}▖`
+				: `▝${"▀".repeat(innerWidth)}▘`}
+		</Text>
+	)
+}
+
+function PopupRow({
+	width,
+	contentWidth,
+	children,
+}: {
+	width: number
+	contentWidth: number
+	children: React.ReactNode
+}) {
+	const trailing = Math.max(0, width - POPUP_PADDING_X * 2 - contentWidth)
+	return (
+		<Text backgroundColor={COLORS.popupBg}>
+			{" ".repeat(POPUP_PADDING_X)}
+			{children}
+			{" ".repeat(trailing + POPUP_PADDING_X)}
+		</Text>
+	)
+}
 
 /** Higher is better; -1 means no match. Prefers basename prefix > basename > path > subsequence. */
 function fuzzyScore(target: string, query: string): number {
@@ -45,7 +84,7 @@ function findAtToken(value: string, cursor: number): { query: string; start: num
 	return { query: match[1], start: cursor - match[1].length - 1 }
 }
 
-export function InputBox({ active, slashCommands, onSubmit }: InputBoxProps) {
+export function InputBox({ active, width, slashCommands, onSubmit }: InputBoxProps) {
 	const [value, setValue] = useState("")
 	const [cursor, setCursor] = useState(0)
 	// Terminal-style prompt history: persisted across sessions in ~/.orbcode.
@@ -112,6 +151,16 @@ export function InputBox({ active, slashCommands, onSubmit }: InputBoxProps) {
 
 	useInput(
 		(input, key) => {
+			if (isMouseInput(input)) return
+			if (key.escape && value.length > 0) {
+				setValue("")
+				setCursor(0)
+				setHistoryIndex(-1)
+				setFileIndex(0)
+				setSlashIndex(0)
+				setDismissedValue(null)
+				return
+			}
 			// While actively browsing history, arrows keep navigating history even
 			// if a recalled entry opened the slash/file menu.
 			if ((key.upArrow || key.downArrow) && historyIndex !== -1) {
@@ -135,10 +184,6 @@ export function InputBox({ active, slashCommands, onSubmit }: InputBoxProps) {
 				}
 				if (key.return || (key.tab && !key.shift)) {
 					insertFile(fileMatches[Math.min(fileIndex, fileMatches.length - 1)])
-					return
-				}
-				if (key.escape) {
-					setDismissedValue(value)
 					return
 				}
 			}
@@ -242,43 +287,72 @@ export function InputBox({ active, slashCommands, onSubmit }: InputBoxProps) {
 
 	return (
 		<Box flexDirection="column">
+			{slashMatches.length > 0 && (
+				<Box flexDirection="column">
+					<PopupEdge width={width} position="top" />
+					{slashMatches.map((c, i) => {
+						const prefix = i === slashIndex ? "❯ " : "  "
+						const descriptionWidth = Math.max(
+							0,
+							width - POPUP_PADDING_X * 2 - prefix.length - c.name.length - 3,
+						)
+						const description = fitText(c.description, descriptionWidth)
+						const contentWidth = prefix.length + c.name.length + 3 + description.length
+						return (
+							<PopupRow key={c.name} width={width} contentWidth={contentWidth}>
+								<Text color={i === slashIndex ? COLORS.primary : COLORS.accent} bold={i === slashIndex}>
+									{prefix}{c.name}
+								</Text>
+								<Text color={COLORS.dim}> — {description}</Text>
+							</PopupRow>
+						)
+					})}
+					{(() => {
+						const hint = fitText("↑/↓ select · enter run · tab complete", width - POPUP_PADDING_X * 2)
+						return (
+							<PopupRow width={width} contentWidth={hint.length}>
+								<Text color={COLORS.dim}>{hint}</Text>
+							</PopupRow>
+						)
+					})()}
+					<PopupEdge width={width} position="bottom" />
+				</Box>
+			)}
+			{fileMatches.length > 0 && (
+				<Box flexDirection="column">
+					<PopupEdge width={width} position="top" />
+					{fileMatches.map((file, i) => {
+						const prefix = i === fileIndex ? "❯ " : "  "
+						const displayFile = fitText(file, width - POPUP_PADDING_X * 2 - prefix.length)
+						return (
+							<PopupRow key={file} width={width} contentWidth={prefix.length + displayFile.length}>
+								<Text color={i === fileIndex ? COLORS.primary : COLORS.accent} bold={i === fileIndex}>
+									{prefix}{displayFile}
+								</Text>
+							</PopupRow>
+						)
+					})}
+					{(() => {
+						const hint = fitText("↑/↓ select · enter/tab insert · esc dismiss", width - POPUP_PADDING_X * 2)
+						return (
+							<PopupRow width={width} contentWidth={hint.length}>
+								<Text color={COLORS.dim}>{hint}</Text>
+							</PopupRow>
+						)
+					})()}
+					<PopupEdge width={width} position="bottom" />
+				</Box>
+			)}
 			<Box
 				borderStyle="round"
-				borderColor={active ? COLORS.primary : "gray"}
-				borderLeft={false}
-				borderRight={false}
+				borderColor={active ? COLORS.inputBorder : COLORS.inputBorderInactive}
 				paddingX={1}
 			>
 				<Text color={COLORS.user} bold>
 					{"❯ "}
 				</Text>
-				{active ? <Text>{display}</Text> : <Text dimColor>{value || "waiting…"}</Text>}
+				{active ? <Text>{display}</Text> : <Text color={COLORS.dim}>{value || "waiting…"}</Text>}
 			</Box>
-			{slashMatches.length > 0 && (
-				<Box flexDirection="column" paddingLeft={2}>
-					{slashMatches.map((c, i) => (
-						<Text key={c.name}>
-							<Text color={i === slashIndex ? COLORS.accent : undefined}>
-								{i === slashIndex ? "❯ " : "  "}
-								{c.name}
-							</Text>
-							<Text dimColor> — {c.description}</Text>
-						</Text>
-					))}
-					<Text dimColor>↑/↓ select · enter run · tab complete</Text>
-				</Box>
-			)}
-			{fileMatches.length > 0 && (
-				<Box flexDirection="column" paddingLeft={2}>
-					{fileMatches.map((file, i) => (
-						<Text key={file} color={i === fileIndex ? COLORS.accent : undefined}>
-							{i === fileIndex ? "❯ " : "  "}
-							{file}
-						</Text>
-					))}
-					<Text dimColor>↑/↓ select · enter/tab insert · esc dismiss</Text>
-				</Box>
-			)}
 		</Box>
 	)
 }

--- a/src/ui/components/LinkManager.tsx
+++ b/src/ui/components/LinkManager.tsx
@@ -70,8 +70,8 @@ export function LinkManager({ links, status, onAdd, onRemove, onClose }: LinkMan
 			<Text bold color={COLORS.primary}>
 				Linked repositories
 			</Text>
-			<Text dimColor>Repos linked here are shared with the agent so changes can be checked across them.</Text>
-			{links.length === 0 && <Text dimColor>  (none yet)</Text>}
+			<Text color={COLORS.dim}>Repos linked here are shared with the agent so changes can be checked across them.</Text>
+			{links.length === 0 && <Text color={COLORS.dim}>  (none yet)</Text>}
 			{links.map((link, index) => (
 				// truncate-start keeps the meaningful tail of long paths visible
 				// instead of wrapping them onto the next line.
@@ -93,8 +93,8 @@ export function LinkManager({ links, status, onAdd, onRemove, onClose }: LinkMan
 					<Text inverse> </Text>
 				</Text>
 			)}
-			{status && <Text dimColor>{status}</Text>}
-			<Text dimColor>↑/↓ select · enter add/remove · d remove · esc done</Text>
+			{status && <Text color={COLORS.dim}>{status}</Text>}
+			<Text color={COLORS.dim}>↑/↓ select · enter add/remove · d remove · esc done</Text>
 		</Box>
 	)
 }

--- a/src/ui/components/McpApprovalPrompt.tsx
+++ b/src/ui/components/McpApprovalPrompt.tsx
@@ -66,8 +66,8 @@ export function McpApprovalPrompt({ serverNames, onApprove }: McpApprovalPromptP
 			<Text bold color={COLORS.warning}>
 				{count} MCP server{count === 1 ? "" : "s"} found in .mcp.json
 			</Text>
-			<Text dimColor>Select any you wish to enable for this project.</Text>
-			{windowStart > 0 && <Text dimColor>  ↑ {windowStart} more</Text>}
+			<Text color={COLORS.dim}>Select any you wish to enable for this project.</Text>
+			{windowStart > 0 && <Text color={COLORS.dim}>  ↑ {windowStart} more</Text>}
 			{visible.map((name, i) => {
 				const index = windowStart + i
 				const isSelected = index === selected
@@ -80,9 +80,9 @@ export function McpApprovalPrompt({ serverNames, onApprove }: McpApprovalPromptP
 				)
 			})}
 			{windowStart + VISIBLE_ROWS < count && (
-				<Text dimColor>  ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
+				<Text color={COLORS.dim}>  ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
 			)}
-			<Text dimColor>space toggle · enter confirm · esc reject all</Text>
+			<Text color={COLORS.dim}>space toggle · enter confirm · esc reject all</Text>
 		</Box>
 	)
 }

--- a/src/ui/components/McpAuthScreen.tsx
+++ b/src/ui/components/McpAuthScreen.tsx
@@ -78,7 +78,7 @@ export function McpAuthScreen({ serverName, authUrl, onPasteCode, onCancel }: Mc
 			<Text> </Text>
 			{authUrl ? (
 				<Box flexDirection="column">
-					<Text dimColor>
+					<Text color={COLORS.dim}>
 						If your browser doesn't open automatically, copy this URL manually (c to copy)
 					</Text>
 					<Box paddingLeft={1} marginTop={0}>
@@ -89,26 +89,26 @@ export function McpAuthScreen({ serverName, authUrl, onPasteCode, onCancel }: Mc
 					{copied && <Text color={COLORS.success}>✓ Copied to clipboard</Text>}
 				</Box>
 			) : (
-				<Text dimColor>Waiting for the authorization URL…</Text>
+				<Text color={COLORS.dim}>Waiting for the authorization URL…</Text>
 			)}
 			<Text> </Text>
 			{mode === "paste" ? (
 				<Box flexDirection="column">
-					<Text dimColor>If the redirect page shows a connection error, paste the URL from your browser's address bar:</Text>
+					<Text color={COLORS.dim}>If the redirect page shows a connection error, paste the URL from your browser's address bar:</Text>
 					<Text>
-						<Text dimColor>URL&gt; </Text>
+						<Text color={COLORS.dim}>URL&gt; </Text>
 						{pasted}
 						<Text inverse> </Text>
 					</Text>
-					<Text dimColor>enter to submit · esc to go back</Text>
+					<Text color={COLORS.dim}>enter to submit · esc to go back</Text>
 				</Box>
 			) : (
-				<Text dimColor>
+				<Text color={COLORS.dim}>
 					Press enter to paste a redirect URL manually · esc to go back
 				</Text>
 			)}
 			<Text> </Text>
-			<Text dimColor>Return here after authenticating in your browser. Press Esc to go back.</Text>
+			<Text color={COLORS.dim}>Return here after authenticating in your browser. Press Esc to go back.</Text>
 		</Box>
 	)
 }

--- a/src/ui/components/McpMigrationPicker.tsx
+++ b/src/ui/components/McpMigrationPicker.tsx
@@ -77,12 +77,12 @@ export function McpMigrationPicker({
         <Text bold color={COLORS.primary}>
           Migrate MCP servers
         </Text>
-        <Text dimColor>No MCP servers found on this machine to migrate.</Text>
-        <Text dimColor>
+        <Text color={COLORS.dim}>No MCP servers found on this machine to migrate.</Text>
+        <Text color={COLORS.dim}>
           Install Claude Code or Claude Desktop, or add servers with `orbcode
           mcp add`.
         </Text>
-        <Text dimColor>esc to close</Text>
+        <Text color={COLORS.dim}>esc to close</Text>
       </Box>
     );
   }
@@ -108,11 +108,11 @@ export function McpMigrationPicker({
       <Text bold color={COLORS.primary}>
         Migrate MCP servers from Claude Code / Desktop
       </Text>
-      <Text dimColor>
+      <Text color={COLORS.dim}>
         Servers will be copied to ~/.orbcode/settings.json. Conflicts (same name
         already exists) are skipped.
       </Text>
-      {windowStart > 0 && <Text dimColor> ↑ {windowStart} more</Text>}
+      {windowStart > 0 && <Text color={COLORS.dim}> ↑ {windowStart} more</Text>}
       {visible.map((entry, i) => {
         const isSelected = windowStart + i === selected;
         return (
@@ -120,18 +120,18 @@ export function McpMigrationPicker({
             <Text color={isSelected ? COLORS.accent : undefined}>
               {isSelected ? "❯ " : "  "}
               {checked.has(entry.key) ? "☑" : "☐"} {entry.name}
-              <Text dimColor> · {describeEntry(entry)}</Text>
+              <Text color={COLORS.dim}> · {describeEntry(entry)}</Text>
             </Text>
             <Box paddingLeft={5}>
-              <Text dimColor>{entry.sourceLabel}</Text>
+              <Text color={COLORS.dim}>{entry.sourceLabel}</Text>
             </Box>
           </Box>
         );
       })}
       {windowStart + VISIBLE_ROWS < count && (
-        <Text dimColor> ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
+        <Text color={COLORS.dim}> ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
       )}
-      <Text dimColor>
+      <Text color={COLORS.dim}>
         space toggle · enter confirm ({checkedCount}/{count}) · esc cancel
       </Text>
     </Box>

--- a/src/ui/components/McpPicker.tsx
+++ b/src/ui/components/McpPicker.tsx
@@ -316,11 +316,11 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 				<Text bold color={COLORS.primary}>
 					MCP servers
 				</Text>
-				<Text dimColor>No MCP servers configured.</Text>
-				<Text dimColor>
+				<Text color={COLORS.dim}>No MCP servers configured.</Text>
+				<Text color={COLORS.dim}>
 					Add servers with: orbcode mcp add &lt;name&gt; &lt;command&gt; [args...]
 				</Text>
-				<Text dimColor>esc to close</Text>
+				<Text color={COLORS.dim}>esc to close</Text>
 			</Box>
 		)
 	}
@@ -343,7 +343,7 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 					{pendingConfirm.title}
 				</Text>
 				<Text>{pendingConfirm.body}</Text>
-				<Text dimColor>y confirm · n / esc cancel</Text>
+				<Text color={COLORS.dim}>y confirm · n / esc cancel</Text>
 			</Box>
 		)
 	}
@@ -356,7 +356,7 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 			<Text bold color={COLORS.primary}>
 				Manage MCP servers ({count})
 			</Text>
-			{windowStart > 0 && <Text dimColor>  ↑ {windowStart} more</Text>}
+			{windowStart > 0 && <Text color={COLORS.dim}>  ↑ {windowStart} more</Text>}
 			{visible.map((state, i) => {
 				const index = windowStart + i
 				const isSelected = index === selected && !actionMode
@@ -368,12 +368,12 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 						<Text color={statusColor(state)}>
 							{statusIcon(state)} {state.status}
 						</Text>
-						{state.toolCount > 0 && <Text dimColor> · {state.toolCount} tools</Text>}
+						{state.toolCount > 0 && <Text color={COLORS.dim}> · {state.toolCount} tools</Text>}
 					</Text>
 				)
 			})}
 			{windowStart + VISIBLE_ROWS < count && (
-				<Text dimColor>  ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
+				<Text color={COLORS.dim}>  ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
 			)}
 			{current && (
 				<DetailPanel
@@ -384,7 +384,7 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 					actionSelected={actionSelected}
 				/>
 			)}
-			<Text dimColor>
+			<Text color={COLORS.dim}>
 				{busy
 					? busyMessage
 					: actionMode
@@ -436,23 +436,23 @@ function DetailPanel({
 				{state.name} MCP Server
 			</Text>
 			<Text>
-				<Text dimColor>Status:          </Text>
+				<Text color={COLORS.dim}>Status:          </Text>
 				<Text color={statusColor(state)}>{statusIcon(state)} {state.status}</Text>
 			</Text>
 			<Text>
-				<Text dimColor>Auth:            </Text>
+				<Text color={COLORS.dim}>Auth:            </Text>
 				<Text color={isOAuth && !authenticated ? COLORS.error : isOAuth ? COLORS.success : COLORS.dim}>
 					{authText}
 				</Text>
 			</Text>
 			<Text>
-				<Text dimColor>URL:             </Text>
+				<Text color={COLORS.dim}>URL:             </Text>
 				{urlText}
 			</Text>
 			{configPath && (
 				<Text>
-					<Text dimColor>Config location: </Text>
-					<Text dimColor>{configPath}</Text>
+					<Text color={COLORS.dim}>Config location: </Text>
+					<Text color={COLORS.dim}>{configPath}</Text>
 				</Text>
 			)}
 			{state.detail && (

--- a/src/ui/components/ModelPicker.tsx
+++ b/src/ui/components/ModelPicker.tsx
@@ -57,7 +57,7 @@ export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps)
 			<Text bold color={COLORS.primary}>
 				Select a model
 			</Text>
-			{windowStart > 0 && <Text dimColor>  ↑ {windowStart} more</Text>}
+			{windowStart > 0 && <Text color={COLORS.dim}>  ↑ {windowStart} more</Text>}
 			{visible.map((model, i) => {
 				const index = windowStart + i
 				const isSelected = index === selected
@@ -68,11 +68,11 @@ export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps)
 							{isSelected ? "❯ " : "  "}
 							{index + 1}. {model.name}
 							{isCurrent && <Text color={COLORS.success}> ✓ current</Text>}
-							<Text dimColor> · {formatPrice(model)}</Text>
+							<Text color={COLORS.dim}> · {formatPrice(model)}</Text>
 						</Text>
 						{isSelected && (
 							<Box paddingLeft={5}>
-								<Text dimColor wrap="wrap">
+								<Text color={COLORS.dim} wrap="wrap">
 									{model.description}
 								</Text>
 							</Box>
@@ -81,9 +81,9 @@ export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps)
 				)
 			})}
 			{windowStart + VISIBLE_ROWS < models.length && (
-				<Text dimColor>  ↓ {models.length - windowStart - VISIBLE_ROWS} more</Text>
+				<Text color={COLORS.dim}>  ↓ {models.length - windowStart - VISIBLE_ROWS} more</Text>
 			)}
-			<Text dimColor>↑/↓ select · enter confirm · esc cancel</Text>
+			<Text color={COLORS.dim}>↑/↓ select · enter confirm · esc cancel</Text>
 		</Box>
 	)
 }

--- a/src/ui/components/SessionPicker.tsx
+++ b/src/ui/components/SessionPicker.tsx
@@ -58,7 +58,7 @@ export function SessionPicker({ sessions, onSelect, onCancel, title = "Resume a 
 			<Text bold color={COLORS.primary}>
 				{title}
 			</Text>
-			{windowStart > 0 && <Text dimColor>  ↑ {windowStart} more</Text>}
+			{windowStart > 0 && <Text color={COLORS.dim}>  ↑ {windowStart} more</Text>}
 			{visible.map((session, i) => {
 				const index = windowStart + i
 				const isSelected = index === selected
@@ -67,7 +67,7 @@ export function SessionPicker({ sessions, onSelect, onCancel, title = "Resume a 
 					<Text key={session.id} color={isSelected ? COLORS.accent : undefined}>
 						{isSelected ? "❯ " : "  "}
 						{index + 1}. {session.title || "(untitled)"}
-						<Text dimColor>
+						<Text color={COLORS.dim}>
 							{" "}
 							· {relativeTime(session.updatedAt)} · {userTurns} message{userTurns === 1 ? "" : "s"}
 						</Text>
@@ -75,9 +75,9 @@ export function SessionPicker({ sessions, onSelect, onCancel, title = "Resume a 
 				)
 			})}
 			{windowStart + VISIBLE_ROWS < sessions.length && (
-				<Text dimColor>  ↓ {sessions.length - windowStart - VISIBLE_ROWS} more</Text>
+				<Text color={COLORS.dim}>  ↓ {sessions.length - windowStart - VISIBLE_ROWS} more</Text>
 			)}
-			<Text dimColor>↑/↓ select · enter resume · esc cancel</Text>
+			<Text color={COLORS.dim}>↑/↓ select · enter resume · esc cancel</Text>
 		</Box>
 	)
 }

--- a/src/ui/components/Spinner.tsx
+++ b/src/ui/components/Spinner.tsx
@@ -22,7 +22,7 @@ export function Spinner({ label }: { label: string }) {
 	return (
 		<Text color={COLORS.thinking}>
 			{FRAMES[frame]} {label}
-			<Text dimColor> ({seconds}s · esc to interrupt)</Text>
+			<Text color={COLORS.dim}> ({seconds}s · esc to interrupt)</Text>
 		</Text>
 	)
 }

--- a/src/ui/components/StatusBar.tsx
+++ b/src/ui/components/StatusBar.tsx
@@ -16,6 +16,12 @@ const MODE_LABELS: Record<ApprovalMode, string> = {
   auto: "⏵⏵⏵ auto-approve on",
 };
 
+const MODE_COLORS: Record<ApprovalMode, string> = {
+  ask: COLORS.primary,
+  edits: COLORS.warning,
+  auto: COLORS.success,
+};
+
 function formatRelativeTime(isoStr?: string): string {
   if (!isoStr) return "on session start";
   const now = Date.now();
@@ -40,6 +46,7 @@ interface StatusBarProps {
   state: string;
   approvalMode: ApprovalMode;
   busy: boolean;
+  exitConfirmationActive: boolean;
   title?: string;
   plan?: string;
   usagePercentage?: number;
@@ -88,6 +95,7 @@ export function StatusBar({
   state,
   approvalMode,
   busy,
+  exitConfirmationActive,
   title,
   plan: _plan,
   usagePercentage: _usagePercentage,
@@ -102,22 +110,27 @@ export function StatusBar({
   return (
     <Box flexDirection="column">
       <Box justifyContent="space-between">
-        <Text dimColor>
-          <Text color={approvalMode === "ask" ? undefined : COLORS.warning}>
-            {MODE_LABELS[approvalMode]}
+        {exitConfirmationActive ? (
+          <Text color={COLORS.warning} bold wrap="truncate">
+            Press Ctrl+D again to exit
           </Text>
-          {" (shift+tab to cycle)"}
-          {busy && " · esc to interrupt"}
-          {state ? <Text color={COLORS.thinking}> · {state}</Text> : null}
-        </Text>
-        <Text dimColor>
+        ) : (
+          <Text color={COLORS.dim} wrap="truncate">
+            <Text color={MODE_COLORS[approvalMode]} bold>
+              {MODE_LABELS[approvalMode]}
+            </Text>
+            {" (shift+tab to cycle)"}
+            {busy && " · esc to interrupt"}
+          </Text>
+        )}
+        <Text color={COLORS.dim} wrap="truncate">
           {title ? `${truncate(title, 32)} · ` : ""}
           {model.name} · ctx {contextTokens.toLocaleString()} ({contextPct}%)
         </Text>
       </Box>
       {usageLine && (
         <Box justifyContent="flex-end">
-          <Text dimColor>{usageLine}</Text>
+          <Text color={COLORS.dim} wrap="truncate">{usageLine}</Text>
         </Box>
       )}
     </Box>

--- a/src/ui/components/rows.tsx
+++ b/src/ui/components/rows.tsx
@@ -40,8 +40,8 @@ export function formatToolName(name: string): string {
 }
 
 const MAX_DIFF_LINES = 60
-const ADDED_BG = "#1C4428"
-const REMOVED_BG = "#5C1A1A"
+const ADDED_BG = COLORS.success
+const REMOVED_BG = COLORS.error
 
 type DiffRow =
 	| { kind: "file"; text: string }
@@ -98,20 +98,20 @@ export function DiffView({ diff }: { diff: string }) {
 	return (
 		<Box flexDirection="column">
 			<Text>
-				<Text dimColor>└ </Text>
+				<Text color={COLORS.dim}>└ </Text>
 				Added {plural(added, "line")}, removed {plural(removed, "line")}
 			</Text>
 			{visible.map((row, i) => {
 				if (row.kind === "file") {
 					return (
-						<Text key={i} bold dimColor>
+						<Text key={i} bold color={COLORS.dim}>
 							{row.text}
 						</Text>
 					)
 				}
 				if (row.kind === "gap") {
 					return (
-						<Text key={i} dimColor>
+						<Text key={i} color={COLORS.dim}>
 							{" ".repeat(numWidth)} ⋯
 						</Text>
 					)
@@ -119,27 +119,27 @@ export function DiffView({ diff }: { diff: string }) {
 				const num = String(row.num).padStart(numWidth)
 				if (row.type === "add") {
 					return (
-						<Text key={i} backgroundColor={ADDED_BG}>
+						<Text key={i} backgroundColor={ADDED_BG} color={COLORS.primary}>
 							{num} + {row.text}
 						</Text>
 					)
 				}
 				if (row.type === "del") {
 					return (
-						<Text key={i} backgroundColor={REMOVED_BG}>
+						<Text key={i} backgroundColor={REMOVED_BG} color={COLORS.primary}>
 							{num} - {row.text}
 						</Text>
 					)
 				}
 				return (
 					<Text key={i}>
-						<Text dimColor>{num}</Text>
+						<Text color={COLORS.dim}>{num}</Text>
 						{"   "}
 						{row.text}
 					</Text>
 				)
 			})}
-			{rows.length > MAX_DIFF_LINES && <Text dimColor>… {rows.length - MAX_DIFF_LINES} more lines</Text>}
+			{rows.length > MAX_DIFF_LINES && <Text color={COLORS.dim}>… {rows.length - MAX_DIFF_LINES} more lines</Text>}
 		</Box>
 	)
 }
@@ -149,17 +149,46 @@ export function formatDuration(durationMs: number): string {
 	return seconds >= 10 ? `${Math.round(seconds)}s` : `${seconds.toFixed(1)}s`
 }
 
-export function RowView({ row }: { row: Row }) {
+/** Build a background-filled user block exactly as wide as the transcript. */
+export function formatUserBlock(text: string, width: number): string {
+	const lineWidth = Math.max(1, width)
+	const paddingX = Math.min(2, Math.floor((lineWidth - 1) / 2))
+	const contentWidth = Math.max(1, lineWidth - paddingX * 2)
+	const sourceLines = (`❯ ${text}`).split("\n")
+	const blank = " ".repeat(lineWidth)
+	const output: string[] = [blank]
+	for (const sourceLine of sourceLines) {
+		if (sourceLine.length === 0) {
+			output.push(blank)
+			continue
+		}
+		for (let offset = 0; offset < sourceLine.length; offset += contentWidth) {
+			output.push(
+				" ".repeat(paddingX) +
+					sourceLine.slice(offset, offset + contentWidth).padEnd(contentWidth) +
+					" ".repeat(paddingX),
+			)
+		}
+	}
+	output.push(blank)
+	return output.join("\n")
+}
+
+/**
+ * Completed transcript rows are immutable. Keeping their rendered Ink tree
+ * around avoids re-running markdown and diff parsing when only the viewport
+ * offset changes.
+ */
+export const RowView = React.memo(function RowView({ row, width }: { row: Row; width: number }) {
 	switch (row.kind) {
 		case "header":
 			return <Header cwd={row.cwd} modelName={row.modelName} />
 		case "user":
 			return (
 				<Box marginTop={1}>
-					<Text color={COLORS.user} bold>
-						{"❯ "}
+					<Text color={COLORS.user} backgroundColor={COLORS.userBg}>
+						{formatUserBlock(row.text, width)}
 					</Text>
-					<Text color={COLORS.user}>{row.text}</Text>
 				</Box>
 			)
 		case "assistant":
@@ -176,11 +205,11 @@ export function RowView({ row }: { row: Row }) {
 				<Box marginTop={1} flexDirection="column">
 					<Text color={COLORS.thinking} italic>
 						✦ Thought for {formatDuration(row.durationMs)}
-						{!row.expanded && <Text dimColor> (ctrl+o to show thinking)</Text>}
+						{!row.expanded && <Text color={COLORS.dim}> (ctrl+o to show thinking)</Text>}
 					</Text>
 					{row.expanded && (
 						<Box paddingLeft={2}>
-							<Text dimColor italic>
+							<Text color={COLORS.dim} italic>
 								{row.text.trim()}
 							</Text>
 						</Box>
@@ -195,7 +224,7 @@ export function RowView({ row }: { row: Row }) {
 							{row.isError ? "✗" : "✓"}{" "}
 						</Text>
 						<Text bold>{formatToolName(row.name)}</Text>
-						<Text dimColor> {row.summary}</Text>
+						<Text color={COLORS.dim}> {row.summary}</Text>
 					</Text>
 					{row.diff ? (
 						<Box paddingLeft={2}>
@@ -204,7 +233,7 @@ export function RowView({ row }: { row: Row }) {
 					) : (
 						row.resultPreview && (
 							<Box paddingLeft={2}>
-								<Text dimColor>{row.resultPreview}</Text>
+								<Text color={COLORS.dim}>{row.resultPreview}</Text>
 							</Box>
 						)
 					)}
@@ -213,7 +242,7 @@ export function RowView({ row }: { row: Row }) {
 		case "info":
 			return (
 				<Box marginTop={1}>
-					<Text dimColor>{row.text}</Text>
+					<Text color={COLORS.dim}>{row.text}</Text>
 				</Box>
 			)
 		case "error":
@@ -232,4 +261,4 @@ export function RowView({ row }: { row: Row }) {
 				</Box>
 			)
 	}
-}
+})

--- a/src/ui/components/rows.tsx
+++ b/src/ui/components/rows.tsx
@@ -11,14 +11,14 @@ export type Row =
 	| { kind: "assistant"; id: string; text: string }
 	| { kind: "reasoning"; id: string; text: string; durationMs: number; expanded: boolean }
 	| {
-			kind: "tool"
-			id: string
-			name: string
-			summary: string
-			resultPreview: string
-			isError: boolean
-			diff?: string
-	  }
+		kind: "tool"
+		id: string
+		name: string
+		summary: string
+		resultPreview: string
+		isError: boolean
+		diff?: string
+	}
 	| { kind: "info"; id: string; text: string }
 	| { kind: "error"; id: string; text: string }
 	| { kind: "completion"; id: string; text: string }
@@ -39,9 +39,19 @@ export function formatToolName(name: string): string {
 	)
 }
 
+/** Alpha-blend a foreground hex color against the terminal background (#1a1a1a). */
+function blendWithBg(hex: string, alpha: number): string {
+	const r = parseInt(hex.slice(1, 3), 16)
+	const g = parseInt(hex.slice(3, 5), 16)
+	const b = parseInt(hex.slice(5, 7), 16)
+	const bgR = 0x1a, bgG = 0x1a, bgB = 0x1a
+	const blend = (c: number, bg: number) => Math.round(c * alpha + bg * (1 - alpha))
+	return `#${[r, g, b].map((c, i) => blend(c, [bgR, bgG, bgB][i]).toString(16).padStart(2, "0")).join("")}`
+}
+
 const MAX_DIFF_LINES = 60
-const ADDED_BG = COLORS.success
-const REMOVED_BG = COLORS.error
+const ADDED_BG = blendWithBg(COLORS.success, 0.05)
+const REMOVED_BG = blendWithBg(COLORS.error, 0.05)
 
 type DiffRow =
 	| { kind: "file"; text: string }
@@ -119,14 +129,14 @@ export function DiffView({ diff }: { diff: string }) {
 				const num = String(row.num).padStart(numWidth)
 				if (row.type === "add") {
 					return (
-						<Text key={i} backgroundColor={ADDED_BG} color={COLORS.primary}>
+						<Text key={i} backgroundColor={ADDED_BG} color={COLORS.success}>
 							{num} + {row.text}
 						</Text>
 					)
 				}
 				if (row.type === "del") {
 					return (
-						<Text key={i} backgroundColor={REMOVED_BG} color={COLORS.primary}>
+						<Text key={i} backgroundColor={REMOVED_BG} color={COLORS.error}>
 							{num} - {row.text}
 						</Text>
 					)
@@ -165,8 +175,8 @@ export function formatUserBlock(text: string, width: number): string {
 		for (let offset = 0; offset < sourceLine.length; offset += contentWidth) {
 			output.push(
 				" ".repeat(paddingX) +
-					sourceLine.slice(offset, offset + contentWidth).padEnd(contentWidth) +
-					" ".repeat(paddingX),
+				sourceLine.slice(offset, offset + contentWidth).padEnd(contentWidth) +
+				" ".repeat(paddingX),
 			)
 		}
 	}

--- a/src/ui/markdown.ts
+++ b/src/ui/markdown.ts
@@ -35,7 +35,7 @@ export function renderMarkdown(markdown: string): string {
 		}
 
 		if (inCodeBlock) {
-			out.push(chalk.dim("│ ") + chalk.hex("#CE9178")(line))
+			out.push(chalk.dim("│ ") + chalk.hex(COLORS.accent)(line))
 			continue
 		}
 

--- a/src/ui/terminal.ts
+++ b/src/ui/terminal.ts
@@ -1,0 +1,35 @@
+const SGR_WHEEL_RE = /\x1b?\[<(\d+);\d+;\d+M/g;
+const SGR_MOUSE_RE = /\x1b?\[<\d+;\d+;\d+[mM]/;
+const URXVT_WHEEL_RE = /\x1b?\[(\d+);\d+;\d+M/g;
+const URXVT_MOUSE_RE = /\x1b?\[\d+;\d+;\d+M/;
+
+export function mouseScrollDelta(input: string): number {
+  let delta = 0;
+  let match: RegExpExecArray | null;
+
+  SGR_WHEEL_RE.lastIndex = 0;
+  while ((match = SGR_WHEEL_RE.exec(input))) {
+    const button = Number(match[1]);
+    if ((button & 64) === 64) delta += (button & 1) === 0 ? 1 : -1;
+  }
+
+  URXVT_WHEEL_RE.lastIndex = 0;
+  while ((match = URXVT_WHEEL_RE.exec(input))) {
+    const button = Number(match[1]);
+    if (button === 64) delta += 1;
+    if (button === 65) delta -= 1;
+  }
+
+  for (let i = 0; i <= input.length - 6; i++) {
+    if (input.charCodeAt(i) !== 0x1b || input[i + 1] !== "[" || input[i + 2] !== "M") continue;
+    const button = input.charCodeAt(i + 3) - 32;
+    if ((button & 64) === 64) delta += (button & 1) === 0 ? 1 : -1;
+    i += 5;
+  }
+
+  return delta;
+}
+
+export function isMouseInput(input: string): boolean {
+  return mouseScrollDelta(input) !== 0 || SGR_MOUSE_RE.test(input) || URXVT_MOUSE_RE.test(input) || input.includes("\x1b[M");
+}


### PR DESCRIPTION
## Summary

Complete visual refresh of OrbCode CLI with a neutral black/white/grey theme, alternate screen buffer TUI, virtual transcript scrolling, and redesigned header/input box.

## Changes

### feat(theme): neutral greyscale palette with semantic accents
- Replace cyan/teal palette with `#ffffff` primary, `#d0d0d0` accent, `#a8a8a8` thinking, `#7a7a7a` dim, `#1a1a1a` background
- Semantic colors: error `#E34671`, success `#3FA266`, warning `#E2CE76`
- Migrate all `<Text dimColor>` to explicit `COLORS.dim` across entire UI
- Add new tokens: `userBg`, `popupBg`, `inputBorder`, `inputBorderInactive`, `orbitalOuter`, `orbitalInner`

### feat(tui): alternate screen buffer with cursor-addressed rendering
- Enter alternate screen (`\x1b[?1049h`) on startup — no scrollback pollution
- Set terminal default fg/bg via OSC 10/11 to match theme
- `createFullscreenStdout` proxy: converts Ink frames to cursor-addressed rows with EL 2
- Synchronized update DCS for tear-free rendering, only rewrites changed rows
- Mouse tracking enabled to prevent wheel-from-scrollback
- Graceful terminal restore on exit

### feat(ui): virtual scrolling transcript with mouse wheel
- Full transcript height tracking with viewport-based virtual rendering
- Mouse wheel support (SGR, URXVT, X10 protocols) with smooth scroll at ~30fps
- PageUp/PageDown navigation, Ctrl+D double-press-to-exit with 3s timeout
- Dynamic resize handling, exact `termRows` root container
- `paddingX={2}` for consistent horizontal margin
- `RowView` now `React.memo` with width-aware layout

### feat(ui): redesigned header and input box
- **Header**: orbital brand mark with half-block glyphs in source-art colors, metadata column, action command grid, shortcut bar
- **InputBox**: full `borderStyle="round"` chrome, styled floating popups with rounded unicode edges, Escape-to-clear

### chore: bump version to 0.4.2
- Package version, lockfile, and changelog updated