### PR TITLE
release: v0.5.3 — figma_fetch tool + auto-fetch from user messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Figma design context (`figma_fetch` tool).** A new native tool fetches the
+  full node tree, components, styles, and rendered image URLs for any
+  `figma.com/design/`, `/file/`, or `/proto/` URL. Requests are authenticated
+  against the MatterAI backend (`/axoncode/figma`), which uses the org's
+  configured Figma access token so callers don't need to handle credentials.
+- **Auto-fetch Figma URLs from user messages.** When a user pastes a Figma
+  link into a prompt, the agent scans the message for Figma URLs and
+  pre-fetches each one before the first model completion. The design data is
+  injected as a tool result, so the model has visual + structural context
+  from step 0 without having to discover and call `figma_fetch` itself.
+  URLs are deduped and trailing punctuation is stripped.
+
 ### Fixed
 
 - **Streaming responses stay visible above the input box.** The transcript's

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -21,6 +21,7 @@ import {
 } from "../tools/index.js"
 import { walkFiles } from "../tools/executors/listFiles.js"
 import { previewFileChange } from "../tools/executors/files.js"
+import { extractFigmaUrls, figmaFetch } from "../tools/executors/figma.js"
 import type { AgentCallbacks, AgentEvent, ApprovalDecision } from "./events.js"
 import {
 	getSessionFilePath,
@@ -677,6 +678,51 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 						]
 					: userContent,
 		})
