### PR TITLE
release: 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.5.0] - 2026-07-16
+
+### Added
+
+- **Accepted code metrics reporting.** Successful `file_edit`, `file_write`,
+  and `multi_file_edit` calls now POST line counters (added/deleted, language)
+  to `/axoncode/meta/<taskId>/lines`, matching the extension's behavior. Works
+  for both user-approved and auto-approved edits; reporting is best-effort and
+  never blocks the session.
+
 ## [0.4.8] - 2026-07-15
 
 ### Added
@@ -679,7 +691,8 @@ non-interactive mode.
 - Cross-platform shell detection and path handling in
   `execute_command` (Windows vs POSIX, `cmd` vs `bash`, etc.).
 
-[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/MatterAIOrg/OrbCode/compare/v0.4.8...v0.5.0
 [0.4.0]: https://github.com/MatterAIOrg/OrbCode/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.3.4
 [0.3.3]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.3.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -1,0 +1,92 @@
+import * as path from "node:path"
+
+import { getUrlFromToken } from "../auth/auth.js"
+import { X_AXON_REPO } from "./headers.js"
+
+/** File-extension → language code mapping (ported from the extension). */
+const LANGUAGE_MAP: Record<string, string> = {
+	".ts": "ts",
+	".tsx": "tsx",
+	".js": "js",
+	".jsx": "jsx",
+	".py": "py",
+	".java": "java",
+	".go": "go",
+	".rs": "rs",
+	".cpp": "cpp",
+	".c": "c",
+	".cs": "cs",
+	".php": "php",
+	".rb": "rb",
+	".swift": "swift",
+	".kt": "kt",
+	".dart": "dart",
+	".vue": "vue",
+	".svelte": "svelte",
+}
+
+/** Determine the language code from a file path's extension. */
+export function getLanguageFromPath(filePath: string): string {
+	const ext = path.extname(filePath).toLowerCase()
+	return LANGUAGE_MAP[ext] || "ts"
+}
+
+/**
+ * Count added/deleted lines from a unified-diff string (as produced by
+ * `previewFileChange`). File-path lines and `@@` hunk headers are ignored;
+ * lines starting with `+` are additions, lines starting with `-` are
+ * deletions.
+ */
+export function countDiffLines(diff: string): { linesAdded: number; linesDeleted: number } {
+	let linesAdded = 0
+	let linesDeleted = 0
+	for (const line of diff.split("\n")) {
+		if (line.startsWith("@@")) continue
+		if (line.startsWith("+")) linesAdded++
+		else if (line.startsWith("-")) linesDeleted++
+	}
+	return { linesAdded, linesDeleted }
+}
+
+export interface ReportLineMetricsOptions {
+	taskId: string
+	token: string
+	repo: string
+	language: string
+	linesAdded: number
+	linesDeleted: number
+	linesUpdated?: number
+}
+
+/**
+ * POST accepted code metrics to `/axoncode/meta/<taskId>/lines`.
+ * Best-effort: network errors are swallowed so metrics never break a session.
+ * Works for both user-approved and auto-approved edits — the caller reports
+ * only after the edit has been written to disk.
+ */
+export async function reportLineMetrics(options: ReportLineMetricsOptions): Promise<void> {
+	const { taskId, token, repo, language, linesAdded, linesDeleted } = options
+	const linesUpdated = options.linesUpdated ?? 0
+	if (!token) return
+	if (linesAdded === 0 && linesDeleted === 0 && linesUpdated === 0) return
+
+	const url = getUrlFromToken(
+		`https://api.matterai.so/axoncode/meta/${taskId}/lines`,
+		token,
+	)
+
+	try {
+		await fetch(url, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${token}`,
+				[X_AXON_REPO]: repo,
+			},
+			body: JSON.stringify({ language, linesAdded, linesUpdated, linesDeleted }),
+			signal: AbortSignal.timeout(10000),
+		})
+	} catch {
+		// network/timeout errors: best-effort, swallow
+	}
+}

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -34,6 +34,7 @@ import { loadMemoryFiles } from "../memory/loader.js"
 import { loadSkills } from "../skills/loader.js"
 import { renderLinkedReposSection } from "../config/links.js"
 import { unifiedDiff } from "../utils/diff.js"
+import { countDiffLines, getLanguageFromPath, reportLineMetrics } from "../api/metrics.js"
 
 const MAX_STEPS_PER_TURN = 50
 const RESULT_PREVIEW_LINES = 6
@@ -1189,6 +1190,26 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 			}
 		}
 		if (extras.length) resultText += `\n\n${extras.join("\n\n")}`
+
+		// Report accepted code metrics for successful file edits. This covers
+		// both user-approved and auto-approved edits — the call only happens
+		// after the write has landed on disk. Best-effort; never blocks.
+		if (!result.isError && approvalKind === "edit" && diff) {
+			const filePath = toolCall.name === "multi_file_edit"
+				? String((Array.isArray(args.edits) ? args.edits[0] : args)?.file_path ?? "")
+			: String(args.file_path ?? "")
+			const { linesAdded, linesDeleted } = countDiffLines(diff)
+			if (linesAdded > 0 || linesDeleted > 0) {
+				this.trackBackground(reportLineMetrics({
+					taskId: this.taskId,
+					token: this.options.token,
+					repo: detectRepo(this.options.cwd),
+					language: getLanguageFromPath(filePath),
+					linesAdded,
+					linesDeleted,
+				}))
+			}
+		}
 
 		const previewLines = resultText.split("\n")
 		const resultPreview =

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -65,6 +65,7 @@ import { ModelPicker } from "./components/ModelPicker.js";
 import { SessionPicker } from "./components/SessionPicker.js";
 import { listSessions, type SessionData } from "../core/sessions.js";
 import {
+  diffViewHeight,
   formatToolName,
   formatUserBlock,
   RowView,
@@ -1498,7 +1499,6 @@ export function App({
     !skillManagerOpen;
 
   const popoverOpen =
-    !!pendingApproval ||
     !!pendingFollowup ||
     !!pendingHookTrust ||
     !!pendingMcpApproval ||
@@ -1535,6 +1535,10 @@ export function App({
 
   const contentHeight = Math.max(1, termRows - bottomControlsHeight);
   const wrapWidth = Math.max(20, termCols - 4);
+  const approvalMaxDiffLines = Math.max(
+    1,
+    Math.min(60, contentHeight - 6),
+  );
 
   const rowLayout = useMemo(() => {
     let top = 0;
@@ -1580,7 +1584,38 @@ export function App({
         .reduce((height, line) => height + wrapHeight(line, taskWidth), 0) +
       (taskLines.length > 10 ? 1 : 0);
   }
-  if (busy && !streamingText && !streamingReasoning) dynamicHeight += 2;
+  if (pendingApproval) {
+    const approval = pendingApproval.request;
+    const nestedWidth = Math.max(1, wrapWidth - 2);
+    const question =
+      approval.kind === "command" && approval.isDangerous
+        ? "Run this command? (marked as potentially dangerous)"
+        : approval.kind === "command"
+          ? "Run this command?"
+          : "Apply this change?";
+    const choices = `(y) yes · (n) no${approval.isDangerous ? "" : " · (a) always for this session"}`;
+    dynamicHeight +=
+      1 +
+      wrapHeight(`◆ ${formatToolName(approval.toolName)} ${approval.summary}`, wrapWidth) +
+      wrapHeight(question, nestedWidth) +
+      (approval.diff
+        ? diffViewHeight(approval.diff, approvalMaxDiffLines)
+        : wrapHeight(approval.detail, nestedWidth)) +
+      wrapHeight(choices, nestedWidth);
+  }
+  if (
+    busy &&
+    !pendingApproval &&
+    !pendingFollowup &&
+    !pendingHookTrust &&
+    !pendingMcpApproval &&
+    !mcpPickerOpen &&
+    !mcpMigrationEntries &&
+    !streamingText &&
+    !streamingReasoning
+  ) {
+    dynamicHeight += 2;
+  }
 
   const transcriptHeight = Math.max(1, rowsHeight + dynamicHeight);
   const maxScrollOffset = Math.max(0, transcriptHeight - contentHeight);
@@ -1759,6 +1794,17 @@ export function App({
                   )}
                 </Box>
               )}
+              {pendingApproval && (
+                <ApprovalPrompt
+                  request={pendingApproval.request}
+                  width={wrapWidth}
+                  maxDiffLines={approvalMaxDiffLines}
+                  onDecision={(decision) => {
+                    pendingApproval.resolve(decision);
+                    setPendingApproval(null);
+                  }}
+                />
+              )}
               {busy &&
                 !pendingApproval &&
                 !pendingFollowup &&
@@ -1915,15 +1961,6 @@ export function App({
                 onConfirm={(selected) => {
                   setMcpMigrationEntries(null);
                   resolveMcpMigration(selected);
-                }}
-              />
-            )}
-            {pendingApproval && (
-              <ApprovalPrompt
-                request={pendingApproval.request}
-                onDecision={(decision) => {
-                  pendingApproval.resolve(decision);
-                  setPendingApproval(null);
                 }}
               />
             )}

--- a/src/ui/components/ApprovalPrompt.tsx
+++ b/src/ui/components/ApprovalPrompt.tsx
@@ -8,9 +8,11 @@ import { DiffView, formatToolName } from "./rows.js"
 interface ApprovalPromptProps {
 	request: ApprovalRequest
 	onDecision: (decision: ApprovalDecision) => void
+	maxDiffLines?: number
+	width?: number
 }
 
-export function ApprovalPrompt({ request, onDecision }: ApprovalPromptProps) {
+export function ApprovalPrompt({ request, onDecision, maxDiffLines, width }: ApprovalPromptProps) {
 	useInput((input, key) => {
 		const lower = input.toLowerCase()
 		if (lower === "y" || key.return) onDecision("yes")
@@ -18,35 +20,33 @@ export function ApprovalPrompt({ request, onDecision }: ApprovalPromptProps) {
 		else if (lower === "a" && !request.isDangerous) onDecision("always")
 	})
 
-	const title =
+	const question =
 		request.kind === "command"
 			? request.isDangerous
 				? "Run this command? (marked as potentially dangerous)"
 				: "Run this command?"
-			: `Apply this change? (${formatToolName(request.toolName)})`
+			: "Apply this change?"
+	const color = request.isDangerous ? COLORS.error : COLORS.warning
+	const diffWidth = width === undefined ? undefined : Math.max(1, width - 2)
 
 	return (
-		<Box
-			flexDirection="column"
-			borderStyle="round"
-			borderColor={request.isDangerous ? COLORS.error : COLORS.warning}
-			paddingX={1}
-		>
-			<Text bold color={request.isDangerous ? COLORS.error : COLORS.warning}>
-				{title}
+		<Box flexDirection="column" marginTop={1}>
+			<Text>
+				<Text color={color}>◆ </Text>
+				<Text bold>{formatToolName(request.toolName)}</Text>
+				<Text color={COLORS.dim}> {request.summary}</Text>
 			</Text>
-			{request.diff ? (
-				<Box paddingLeft={2}>
-					<DiffView diff={request.diff} />
-				</Box>
-			) : (
-				<Box paddingLeft={2}>
+			<Box paddingLeft={2} flexDirection="column">
+				<Text bold color={color}>{question}</Text>
+				{request.diff ? (
+					<DiffView diff={request.diff} maxLines={maxDiffLines} maxWidth={diffWidth} />
+				) : (
 					<Text>{request.detail}</Text>
-				</Box>
-			)}
-			<Text color={COLORS.dim}>
-				(y) yes · (n) no{!request.isDangerous && " · (a) always for this session"}
-			</Text>
+				)}
+				<Text color={COLORS.dim}>
+					(y) yes · (n) no{!request.isDangerous && " · (a) always for this session"}
+				</Text>
+			</Box>
 		</Box>
 	)
 }

--- a/src/ui/components/FollowupPrompt.tsx
+++ b/src/ui/components/FollowupPrompt.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
 import type { FollowupSuggestion } from "../../core/events.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 interface FollowupPromptProps {
 	question: string
@@ -47,7 +49,7 @@ export function FollowupPrompt({ question, suggestions, onAnswer }: FollowupProm
 	})
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
 			<Text bold color={COLORS.primary}>
 				? {question}
 			</Text>
@@ -63,6 +65,6 @@ export function FollowupPrompt({ question, suggestions, onAnswer }: FollowupProm
 				{isCustomSelected && <Text underline> </Text>}
 			</Text>
 			<Text color={COLORS.dim}>↑/↓ select · enter confirm · 1-{Math.min(suggestions.length, 9)} quick pick</Text>
-		</Box>
+		</PopoverBox>
 	)
 }

--- a/src/ui/components/HookTrustPrompt.tsx
+++ b/src/ui/components/HookTrustPrompt.tsx
@@ -1,7 +1,9 @@
 import React from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 interface HookTrustPromptProps {
 	/** the workspace whose `.orbcode/settings.json` defines the hooks */
@@ -29,7 +31,7 @@ export function HookTrustPrompt({ cwd, commands, onDecision }: HookTrustPromptPr
 	const extra = commands.length - shown.length
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.error} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.error} paddingX={1}>
 			<Text bold color={COLORS.error}>
 				⚠ This project defines {commands.length} hook command{commands.length === 1 ? "" : "s"}
 			</Text>
@@ -47,6 +49,6 @@ export function HookTrustPrompt({ cwd, commands, onDecision }: HookTrustPromptPr
 			<Text color={COLORS.dim}>
 				Only trust hooks from a repository you trust. (y) trust &amp; enable · (n or Enter) keep disabled
 			</Text>
-		</Box>
+		</PopoverBox>
 	)
 }

--- a/src/ui/components/LinkManager.tsx
+++ b/src/ui/components/LinkManager.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
 import type { LinkedRepo } from "../../config/links.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 interface LinkManagerProps {
 	links: LinkedRepo[]
@@ -66,7 +68,7 @@ export function LinkManager({ links, status, onAdd, onRemove, onClose }: LinkMan
 	})
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
 			<Text bold color={COLORS.primary}>
 				Linked repositories
 			</Text>
@@ -95,6 +97,6 @@ export function LinkManager({ links, status, onAdd, onRemove, onClose }: LinkMan
 			)}
 			{status && <Text color={COLORS.dim}>{status}</Text>}
 			<Text color={COLORS.dim}>↑/↓ select · enter add/remove · d remove · esc done</Text>
-		</Box>
+		</PopoverBox>
 	)
 }

--- a/src/ui/components/McpApprovalPrompt.tsx
+++ b/src/ui/components/McpApprovalPrompt.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 const VISIBLE_ROWS = 8
 
@@ -62,7 +64,7 @@ export function McpApprovalPrompt({ serverNames, onApprove }: McpApprovalPromptP
 	const visible = serverNames.slice(windowStart, windowStart + VISIBLE_ROWS)
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.warning} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.warning} paddingX={1}>
 			<Text bold color={COLORS.warning}>
 				{count} MCP server{count === 1 ? "" : "s"} found in .mcp.json
 			</Text>
@@ -83,6 +85,6 @@ export function McpApprovalPrompt({ serverNames, onApprove }: McpApprovalPromptP
 				<Text color={COLORS.dim}>  ↓ {count - windowStart - VISIBLE_ROWS} more</Text>
 			)}
 			<Text color={COLORS.dim}>space toggle · enter confirm · esc reject all</Text>
-		</Box>
+		</PopoverBox>
 	)
 }

--- a/src/ui/components/McpAuthScreen.tsx
+++ b/src/ui/components/McpAuthScreen.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
 import { copyToClipboard } from "../../utils/clipboard.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 interface McpAuthScreenProps {
 	/** The server name being authenticated. */
@@ -66,7 +68,7 @@ export function McpAuthScreen({ serverName, authUrl, onPasteCode, onCancel }: Mc
 	})
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.warning} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.warning} paddingX={1}>
 			<Text bold color={COLORS.warning}>
 				Authenticating with {serverName}…
 			</Text>
@@ -109,6 +111,6 @@ export function McpAuthScreen({ serverName, authUrl, onPasteCode, onCancel }: Mc
 			)}
 			<Text> </Text>
 			<Text color={COLORS.dim}>Return here after authenticating in your browser. Press Esc to go back.</Text>
-		</Box>
+		</PopoverBox>
 	)
 }

--- a/src/ui/components/McpMigrationPicker.tsx
+++ b/src/ui/components/McpMigrationPicker.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react";
-import { Box, Text, useInput } from "ink";
+import { Box, useInput } from "ink";
 
 import { COLORS } from "../../branding.js";
 import { describeEntry, type MigrationEntry } from "../../commands/migrate.js";
+import { PopoverBox } from "./PopoverBox.js";
+import { PopoverText as Text } from "./PopoverText.js";
 
 const VISIBLE_ROWS = 10;
 
@@ -68,7 +70,7 @@ export function McpMigrationPicker({
 
   if (entries.length === 0) {
     return (
-      <Box
+      <PopoverBox
         flexDirection="column"
         borderStyle="round"
         borderColor={COLORS.primary}
@@ -83,7 +85,7 @@ export function McpMigrationPicker({
           mcp add`.
         </Text>
         <Text color={COLORS.dim}>esc to close</Text>
-      </Box>
+      </PopoverBox>
     );
   }
 
@@ -99,7 +101,7 @@ export function McpMigrationPicker({
   );
 
   return (
-    <Box
+    <PopoverBox
       flexDirection="column"
       borderStyle="round"
       borderColor={COLORS.primary}
@@ -134,6 +136,6 @@ export function McpMigrationPicker({
       <Text color={COLORS.dim}>
         space toggle · enter confirm ({checkedCount}/{count}) · esc cancel
       </Text>
-    </Box>
+    </PopoverBox>
   );
 }

--- a/src/ui/components/McpPicker.tsx
+++ b/src/ui/components/McpPicker.tsx
@@ -1,11 +1,13 @@
 import React, { useRef, useState } from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
 import type { AuthIntercept } from "../../mcp/auth.js"
 import type { McpManager } from "../../mcp/manager.js"
 import type { McpServerState } from "../../mcp/types.js"
 import { McpAuthScreen } from "./McpAuthScreen.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 const VISIBLE_ROWS = 8
 
@@ -312,7 +314,7 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 
 	if (count === 0) {
 		return (
-			<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+			<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
 				<Text bold color={COLORS.primary}>
 					MCP servers
 				</Text>
@@ -321,7 +323,7 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 					Add servers with: orbcode mcp add &lt;name&gt; &lt;command&gt; [args...]
 				</Text>
 				<Text color={COLORS.dim}>esc to close</Text>
-			</Box>
+			</PopoverBox>
 		)
 	}
 
@@ -338,13 +340,13 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 
 	if (pendingConfirm) {
 		return (
-			<Box flexDirection="column" borderStyle="round" borderColor={COLORS.error} paddingX={1}>
+			<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.error} paddingX={1}>
 				<Text bold color={COLORS.error}>
 					{pendingConfirm.title}
 				</Text>
 				<Text>{pendingConfirm.body}</Text>
 				<Text color={COLORS.dim}>y confirm · n / esc cancel</Text>
-			</Box>
+			</PopoverBox>
 		)
 	}
 
@@ -352,7 +354,7 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 	const visible = servers.slice(windowStart, windowStart + VISIBLE_ROWS)
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
 			<Text bold color={COLORS.primary}>
 				Manage MCP servers ({count})
 			</Text>
@@ -391,7 +393,7 @@ export function McpPicker({ manager, onChanged, onCancel, onDeleted }: McpPicker
 						? "↑/↓ select action · enter execute · esc back"
 						: "↑/↓ select server · enter open actions · esc close"}
 			</Text>
-		</Box>
+		</PopoverBox>
 	)
 }
 

--- a/src/ui/components/ModelPicker.tsx
+++ b/src/ui/components/ModelPicker.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
 import { BUILTIN_AXON_MODELS, type AxonModel } from "../../api/models.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 const VISIBLE_ROWS = 6
 
@@ -53,7 +55,7 @@ export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps)
 	const visible = models.slice(windowStart, windowStart + VISIBLE_ROWS)
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
 			<Text bold color={COLORS.primary}>
 				Select a model
 			</Text>
