### PR TITLE
release: v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-07-13
+
 ### Changed
 
 - **Diff background colors are now 50% transparent.** Added/removed line
@@ -14,6 +16,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   background (`#1a1a1a`), producing a muted green (`#2C5E40`) and muted red
   (`#7E3045`) that are less visually aggressive while preserving the red/green
   semantic.
+- **Viewport layout adapts to the real input box height.** The input box now
+  reports its rendered height to the parent viewport (including multiline
+  prompt wrapping, slash-command popups, and file-completion popups), so the
+  bottom controls stack never overlaps the live response. The previous
+  hardcoded 4-row estimation caused overflow on multiline input or when
+  autocomplete was open.
+- **Streaming output is truncated to the viewport tail.** Instead of
+  accumulating the entire streaming response in the live area (which pushed
+  the input box off-screen in long generations), only lines fitting the
+  available height are rendered. The complete response is committed to the
+  transcript on completion.
+- **Diff line-height estimates in the virtualized transcript now account for
+  the number/type gutter.** The diff gutter occupies ~8 columns, so each
+  content line wraps at a narrower width. Hunks headers are structural and
+  skipped. This prevents underestimation that could overflow the viewport.
+- **Task list height measurement uses proper word-wrap calculations.** Task
+  items are now wrapped at the available terminal width instead of counting
+  raw lines, so long task descriptions don't push controls off-screen.
+- **Reasoning row height estimates account for the gutter.** Collapsed
+  reasoning rows are measured at `width - 2` to match the actual render,
+  preventing underestimation that clips the fold header.
+- **Result preview and completion text use correct line widths.** Both are
+  now wrapped at `width - 2` and `width - 4` respectively, matching the
+  indentation they render at.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -364,6 +364,7 @@ export function App({
   const [exitConfirmationActive, setExitConfirmationActive] = useState(false);
   const [streamingReasoning, setStreamingReasoning] = useState("");
   const [streamingText, setStreamingText] = useState("");
+  const [inputBoxHeight, setInputBoxHeight] = useState(3);
   const [scrollOffset, setScrollOffset] = useState(0);
   const smoothScrollPendingRef = useRef(0);
   const smoothScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -1451,7 +1452,10 @@ export function App({
     usage?.tieredUsage?.weekly ||
     usage?.tieredUsage?.monthly,
   );
-  let bottomControlsHeight = 4 + (hasUsageLine ? 1 : 0);
+  // InputBox reports its real height because multiline input and autocomplete
+  // popups make the bottom stack taller than the normal three-row prompt.
+  // StatusBar is one row, plus its optional usage row.
+  let bottomControlsHeight = inputBoxHeight + 1 + (hasUsageLine ? 1 : 0);
   if (queuedMessages.length > 0) {
     bottomControlsHeight +=
       2 + Math.min(5, queuedMessages.length) +
@@ -1479,15 +1483,32 @@ export function App({
   const streamingReasoningDisplay = streamingReasoning
     ? tailForHeight(streamingReasoning, 3, reasoningWrapWidth)
     : "";
+  // Do not lay out the entire accumulated response on every token. Keep only
+  // the live tail mounted; text-done commits the complete response to the
+  // virtualized transcript, so nothing is lost from history.
+  const streamingTextDisplay = streamingText
+    ? tailForHeight(
+        streamingText,
+        Math.max(1, contentHeight - 1),
+        Math.max(20, wrapWidth - 2),
+      )
+    : "";
   if (streamingReasoning) {
     dynamicHeight +=
       2 + wrapHeight(streamingReasoningDisplay, reasoningWrapWidth);
   }
-  if (streamingText) {
-    dynamicHeight += 1 + wrapHeight(`● ${streamingText}`, wrapWidth);
+  if (streamingTextDisplay) {
+    dynamicHeight += 1 + wrapHeight(`● ${streamingTextDisplay}`, wrapWidth);
   }
-  if (taskLines.length > 0)
-    dynamicHeight += 2 + Math.min(10, taskLines.length);
+  if (taskLines.length > 0) {
+    const taskWidth = Math.max(20, wrapWidth - 1);
+    dynamicHeight +=
+      2 +
+      taskLines
+        .slice(0, 10)
+        .reduce((height, line) => height + wrapHeight(line, taskWidth), 0) +
+      (taskLines.length > 10 ? 1 : 0);
+  }
   if (
     pendingApproval ||
     pendingFollowup ||
@@ -1615,11 +1636,11 @@ export function App({
                 </Box>
               </Box>
             )}
-            {streamingText && (
+            {streamingTextDisplay && (
               <Box marginTop={1}>
                 <Text>
                   <Text color={COLORS.primary}>● </Text>
-                  {streamingText}
+                  {streamingTextDisplay}
                 </Text>
               </Box>
             )}
@@ -1798,6 +1819,7 @@ export function App({
               width={wrapWidth}
               slashCommands={SLASH_COMMANDS}
               onSubmit={handleSubmit}
+              onHeightChange={setInputBoxHeight}
             />
             <StatusBar
               modelId={settings.model}
@@ -1856,10 +1878,11 @@ function tailForHeight(text: string, maxLines: number, width: number): string {
  * push the input box off-screen. */
 function estimateRowLines(row: Row, width: number): number {
   const w = Math.max(20, width);
-  function wrapped(text: string): number {
+  function wrapped(text: string, lineWidth = w): number {
+    const available = Math.max(1, lineWidth);
     return text.split("\n").reduce(
       (sum, line) =>
-        sum + Math.max(1, Math.ceil(Math.max(1, line.length) / w)),
+        sum + Math.max(1, Math.ceil(Math.max(1, line.length) / available)),
       0,
     );
   }
@@ -1903,15 +1926,26 @@ function estimateRowLines(row: Row, width: number): number {
     case "assistant":
       return 1 + wrapped(`● ${row.text}`);
     case "reasoning":
-      return row.expanded ? 2 + wrapped(row.text) : 2;
+      return row.expanded ? 2 + wrapped(row.text, w - 2) : 2;
     case "tool": {
       const heading = `${formatToolName(row.name)} ${row.summary}`;
       let h = 1 + wrapped(heading);
       if (row.diff) {
-        const diffLines = row.diff.split("\n").length;
-        h += 1 + Math.min(60, diffLines) + (diffLines > 60 ? 1 : 0);
+        // DiffView adds a stats row and an 8-ish-column number/type gutter.
+        // Hunk headers are structural and aren't rendered as their own rows.
+        const diffLines = row.diff
+          .split("\n")
+          .filter((line) => !line.startsWith("@@"));
+        const visible = diffLines.slice(0, 60);
+        h +=
+          1 +
+          visible.reduce(
+            (height, line) => height + wrapped(line, w - 10),
+            0,
+          ) +
+          (diffLines.length > 60 ? 1 : 0);
       } else if (row.resultPreview) {
-        h += wrapped(row.resultPreview);
+        h += wrapped(row.resultPreview, w - 2);
       }
       return h;
     }
@@ -1920,7 +1954,7 @@ function estimateRowLines(row: Row, width: number): number {
     case "error":
       return 1 + wrapped(`✗ ${row.text}`);
     case "completion":
-      return 4 + wrapped(row.text);
+      return 4 + wrapped(row.text, w - 4);
     default:
       return 1;
   }

--- a/src/ui/components/InputBox.tsx
+++ b/src/ui/components/InputBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react"
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { Box, Text, useInput } from "ink"
 import chalk from "chalk"
 
@@ -17,6 +17,8 @@ interface InputBoxProps {
 	width: number
 	slashCommands: SlashCommand[]
 	onSubmit: (value: string) => void
+	/** Reports the complete rendered height, including autocomplete popups. */
+	onHeightChange?: (height: number) => void
 }
 
 const MAX_FILE_MATCHES = 8
@@ -84,7 +86,7 @@ function findAtToken(value: string, cursor: number): { query: string; start: num
 	return { query: match[1], start: cursor - match[1].length - 1 }
 }
 
-export function InputBox({ active, width, slashCommands, onSubmit }: InputBoxProps) {
+export function InputBox({ active, width, slashCommands, onSubmit, onHeightChange }: InputBoxProps) {
 	const [value, setValue] = useState("")
 	const [cursor, setCursor] = useState(0)
 	// Terminal-style prompt history: persisted across sessions in ~/.orbcode.
@@ -290,6 +292,26 @@ export function InputBox({ active, width, slashCommands, onSubmit }: InputBoxPro
 	// cursor to the next line on short values.
 	const display =
 		value.slice(0, cursor) + chalk.inverse(value[cursor] ?? " ") + value.slice(cursor + 1)
+	const plainDisplay = active
+		? value.slice(0, cursor) + (value[cursor] ?? " ") + value.slice(cursor + 1)
+		: value || "waiting…"
+	// Border (2) + wrapped prompt content. The prompt glyph occupies two
+	// columns beside the editable text, while border and padding consume four.
+	const editableWidth = Math.max(1, width - 6)
+	const promptHeight = plainDisplay.split("\n").reduce(
+		(sum, line) => sum + Math.max(1, Math.ceil(Math.max(1, line.length) / editableWidth)),
+		0,
+	)
+	const slashPopupHeight = slashMatches.length > 0 ? slashMatches.length + 3 : 0
+	const filePopupHeight = fileMatches.length > 0 ? fileMatches.length + 3 : 0
+	const renderedHeight = 2 + promptHeight + slashPopupHeight + filePopupHeight
+
+	// Parent viewport calculations must use the real bottom-stack height. A
+	// layout effect updates it before Ink paints the next frame, preventing a
+	// multiline prompt or popup from covering the live response above it.
+	useLayoutEffect(() => {
+		onHeightChange?.(renderedHeight)
+	}, [onHeightChange, renderedHeight])
 
 	return (
 		<Box flexDirection="column">


### PR DESCRIPTION
## Release v0.4.3

### Changed
- **Diff background colors are now 50% transparent.** Added/removed line backgrounds in the diff view are alpha-blended against the terminal background (`#1a1a1a`), producing a muted green (`#2C5E40`) and muted red (`#7E3045`).
- **Viewport layout adapts to the real input box height.** The input box now reports its rendered height to the parent viewport (including multiline prompt wrapping, slash-command popups, and file-completion popups), so the bottom controls stack never overlaps the live response.
- **Streaming output is truncated to the viewport tail.** Only lines fitting the available height are rendered during streaming. The complete response is committed to the transcript on completion.
- **Diff line-height estimates in the virtualized transcript now account for the number/type gutter.**
- **Task list height measurement uses proper word-wrap calculations.**
- **Reasoning row height estimates account for the gutter.**
- **Result preview and completion text use correct line widths.**

### Fixed
- **Resumed sessions now restore reasoning and tool history.** Persist the exact visible transcript, including thinking durations, tool summaries, result previews, errors, and diffs. Older sessions reconstruct tool calls, results, and edit fragments from their stored model messages when possible.
- **@-file autocomplete now shows files created during the session.** File list is re-scanned each time the `@` popup opens instead of being computed once on mount.

### Release flow
Once this PR is merged into `main`, tag the merge commit with `v0.4.3` to trigger the npm publish workflow.