### PR TITLE
fix: anchor streaming transcript to bottom so live edge stays visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Streaming responses stay visible above the input box.** The transcript's
+  live edge is now anchored using its rendered layout instead of relying on
+  approximate text-height calculations, so word-wrapped final lines are not
+  clipped behind the composer.
+
 ## [0.5.1] - 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {
@@ -36,6 +36,7 @@
     "test:attachments": "node --import tsx --test test/attachments.test.ts",
     "test:mcp": "node --import tsx --test test/mcp-client.test.ts",
     "test:plugins": "node --import tsx --test test/plugins.test.ts",
+    "test:ui": "bun test test/ui-viewport.test.tsx",
     "prepublishOnly": "npm run typecheck && npm run build"
   },
   "dependencies": {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -80,6 +80,7 @@ import {
 } from "./components/rows.js";
 import { LinkManager } from "./components/LinkManager.js";
 import { PluginManager } from "./components/PluginManager.js";
+import { TranscriptViewport } from "./components/TranscriptViewport.js";
 import {
   addLink,
   loadLinks,
@@ -1702,6 +1703,12 @@ export function App({
   ]);
   const virtualTranscriptMarginTop = transcriptMarginTop + virtualRows.startY;
   const rowBottomSpacerHeight = Math.max(0, rowsHeight - virtualRows.endY);
+  // Height estimates are only an approximation of OpenTUI's word wrapping.
+  // At the live edge, let Yoga align the rendered content itself so the last
+  // line always remains above the composer even when an earlier row wrapped to
+  // more lines than estimated. Estimates still drive virtualization/scrolling.
+  const anchorTranscriptToBottom =
+    !introHeaderOnly && effectiveScrollOffset === 0;
 
   useEffect(() => {
     setScrollOffset((current) => Math.min(current, maxScrollOffset));
@@ -1738,17 +1745,13 @@ export function App({
           minHeight={0}
           overflow="hidden"
         >
-          <Box
-            flexDirection="column"
-            flexGrow={1}
-            flexShrink={1}
-            minHeight={0}
-            overflow="hidden"
-          >
+          <TranscriptViewport anchorToBottom={anchorTranscriptToBottom}>
             <Box
               flexDirection="column"
               flexShrink={0}
-              marginTop={virtualTranscriptMarginTop}
+              marginTop={
+                anchorTranscriptToBottom ? 0 : virtualTranscriptMarginTop
+              }
             >
               {virtualRows.rows.map((row) => (
                 <RowView key={row.id} row={row} width={wrapWidth} />
@@ -1859,7 +1862,7 @@ export function App({
                   </Box>
                 )}
             </Box>
-          </Box>
+          </TranscriptViewport>
           <Box flexDirection="column" flexShrink={0}>
             {queuedMessages.length > 0 && (
               <Box flexDirection="column" paddingLeft={1} marginBottom={1}>

--- a/src/ui/components/TranscriptViewport.tsx
+++ b/src/ui/components/TranscriptViewport.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { Box } from "../primitives.js";
+
+/**
+ * Clips transcript overflow while keeping the live edge aligned from the
+ * renderer's real layout. This avoids relying on approximate wrapped heights
+ * to keep the final response line above the composer.
+ */
+export function TranscriptViewport({
+  anchorToBottom,
+  children,
+}: React.PropsWithChildren<{ anchorToBottom: boolean }>) {
+  return (
+    <Box
+      flexDirection="column"
+      flexGrow={1}
+      flexShrink={1}
+      minHeight={0}
+      overflow="hidden"
+      justifyContent={anchorToBottom ? "flex-end" : "flex-start"}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/test/ui-viewport.test.tsx
+++ b/test/ui-viewport.test.tsx
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import React, { act } from "react";
+import { testRender } from "@opentui/react/test-utils";
+
+import { Box, Text } from "../src/ui/primitives.js";
+import { TranscriptViewport } from "../src/ui/components/TranscriptViewport.js";
+
+test("keeps the wrapped live response above the composer", async () => {
+  const finalResponse =
+    "● Pushed to main as 51610d9. The local commits rebased cleanly onto the remote sitemap update and went up. Working tree is clean and in sync with origin/main.";
+  const transcript = [
+    "Execute Command git pull --rebase --autostash origin main && git push origin main",
+    "From github.com:MatterAIOrg/matter-website",
+    "branch main -> FETCH_HEAD",
+    "Rebasing (1/1)",
+    "Successfully rebased and updated refs/heads/main.",
+    "To github.com:MatterAIOrg/matter-website.git",
+    "fb0ac03..51610d9 main -> main",
+    "… (7 lines)",
+    finalResponse,
+  ].join("\n");
+
+  const screen = await testRender(
+    <Box flexDirection="column" width={54} height={14}>
+      <TranscriptViewport anchorToBottom>
+        <Box flexDirection="column" flexShrink={0}>
+          <Text>{transcript}</Text>
+        </Box>
+      </TranscriptViewport>
+      <Box flexDirection="column" height={4} flexShrink={0}>
+        <Text>{"INPUT\nSTATUS"}</Text>
+      </Box>
+    </Box>,
+    { width: 54, height: 14 },
+  );
+
+  try {
+    await screen.renderOnce();
+    const rows = screen.captureCharFrame().split("\n");
+    const finalRow = rows.findIndex((row) => row.includes("origin/main."));
+    const composerRow = rows.findIndex((row) => row.includes("INPUT"));
+
+    assert.notEqual(finalRow, -1);
+    assert.notEqual(composerRow, -1);
+    assert.equal(finalRow, composerRow - 1);
+  } finally {
+    act(() => screen.renderer.destroy());
+  }
+});


### PR DESCRIPTION
## Summary

The transcript's live edge was being placed using an approximate text-height calculation that underestimated word-wrapped final lines, so the most recently streamed text would be clipped behind the composer when the user hadn't scrolled.

## What changed

- New `src/ui/components/TranscriptViewport.tsx` that anchors the live edge to the rendered layout (when scrolled to the bottom), letting Yoga drive the final position so word-wrapped content is no longer clipped.
- `src/ui/App.tsx` wires the new viewport in. Estimates still drive virtualization and scrolling, so behaviour is preserved when the user has scrolled away from the bottom.
- Added `test/ui-viewport.test.tsx` covering the new viewport behaviour.
- `package.json`: bumps version to `0.5.2` and adds `test:ui` script.
- `CHANGELOG.md`: entry under `[Unreleased]` / `Fixed`.

## Test plan

- [ ] `npm run typecheck`
- [ ] `bun test test/ui-viewport.test.tsx`
- [ ] Manual: in a TUI session, stream a long response that wraps to the final line; the last word should remain visible above the input box.

## Notes

Non-release branch (`fix/transcript-live-edge-anchoring`); no npm release is triggered by this PR.