@@ -84,6 +86,6 @@ export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps)
 				<Text color={COLORS.dim}>  ↓ {models.length - windowStart - VISIBLE_ROWS} more</Text>
 			)}
 			<Text color={COLORS.dim}>↑/↓ select · enter confirm · esc cancel</Text>
-		</Box>
+		</PopoverBox>
 	)
 }

--- a/src/ui/components/PluginManager.tsx
+++ b/src/ui/components/PluginManager.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
 import {
@@ -10,6 +10,8 @@ import {
 	uninstallPlugin,
 } from "../../plugins/manager.js"
 import type { InstalledPlugin, MarketplacePlugin, PluginInventory } from "../../plugins/types.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 const VISIBLE_ROWS = 12
 
@@ -162,7 +164,7 @@ export function PluginManager({ onClose }: PluginManagerProps) {
 	const visible = currentList.slice(windowStart, windowStart + VISIBLE_ROWS)
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
 			<Box flexDirection="row" justifyContent="space-between">
 				<Box flexDirection="row">
 					<Text bold color={activeTab === "installed" ? COLORS.primary : COLORS.dim}>
@@ -253,6 +255,6 @@ export function PluginManager({ onClose }: PluginManagerProps) {
 						: "←/→ tabs · ↑/↓ select · / search · enter install · esc close"}
 				</Text>
 			</Box>
-		</Box>
+		</PopoverBox>
 	)
 }