+
+		// --- Auto-fetch Figma URLs from the user's message ---
+		// Instead of relying on the model to call figma_fetch, we scan the
+		// user's text for figma.com URLs and pre-fetch each one so the design
+		// data is always available to the model from the first completion.
+		// This runs once per URL, deterministically.
+		const figmaUrls = extractFigmaUrls(userText)
+		if (figmaUrls.length > 0) {
+			const ctx = this.toolContext()
+			const autoToolCalls = figmaUrls.map((figmaUrl, i) => ({
+				id: `figma_auto_${Date.now()}_${i}`,
+				name: "figma_fetch",
+				arguments: JSON.stringify({ url: figmaUrl }),
+			}))
+			// Push the assistant tool_calls message so the API accepts the
+			// tool results that follow.
+			this.messages.push({
+				role: "assistant",
+				content: "",
+				tool_calls: autoToolCalls.map((tc) => ({
+					id: tc.id,
+					type: "function" as const,
+					function: { name: tc.name, arguments: tc.arguments },
+				})),
+			})
+			for (const toolCall of autoToolCalls) {
+				const summary = describeToolCall(toolCall.name, JSON.parse(toolCall.arguments))
+				onEvent({ type: "tool-start", id: toolCall.id, name: toolCall.name, summary })
+				const result = await figmaFetch(JSON.parse(toolCall.arguments), ctx)
+				const resultText = result.text
+				this.messages.push({ role: "tool", tool_call_id: toolCall.id, content: resultText })
+				const previewLines = resultText.split("\n")
+				const resultPreview =
+					previewLines.slice(0, RESULT_PREVIEW_LINES).join("\n") +
+					(previewLines.length > RESULT_PREVIEW_LINES ? `\n… (${previewLines.length} lines)` : "")
+				onEvent({
+					type: "tool-end",
+					id: toolCall.id,
+					name: toolCall.name,
+					summary,
+					resultPreview,
+					isError: Boolean(result.isError),
+				})
+			}
+		}
 
 		try {
 			this.stopHookActive = false

--- a/src/tools/executors/figma.ts
+++ b/src/tools/executors/figma.ts
@@ -1,0 +1,88 @@
+import { getUrlFromToken } from "../../auth/auth.js"
+import type { ToolContext, ToolResult } from "../types.js"
+
+// Calls the MatterAI backend's /axoncode/figma endpoint, which uses the
+// org's configured Figma access token to fetch design data from the Figma
+// REST API. The backend returns the full node tree + rendered image URLs.
+
+interface FigmaDesignData {
+	fileKey: string
+	nodeId: string | null
+	name: string
+	lastModified: string
+	thumbnailUrl: string
+	nodes: Record<string, { document: unknown; components: Record<string, unknown> }>
+	components: Record<string, unknown>
+	styles: Record<string, unknown>
+	images: Record<string, string | null>
+}
+
+interface FigmaFetchResponse {
+	success: boolean
+	data?: FigmaDesignData
+	error?: string
+}
+
+export async function figmaFetch(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
+	const url = String(args.url ?? "")
+	if (!url) return { text: "FAILED: url is empty", isError: true }
+
+	try {
+		new URL(url)
+	} catch {
+		return { text: `Invalid URL format: ${url}`, isError: true }
+	}
+
+	try {
+		const apiUrl = getUrlFromToken("https://api.matterai.so/axoncode/figma", context.token)
+		const response = await fetch(apiUrl, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${context.token}`,
+			},
+			body: JSON.stringify({ url, render_images: true, image_format: "png" }),
+			signal: AbortSignal.timeout(60_000),
+		})
+
+		if (!response.ok) {
+			const body = (await response.json().catch(() => ({}))) as { error?: string }
+			return { text: `Figma fetch failed (${response.status}): ${body.error ?? response.statusText}`, isError: true }
+		}
+
+		const data = (await response.json()) as FigmaFetchResponse
+		if (!data.success || !data.data) {
+			return { text: data.error ?? "Could not fetch the Figma design.", isError: true }
+		}
+
+		const d = data.data
+		const imageUrls = Object.entries(d.images ?? {})
+			.map(([id, u]) => `node ${id}: ${u}`)
+			.join("\n")
+
+		const resultText =
+			`Figma file: ${d.name} (key: ${d.fileKey})\n` +
+			`Last modified: ${d.lastModified}\n` +
+			`Thumbnail: ${d.thumbnailUrl}\n` +
+			`Nodes:\n` +
+			JSON.stringify(d.nodes, null, 2) +
+			(imageUrls ? `\n\nRendered images:\n${imageUrls}` : "")
+
+		return { text: `Figma design data for ${url}:\n\n${resultText}` }
+	} catch (error) {
+		return { text: `Figma fetch failed: ${(error as Error).message}`, isError: true }
+	}
+}
+
+/**
+ * Extract unique Figma URLs from a block of text.
+ * Matches figma.com/design/, /file/, /proto/ URLs (with or without node-id).
+ */
+const FIGMA_URL_REGEX = /https?:\/\/(?:www\.)?figma\.com\/(?:design|file|proto)\/[A-Za-z0-9]+\/[^\s"'<>]*/gi
+
+export function extractFigmaUrls(text: string): string[] {
+	if (!text) return []
+	const matches = text.match(FIGMA_URL_REGEX) || []
+	// Dedupe while preserving order; strip trailing punctuation
+	return [...new Set(matches.map((u) => u.replace(/[.,;:!?)]+$/, "")))]
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,6 +8,7 @@ import { searchFiles } from "./executors/searchFiles.js"
 import { executeCommand } from "./executors/executeCommand.js"
 import { useSkill } from "./executors/skills.js"
 import { webFetch, webSearch } from "./executors/web.js"
+import { figmaFetch } from "./executors/figma.js"
 import type { McpManager } from "../mcp/manager.js"
 
 export { nativeTools }
@@ -53,6 +54,8 @@ export function describeToolCall(toolName: string, args: Record<string, unknown>
 			return String(args.query ?? "")
 		case "web_fetch":
 			return String(args.url ?? "")
+		case "figma_fetch":
+			return String(args.url ?? "")
 		case "update_todo_list":
 			return "updating tasks"
 		case "use_skill":
@@ -81,6 +84,7 @@ const executors: Record<string, (args: Record<string, unknown>, context: ToolCon
 	execute_command: executeCommand,
 	web_search: webSearch,
 	web_fetch: webFetch,
+	figma_fetch: figmaFetch,
 	use_skill: useSkill,
 	update_todo_list: async (args, context) => {
 		context.setTodos(String(args.todos ?? ""))

--- a/src/tools/schemas/figma_fetch.ts
+++ b/src/tools/schemas/figma_fetch.ts
@@ -1,0 +1,23 @@
+import type OpenAI from "openai"
+
+export default {
+	type: "function",
+	function: {
+		name: "figma_fetch",
+		description:
+			"Fetch design data from a Figma URL. Returns the complete node tree (layout, styles, text content, nested children, components) and rendered image URLs for the file or a specific frame. Use this whenever the user shares a Figma link and wants design context, code generation from a design, or analysis of a Figma frame.",
+		strict: true,
+		parameters: {
+			type: "object",
+			properties: {
+				url: {
+					type: "string",
+					description:
+						"The full Figma URL, e.g. https://www.figma.com/design/<key>/<title>?node-id=1-2",
+				},
+			},
+			required: ["url"],
+			additionalProperties: false,
+		},
+	},
+} satisfies OpenAI.Chat.ChatCompletionTool

--- a/src/tools/schemas/index.ts
+++ b/src/tools/schemas/index.ts
@@ -11,6 +11,7 @@ import { read_file_single } from "./read_file.js"
 import searchFiles from "./search_files.js"
 import updateTodoList from "./update_todo_list.js"
 import useSkill from "./use_skill.js"
+import figmaFetch from "./figma_fetch.js"
 import webFetch from "./web_fetch.js"
 import webSearch from "./web_search.js"
 
@@ -30,6 +31,7 @@ export const nativeTools = [
 	searchFiles,
 	updateTodoList,
 	useSkill,
+	figmaFetch,
 	webFetch,
 	webSearch,
 ] satisfies OpenAI.Chat.ChatCompletionTool[]


### PR DESCRIPTION
## Summary

Adds native Figma integration so the agent can pull design context directly from a Figma link in the user's message, with no Figma credentials required on the client.

### Added
- **`figma_fetch` native tool** — fetches the full node tree, components, styles, and rendered image URLs for any `figma.com/design/`, `/file/`, or `/proto/` URL. Authenticated against the MatterAI backend's `/axoncode/figma` endpoint using the org's configured Figma access token. 60s timeout; both invalid URLs and backend failures return `isError: true`.
- **Auto-fetch Figma URLs from user messages** — when a user pastes a Figma link, the agent scans the message, pre-fetches each URL, and injects the result as a `role: "tool"` message before the first model completion. URLs are deduped (order-preserving) and trailing punctuation is stripped. Emits `tool-start` / `tool-end` events so the TUI shows progress.
- **CHANGELOG entry** under `[Unreleased]` for both items above.

### Changed
- Bumps version `0.5.2` → `0.5.3`.

## Commits

1. `feat(tools): add figma_fetch native tool` — schema, executor, dispatch wiring, CHANGELOG
2. `feat(agent): auto-fetch Figma URLs from user messages` — pre-fetch loop in `Agent.run`
3. `chore(release): bump version to 0.5.3` — `package.json`

## Test plan

- [ ] Send a prompt containing a `figma.com/design/<key>/<title>` URL and confirm a `figma_fetch` tool call appears in the transcript and the model references design data in its response.
- [ ] Paste multiple distinct Figma URLs in one message and confirm they are deduped and each fetched once.
- [ ] Paste a malformed URL (or no Figma URL) and confirm the model still responds normally without spurious tool calls.
- [ ] Run `npm run typecheck` and `npm run build` — both pass.
- [ ] Confirm `figma_fetch` does not require approval in the TUI (read-only data fetch).

## Risk

Low. The auto-fetch runs only on URLs already present in the user's text and only POSTs to the existing MatterAI backend. `figma_fetch` is read-only and does not modify the filesystem.