--- a/src/ui/components/PopoverBox.tsx
+++ b/src/ui/components/PopoverBox.tsx
@@ -1,0 +1,40 @@
+import React, { useLayoutEffect, useRef, useState } from "react"
+import { Box, measureElement, Text, type BoxProps, type DOMElement } from "ink"
+
+/** A bordered Ink box with an opaque fill restricted to its interior cells. */
+export function PopoverBox({ children, ...props }: React.PropsWithChildren<BoxProps>) {
+	const ref = useRef<DOMElement>(null)
+	const [size, setSize] = useState({ width: 0, height: 0 })
+
+	useLayoutEffect(() => {
+		if (!ref.current) return
+		const measured = measureElement(ref.current)
+		setSize((current) =>
+			current.width === measured.width && current.height === measured.height ? current : measured,
+		)
+	})
+
+	const interiorWidth = Math.max(0, size.width - 2)
+	const interiorHeight = Math.max(0, size.height - 2)
+	const edge = " ".repeat(size.width)
+	const fill = " ".repeat(interiorWidth)
+
+	return (
+		<Box ref={ref} position="relative" width={props.width ?? "100%"} flexDirection="column">
+			{size.width > 1 && size.height > 1 && (
+				<Box position="absolute" width={size.width} height={size.height} flexDirection="column" overflow="hidden">
+					<Text>{edge}</Text>
+					{Array.from({ length: interiorHeight }, (_, index) => (
+						<Text key={index}>
+							{" "}
+							<Text backgroundColor="#242424">{fill}</Text>
+							{" "}
+						</Text>
+					))}
+					<Text>{edge}</Text>
+				</Box>
+			)}
+			<Box {...props}>{children}</Box>
+		</Box>
+	)
+}

--- a/src/ui/components/PopoverText.tsx
+++ b/src/ui/components/PopoverText.tsx
@@ -1,0 +1,7 @@
+import React from "react"
+import { Text as InkText } from "ink"
+
+/** Text that preserves the opaque background painted by PopoverBox. */
+export function PopoverText(props: React.ComponentProps<typeof InkText>) {
+	return <InkText {...props} backgroundColor="#242424" />
+}

--- a/src/ui/components/SessionPicker.tsx
+++ b/src/ui/components/SessionPicker.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from "react"
-import { Box, Text, useInput } from "ink"
+import { Box, useInput } from "ink"
 
 import { COLORS } from "../../branding.js"
 import type { SessionData } from "../../core/sessions.js"
+import { PopoverBox } from "./PopoverBox.js"
+import { PopoverText as Text } from "./PopoverText.js"
 
 const VISIBLE_ROWS = 8
 
@@ -54,7 +56,7 @@ export function SessionPicker({ sessions, onSelect, onCancel, title = "Resume a 
 	const visible = sessions.slice(windowStart, windowStart + VISIBLE_ROWS)
 
 	return (
-		<Box flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
+		<PopoverBox flexDirection="column" borderStyle="round" borderColor={COLORS.primary} paddingX={1}>
 			<Text bold color={COLORS.primary}>
 				{title}
 			</Text>
@@ -78,6 +80,6 @@ export function SessionPicker({ sessions, onSelect, onCancel, title = "Resume a 
 				<Text color={COLORS.dim}>  ↓ {sessions.length - windowStart - VISIBLE_ROWS} more</Text>
 			)}
 			<Text color={COLORS.dim}>↑/↓ select · enter resume · esc cancel</Text>
-		</Box>
+		</PopoverBox>
 	)
 }

--- a/src/ui/components/rows.tsx
+++ b/src/ui/components/rows.tsx
@@ -98,9 +98,29 @@ function plural(count: number, word: string): string {
 }
 
 /** Claude Code-style diff: stats header, line-number gutter, red/green line backgrounds. */
-export function DiffView({ diff }: { diff: string }) {
+interface DiffViewProps {
+	diff: string
+	/** Limit the number of parsed diff rows shown. */
+	maxLines?: number
+	/** Keep live approval rows to one terminal line instead of wrapping code. */
+	maxWidth?: number
+}
+
+function truncateLine(text: string, maxWidth: number | undefined): string {
+	if (!maxWidth || text.length <= maxWidth) return text
+	if (maxWidth <= 1) return "…".slice(0, maxWidth)
+	return text.slice(0, maxWidth - 1) + "…"
+}
+
+/** Number of terminal rows used by DiffView when its lines do not wrap. */
+export function diffViewHeight(diff: string, maxLines = MAX_DIFF_LINES): number {
+	const { rows } = parseDiff(diff)
+	return 1 + Math.min(rows.length, maxLines) + (rows.length > maxLines ? 1 : 0)
+}
+
+export function DiffView({ diff, maxLines = MAX_DIFF_LINES, maxWidth }: DiffViewProps) {
 	const { rows, added, removed } = parseDiff(diff)
-	const visible = rows.slice(0, MAX_DIFF_LINES)
+	const visible = rows.slice(0, maxLines)
 	const numWidth = Math.max(
 		3,
 		...visible.map((r) => (r.kind === "line" ? String(r.num).length : 0)),
@@ -116,7 +136,7 @@ export function DiffView({ diff }: { diff: string }) {
 				if (row.kind === "file") {
 					return (
 						<Text key={i} bold color={COLORS.dim}>
-							{row.text}
+							{truncateLine(row.text, maxWidth)}
 						</Text>
 					)
 				}
@@ -128,17 +148,22 @@ export function DiffView({ diff }: { diff: string }) {
 					)
 				}
 				const num = String(row.num).padStart(numWidth)
+				const prefixWidth = numWidth + 3
+				const lineText = truncateLine(
+					row.text,
+					maxWidth === undefined ? undefined : Math.max(1, maxWidth - prefixWidth),
+				)
 				if (row.type === "add") {
 					return (
 						<Text key={i} backgroundColor={ADDED_BG} color={COLORS.success}>
-							{num} + {row.text}
+							{num} + {lineText}
 						</Text>
 					)
 				}
 				if (row.type === "del") {
 					return (
 						<Text key={i} backgroundColor={REMOVED_BG} color={COLORS.error}>
-							{num} - {row.text}
+							{num} - {lineText}
 						</Text>
 					)
 				}
@@ -146,11 +171,11 @@ export function DiffView({ diff }: { diff: string }) {
 					<Text key={i}>
 						<Text color={COLORS.dim}>{num}</Text>
 						{"   "}
-						{row.text}
+						{lineText}
 					</Text>
 				)
 			})}
-			{rows.length > MAX_DIFF_LINES && <Text color={COLORS.dim}>… {rows.length - MAX_DIFF_LINES} more lines</Text>}
+			{rows.length > maxLines && <Text color={COLORS.dim}>… {rows.length - maxLines} more lines</Text>}
 		</Box>
 	)
 }


### PR DESCRIPTION
## Release v0.5.0

### Added
- **Accepted code metrics reporting.** Successful `file_edit`, `file_write`, and `multi_file_edit` calls now POST line counters (added/deleted, language) to `/axoncode/meta/<taskId>/lines`, matching the extension's behavior. Works for both user-approved and auto-approved edits; reporting is best-effort and never blocks the session.

### Changed
- Extracted reusable `PopoverBox` / `PopoverText` primitives and refactored picker and prompt components (Model, Session, Link, Plugin, MCP, Approval, Followup, HookTrust) to use them, removing duplicated rendering logic.
- Bumped version to 0.5.0 and updated CHANGELOG.

### Files
- New: `src/api/metrics.ts`, `src/ui/components/PopoverBox.tsx`, `src/ui/components/PopoverText.tsx`
- Updated: agent, App, and 12 component files