### PR TITLE
Release v0.5.5: external skill paths, Figma MCP guard, weekly-reset and create-skill commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`/create-skill` slash command.** Describe a repository-specific workflow in
+  plain language and OrbCode creates or updates a reusable skill under
+  `.orb/skills/<skill-name>/`, keeping any supporting scripts, references, and
+  assets inside the same skill directory.
 - **Figma design context (`figma_fetch` tool).** A new native tool fetches the
   full node tree, components, styles, and rendered image URLs for any
   `figma.com/design/`, `/file/`, or `/proto/` URL. Requests are authenticated

--- a/README.md
+++ b/README.md
@@ -310,7 +310,9 @@ MatterAI gateway untouched.
 | `/tasks`     | print the current task list                                                                           |
 | `/status`    | version, model, account, gateway, context usage, cost, approval modes                                 |
 | `/usage`     | fetch plan usage                                                                                      |
+| `/weekly-reset` | reset weekly usage (Pro and above, once per monthly billing cycle)                                    |
 | `/init`      | analyze the codebase and create/improve `AGENTS.md` in the repo's `.orb/` directory                   |
+| `/create-skill <description>` | create or update a repository skill under `.orb/skills/<skill-name>/` from a plain-language prompt |
 | `/task`      | reference a previous session as context for the current task — opens a picker if no ID is given |
 | `/link`      | link other repos on your machine so changes here are checked against them (enter a folder path) |
 | `/mcp`       | manage MCP servers — enable, disable, reconnect, view status & tool counts                            |
@@ -808,6 +810,11 @@ calls the `use_skill` tool with the skill's name, which loads the full
 instructions into context. Project skills override user skills on name
 collisions (closer-to-cwd wins).
 
+The tool also accepts an explicit path to a skill directory or its `SKILL.md`
+file. Paths may be absolute, relative to the current workspace, or start with
+`~/`, so a prompt or `AGENTS.md` can point to a shared skill stored outside the
+standard discovery directories.
+
 ## AGENTS.md memory
 
 AGENTS.md files provide project- and user-level instructions that are injected
@@ -933,7 +940,8 @@ extension). It shows in the status bar, is written into the session file (so
 
 **Usage data**: `/status` and `/usage` fetch `/axoncode/profile` and show the
 plan, usage percentage (used/remaining), remaining reviews, and the credits
-reset date — the same data as the extension's profile view.
+reset date — the same data as the extension's profile view. Eligible paid users
+can run `/weekly-reset` once per monthly billing cycle.
 
 ## Tools
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.4",
+  "version": "0.5.5-dev",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -127,6 +127,13 @@ export interface AxonCodeTieredUsage {
   monthly: AxonCodeWindowUsage;
 }
 
+export interface AxonCodeWeeklyResetAvailability {
+  eligible: boolean;
+  available: boolean;
+  lastResetAt: string | null;
+  nextAvailableAt: string | null;
+}
+
 export interface ProfileData {
   user?: { name?: string; email?: string; image?: string };
   organizations?: Array<{ id: string; name: string; role?: string }>;
@@ -137,7 +144,14 @@ export interface ProfileData {
   creditsResetDate?: string;
   // Tiered usage windows (weekly / monthly).
   tieredUsage?: AxonCodeTieredUsage;
+  weeklyReset?: AxonCodeWeeklyResetAvailability;
   [key: string]: unknown;
+}
+
+export interface WeeklyResetResponse {
+  success: true;
+  weeklyReset: AxonCodeWeeklyResetAvailability;
+  tieredUsage: AxonCodeTieredUsage;
 }
 
 export async function fetchProfile(token: string): Promise<ProfileData> {
@@ -157,6 +171,35 @@ export async function fetchProfile(token: string): Promise<ProfileData> {
     );
   }
   return (await response.json()) as ProfileData;
+}
+
+export async function resetWeeklyUsage(
+  token: string,
+): Promise<WeeklyResetResponse> {
+  const url = getUrlFromToken(
+    "https://api.matterai.so/axoncode/weekly-reset",
+    token,
+  );
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: "{}",
+  });
+  const data = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  if (!response.ok) {
+    throw new Error(
+      typeof data.error === "string"
+        ? data.error
+        : `Weekly reset failed (${response.status}).`,
+    );
+  }
+  return data as unknown as WeeklyResetResponse;
 }
 
 /**

--- a/src/commands/createSkill.ts
+++ b/src/commands/createSkill.ts
@@ -1,0 +1,25 @@
+export const CREATE_SKILL_USAGE =
+	"Usage: /create-skill <describe the repository skill you want>"
+
+export function buildCreateSkillPrompt(skillRequest: string): string {
+	return `Create or update a reusable skill for this repository from the user's request below.
+
+<skill_request>
+${skillRequest.trim()}
+</skill_request>
+
+All generated skill files must live under this repository path:
+
+  .orb/skills/<skill-name>/
+
+Do not create the skill in .orbcode, .claude, .agents, a home-directory skills folder, or anywhere else. Supporting scripts, references, and assets must also stay inside the same .orb/skills/<skill-name>/ directory. During this command, do not modify any file outside that skill directory. If the request is too ambiguous to implement safely, use ask_followup_question to ask one focused question before writing files.
+
+Workflow:
+1. Read .orb/AGENTS.md when present, inspect the relevant repository files, and check existing skills in .orb/skills so the new skill reflects this codebase and does not accidentally overwrite a different skill.
+2. Derive a short, descriptive skill name using lowercase letters, digits, and hyphens only. Keep it under 64 characters and use that exact value for both the folder name and the frontmatter name.
+3. Decide whether the skill needs only SKILL.md or also reusable scripts, references, or assets. Create only files that directly help execute the requested workflow repeatedly.
+4. Write .orb/skills/<skill-name>/SKILL.md with YAML frontmatter containing exactly name and description. Make the description say both what the skill does and when it should be used. Write the body as concise imperative instructions for another coding agent; keep essential guidance in SKILL.md and place lengthy detail in directly linked reference files.
+5. Preserve useful existing content when updating a skill. Do not create extra README, changelog, installation, or quick-reference files inside the skill.
+6. Test any scripts you add. Then read the generated files back and verify the folder name, frontmatter name, description, paths, and instructions are consistent.
+7. Finish by reporting the created or updated skill name, its .orb/skills path, and a short summary of what it teaches the agent.`
+}

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -13,6 +13,7 @@ import {
 } from "./migrate.js"
 import { loadSettings } from "../config/settings.js"
 import type { McpHttpServerConfig, McpScope, McpServerConfig, McpSseServerConfig, McpStdioServerConfig } from "../mcp/types.js"
+import { isFigmaMcpServer } from "../mcp/figmaGuard.js"
 
 /**
  * `orbcode mcp` subcommand — manage MCP servers from the command line, like
@@ -427,7 +428,9 @@ function applyMigrationDryRun(entries: MigrationEntry[]): {
 	const added: string[] = []
 	const skipped: { entry: MigrationEntry; reason: string }[] = []
 	for (const entry of entries) {
-		if (entry.name in existing) {
+		if (isFigmaMcpServer(entry.name, entry.config)) {
+			skipped.push({ entry, reason: "external Figma MCPs are disabled; use the native figma_fetch tool" })
+		} else if (entry.name in existing) {
 			skipped.push({ entry, reason: "already exists in ~/.orbcode/settings.json" })
 		} else {
 			added.push(entry.key)

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -26,6 +26,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { getConfigDir, loadSettings } from "../config/settings.js";
+import { isFigmaMcpServer } from "../mcp/figmaGuard.js";
 import type {
   McpHttpServerConfig,
   McpServerConfig,
@@ -190,7 +191,7 @@ function readMcpServers(filePath: string): Record<string, McpServerConfig> {
   for (const [name, raw] of Object.entries(block)) {
     if (!/^[A-Za-z0-9_-]+$/.test(name)) continue;
     const config = normalizeExternalServer(raw);
-    if (config) out[name] = config;
+    if (config && !isFigmaMcpServer(name, config)) out[name] = config;
   }
   return out;
 }
@@ -238,7 +239,7 @@ function readMcpServersFromObject(
   for (const [name, raw] of Object.entries(block)) {
     if (!/^[A-Za-z0-9_-]+$/.test(name)) continue;
     const config = normalizeExternalServer(raw);
-    if (config) out[name] = config;
+    if (config && !isFigmaMcpServer(name, config)) out[name] = config;
   }
   return out;
 }
@@ -363,6 +364,13 @@ export function applyMigration(entries: MigrationEntry[]): MigrationResult {
   const skipped: { entry: MigrationEntry; reason: string }[] = [];
 
   for (const entry of entries) {
+    if (isFigmaMcpServer(entry.name, entry.config)) {
+      skipped.push({
+        entry,
+        reason: "external Figma MCPs are disabled; use the native figma_fetch tool",
+      });
+      continue;
+    }
     if (entry.name in servers) {
       skipped.push({
         entry,

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -6,6 +6,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { VERSION } from "../branding.js"
 import type { McpServerConfig, McpTool } from "./types.js"
 import { createAuthTransport, hasOAuth, type AuthIntercept } from "./auth.js"
+import { isFigmaMcpServer, isFigmaMcpTool } from "./figmaGuard.js"
 
 /** The SDK transport type (union of the three we use). */
 type AnyTransport = StdioClientTransport | StreamableHTTPClientTransport | SSEClientTransport
@@ -84,6 +85,9 @@ export function truncateMcpResult(text: string, limit = MAX_MCP_RESULT_CHARS): s
  *  `authIntercept` lets the caller surface the OAuth URL in the TUI and
  *  provide the auth code (from the callback or a manual paste). */
 export async function connectMcpServer(name: string, config: McpServerConfig, authIntercept?: AuthIntercept): Promise<McpConnection> {
+	if (isFigmaMcpServer(name, config)) {
+		throw new Error("External Figma MCP servers are disabled. Use OrbCode's native figma_fetch tool instead.")
+	}
 	const { transport, authenticate } = buildTransport(name, config, authIntercept)
 	const client = new Client(CLIENT_INFO, { capabilities: {} })
 
@@ -118,13 +122,15 @@ export async function connectMcpServer(name: string, config: McpServerConfig, au
 /** Enumerate tools from a connected client, namespaced as mcp__<server>__<tool>. */
 export async function listServerTools(server: string, client: Client): Promise<McpTool[]> {
 	const result = await client.listTools()
-	return (result.tools ?? []).map((tool) => ({
-		name: `mcp__${server}__${tool.name}`,
-		originalName: tool.name,
-		server,
-		description: tool.description,
-		inputSchema: (tool.inputSchema as Record<string, unknown>) ?? { type: "object", properties: {} },
-	}))
+	return (result.tools ?? [])
+		.filter((tool) => !isFigmaMcpTool(tool))
+		.map((tool) => ({
+			name: `mcp__${server}__${tool.name}`,
+			originalName: tool.name,
+			server,
+			description: tool.description,
+			inputSchema: (tool.inputSchema as Record<string, unknown>) ?? { type: "object", properties: {} },
+		}))
 }
 
 /** Call a tool on a connected client and return a text result for the model. */

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -3,6 +3,7 @@ import * as path from "node:path"
 
 import { getConfigDir } from "../config/settings.js"
 import { installedPluginDirs } from "../plugins/manager.js"
+import { isFigmaMcpServer } from "./figmaGuard.js"
 import type {
 	McpHttpServerConfig,
 	McpJsonConfig,
@@ -131,7 +132,7 @@ function normalizeServers(
 	for (const [name, cfg] of Object.entries(raw)) {
 		if (!/^[A-Za-z0-9_-]+$/.test(name)) continue
 		const normalized = normalizeServerConfig(cfg, variables)
-		if (normalized) servers[name] = normalized
+		if (normalized && !isFigmaMcpServer(name, normalized)) servers[name] = normalized
 	}
 	return servers
 }
@@ -275,6 +276,9 @@ export function configPathForScope(cwd: string, scope: McpScope): string {
 export function addMcpServer(cwd: string, name: string, config: McpServerConfig, scope: McpScope): void {
 	if (!/^[A-Za-z0-9_-]+$/.test(name)) {
 		throw new Error(`Invalid server name "${name}". Use only letters, numbers, hyphens, and underscores.`)
+	}
+	if (isFigmaMcpServer(name, config)) {
+		throw new Error("External Figma MCP servers are disabled. Use OrbCode's native figma_fetch tool instead.")
 	}
 	if (scope === "project") {
 		const existing = readProjectMcpJson(cwd)

--- a/src/mcp/figmaGuard.ts
+++ b/src/mcp/figmaGuard.ts
@@ -1,0 +1,30 @@
+const FIGMA_MARKER = /figma/i
+const FIGMA_DESKTOP_ENDPOINT = /^https?:\/\/(?:127\.0\.0\.1|localhost|\[::1\]):3845(?:\/|$)/i
+
+/**
+ * OrbCode provides Figma access through its native `figma_fetch` tool. An
+ * external Figma MCP must never be loaded because it could bypass or compete
+ * with that native integration.
+ */
+export function isFigmaMcpServer(name: string, config: unknown): boolean {
+	if (FIGMA_MARKER.test(name)) return true
+	if (!config || typeof config !== "object") return false
+
+	const candidate = config as Record<string, unknown>
+	if (typeof candidate.url === "string" && FIGMA_DESKTOP_ENDPOINT.test(candidate.url)) return true
+	const identityParts: unknown[] = [candidate.command, candidate.url, candidate.args]
+	for (const field of [candidate.env, candidate.headers]) {
+		if (field && typeof field === "object" && !Array.isArray(field)) {
+			identityParts.push(Object.entries(field as Record<string, unknown>).flat())
+		}
+	}
+
+	return identityParts.flat(2).some((value) => typeof value === "string" && FIGMA_MARKER.test(value))
+}
+
+/** Block Figma-specific functions exposed by an otherwise general MCP server. */
+export function isFigmaMcpTool(tool: { name?: string; description?: string }): boolean {
+	return [tool.name, tool.description].some(
+		(value) => typeof value === "string" && FIGMA_MARKER.test(value),
+	)
+}

--- a/src/mcp/manager.ts
+++ b/src/mcp/manager.ts
@@ -3,6 +3,7 @@ import type OpenAI from "openai"
 import { callMcpTool, connectMcpServer, type McpConnection } from "./client.js"
 import { configPathForScope, loadMcpConfig, removeMcpServerAnyScope } from "./config.js"
 import { hasStoredAuth, isOAuthConfig, type AuthIntercept } from "./auth.js"
+import { isFigmaMcpServer, isFigmaMcpTool } from "./figmaGuard.js"
 import type { McpHttpServerConfig, McpServerConfig, McpServerState, McpSnapshot, McpTool, ScopedMcpServerConfig } from "./types.js"
 
 /**
@@ -83,6 +84,11 @@ export class McpManager {
 		const cfg = this.configs.get(name)
 		if (!cfg) return
 		const state = this.states.get(name)!
+		if (isFigmaMcpServer(name, cfg)) {
+			state.status = "disabled"
+			state.detail = "external Figma MCP disabled — use native figma_fetch"
+			return
+		}
 		const isRemote = cfg.type === "http" || cfg.type === "sse"
 
 		// At startup, don't open a browser for OAuth servers that haven't been
@@ -229,6 +235,9 @@ export class McpManager {
 	async callTool(toolName: string, args: Record<string, unknown>): Promise<{ text: string; isError?: boolean }> {
 		if (!toolName.startsWith("mcp__")) {
 			return { text: `Invalid MCP tool name: ${toolName}`, isError: true }
+		}
+		if (isFigmaMcpTool({ name: toolName })) {
+			return { text: "External Figma MCP tools are disabled. Use the native figma_fetch tool instead.", isError: true }
 		}
 		for (const connection of this.connections.values()) {
 			const tool = connection.tools.find((candidate) => candidate.name === toolName)

--- a/src/skills/loader.ts
+++ b/src/skills/loader.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs"
+import * as os from "node:os"
 import * as path from "node:path"
 
 import { getConfigDir } from "../config/settings.js"
@@ -12,7 +13,8 @@ import type { ParsedFrontmatter, Skill } from "./types.js"
  * invokes the `use_skill` tool. Discovery mirrors Claude Code's layout:
  *
  *   - User skills:   ~/.orbcode/skills/<name>/SKILL.md
- *   - Project skills: .orbcode/skills/<name>/SKILL.md (in cwd and parents)
+ *   - Project skills: .orb/skills/<name>/SKILL.md (in cwd and parents)
+ *   - External skills: an explicit directory or SKILL.md path passed to use_skill
  *
  * Only the directory format (`<name>/SKILL.md`) is supported, matching Claude
  * Code's current skills/ convention. Project skills override user skills on
@@ -48,7 +50,7 @@ function descriptionFromBody(content: string): string {
 /** Load a single skill from a `<dir>/SKILL.md` path. */
 function loadSkill(
 	skillDir: string,
-	source: "user" | "project" | "plugin",
+	source: "user" | "project" | "plugin" | "external",
 	options: { skillFile?: string; name?: string; plugin?: string; pluginDir?: string } = {},
 ): Skill | undefined {
 	const skillFile = options.skillFile ?? path.join(skillDir, "SKILL.md")
@@ -71,6 +73,23 @@ function loadSkill(
 		plugin: options.plugin,
 		pluginDir: options.pluginDir,
 	}
+}
+
+function resolveSkillFile(skillPath: string, cwd: string): string {
+	const expandedPath =
+		skillPath === "~"
+			? os.homedir()
+			: skillPath.startsWith(`~${path.sep}`)
+				? path.join(os.homedir(), skillPath.slice(2))
+				: skillPath
+	const resolvedPath = path.resolve(cwd, expandedPath)
+	return path.basename(resolvedPath) === "SKILL.md" ? resolvedPath : path.join(resolvedPath, "SKILL.md")
+}
+
+/** Load a skill from an explicit directory or SKILL.md path. */
+export function loadSkillFromPath(skillPath: string, cwd = process.cwd()): Skill | undefined {
+	const skillFile = resolveSkillFile(skillPath.trim(), cwd)
+	return loadSkill(path.dirname(skillFile), "external", { skillFile })
 }
 
 /** Load all skills from a `skills/` directory (each subdirectory is one skill). */
@@ -148,7 +167,9 @@ export function renderSkillCatalog(skills: Map<string, Skill>): string {
 		lines.push(`- \`${skill.name}\`: ${skill.description}${when}`)
 	}
 	lines.push("")
-	lines.push("Use the `use_skill` tool with a `skill_name` to load a skill's full instructions.")
+	lines.push(
+		"Use the `use_skill` tool with a skill name from this list or an explicit skill directory/SKILL.md path to load its full instructions.",
+	)
 	return lines.join("\n")
 }
 

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -9,7 +9,7 @@ export interface Skill {
 	/** The full markdown body (without frontmatter). */
 	content: string
 	/** Where this skill was loaded from. */
-	source: "user" | "project" | "plugin"
+	source: "user" | "project" | "plugin" | "external"
 	/** Absolute path to the skill's directory (for ${SKILL_DIR} substitution). */
 	dir: string
 	/** Plugin namespace/root when this skill was installed as part of a plugin. */

--- a/src/tools/executors/skills.ts
+++ b/src/tools/executors/skills.ts
@@ -1,5 +1,5 @@
 import type { ToolContext, ToolResult } from "../types.js"
-import { loadSkills, renderSkillContent } from "../../skills/loader.js"
+import { loadSkillFromPath, loadSkills, renderSkillContent } from "../../skills/loader.js"
 
 /**
  * `use_skill` executor: loads a skill's full markdown instructions and returns
@@ -7,7 +7,7 @@ import { loadSkills, renderSkillContent } from "../../skills/loader.js"
  *
  * Skills are discovered from standalone skill directories and installed
  * plugin bundles (see the skills loader). The model sees the catalog in the
- * system prompt and invokes this tool with a `skill_name`.
+ * system prompt and invokes this tool with a discovered name or explicit path.
  */
 export async function useSkill(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
 	const skillName = String(args.skill_name ?? "").trim()
@@ -15,11 +15,11 @@ export async function useSkill(args: Record<string, unknown>, context: ToolConte
 		return { text: "No skill_name provided.", isError: true }
 	}
 	const skills = loadSkills(context.cwd)
-	const skill = skills.get(skillName)
+	const skill = skills.get(skillName) ?? loadSkillFromPath(skillName, context.cwd)
 	if (!skill) {
 		const available = [...skills.keys()].join(", ") || "(none)"
 		return {
-			text: `Skill "${skillName}" not found. Available skills: ${available}`,
+			text: `Skill "${skillName}" not found or invalid. Use a listed skill name or a path to a skill directory or SKILL.md file. Available skills: ${available}`,
 			isError: true,
 		}
 	}

--- a/src/tools/schemas/use_skill.ts
+++ b/src/tools/schemas/use_skill.ts
@@ -5,7 +5,7 @@ export default {
 	function: {
 		name: "use_skill",
 		description:
-			"Use a specific skill to guide the task execution. Skills can be standalone user/project skills or namespaced skills installed as part of a plugin bundle. The available skills are listed in the 'Available Skills' section of your system prompt — invoke this tool with a skill_name from that list when the task matches the skill's when-to-use condition.",
+			"Use a skill by its discovered name or by an explicit skill directory or SKILL.md path. Skills can be standalone user/project skills, external path-based skills, or namespaced skills installed as part of a plugin bundle.",
 		strict: true,
 		parameters: {
 			type: "object",
@@ -13,7 +13,7 @@ export default {
 				skill_name: {
 					type: "string",
 					description:
-						"The name of the skill to use. Must match one of the available skills listed in the tool description.",
+						"A discovered skill name, plugin:skill name, or an absolute, workspace-relative, or home-relative path to a skill directory or SKILL.md file.",
 				},
 			},
 			required: ["skill_name"],

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -33,6 +33,7 @@ import {
   APP_URL,
   fetchProfile,
   fetchTaskTitle,
+  resetWeeklyUsage,
   type ProfileData,
 } from "../auth/auth.js";
 import {
@@ -66,6 +67,10 @@ import {
   listMigrationEntries,
   type MigrationEntry,
 } from "../commands/migrate.js";
+import {
+  buildCreateSkillPrompt,
+  CREATE_SKILL_USAGE,
+} from "../commands/createSkill.js";
 import { StatusBar, type ApprovalMode } from "./components/StatusBar.js";
 import { ModelPicker } from "./components/ModelPicker.js";
 import { ThemePicker } from "./components/ThemePicker.js";
@@ -118,8 +123,16 @@ const SLASH_COMMANDS: SlashCommand[] = [
   },
   { name: "/usage", description: "fetch plan usage" },
   {
+    name: "/weekly-reset",
+    description: "reset weekly usage (Pro+, once per month)",
+  },
+  {
     name: "/init",
     description: "analyze this codebase and create an AGENTS.md",
+  },
+  {
+    name: "/create-skill",
+    description: "create a repo-local skill from a plain-language description",
   },
   {
     name: "/link",
@@ -1041,6 +1054,22 @@ export function App({
           void getAgent().runTurn(buildInitPrompt(agentsPath));
           break;
         }
+        case "/create-skill": {
+          const skillRequest = arg.trim();
+          if (!skillRequest) {
+            pushRow({ kind: "error", text: CREATE_SKILL_USAGE });
+            break;
+          }
+          if (!getAuthToken(settings)) {
+            setView("login");
+            break;
+          }
+          pushRow({ kind: "user", text: command });
+          setBusy(true);
+          setBusyLabel("Creating skill");
+          void getAgent().runTurn(buildCreateSkillPrompt(skillRequest));
+          break;
+        }
         case "/link":
           setLinks(loadLinks(process.cwd()));
           setLinkStatus("");
@@ -1105,6 +1134,36 @@ export function App({
               })
               .catch(() => {});
           }
+          break;
+        }
+        case "/weekly-reset": {
+          const token = getAuthToken(settings);
+          if (!token) {
+            setView("login");
+            break;
+          }
+          pushRow({ kind: "info", text: "Resetting weekly usage…" });
+          resetWeeklyUsage(token)
+            .then((result) => {
+              setUsage((current) => ({
+                ...current,
+                plan: result.tieredUsage.plan,
+                tieredUsage: result.tieredUsage,
+              }));
+              pushRow({
+                kind: "info",
+                text: `Weekly usage reset. Available again ${formatRelativeTime(result.weeklyReset.nextAvailableAt ?? undefined)}.`,
+              });
+            })
+            .catch((error) => {
+              pushRow({
+                kind: "error",
+                text:
+                  error instanceof Error
+                    ? error.message
+                    : "Failed to reset weekly usage.",
+              });
+            });
           break;
         }
         case "/login":

--- a/test/create-skill.test.ts
+++ b/test/create-skill.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { buildCreateSkillPrompt, CREATE_SKILL_USAGE } from "../src/commands/createSkill.js"
+
+test("builds a repo-local skill creation prompt", () => {
+	const prompt = buildCreateSkillPrompt("Review database migrations safely")
+
+	assert.match(prompt, /<skill_request>\nReview database migrations safely\n<\/skill_request>/)
+	assert.match(prompt, /\.orb\/skills\/<skill-name>\/SKILL\.md/)
+	assert.match(prompt, /frontmatter containing exactly name and description/)
+	assert.match(prompt, /Supporting scripts, references, and assets/)
+	assert.match(prompt, /Do not create the skill in \.orbcode/)
+	assert.match(prompt, /do not modify any file outside that skill directory/)
+})
+
+test("documents the required slash-command argument", () => {
+	assert.equal(CREATE_SKILL_USAGE, "Usage: /create-skill <describe the repository skill you want>")
+})

--- a/test/mcp-client.test.ts
+++ b/test/mcp-client.test.ts
@@ -1,12 +1,18 @@
 import assert from "node:assert/strict"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
 import { test } from "node:test"
 
 import {
 	callMcpTool,
 	MAX_MCP_RESULT_CHARS,
+	listServerTools,
 	truncateMcpResult,
 	type McpConnection,
 } from "../src/mcp/client.js"
+import { isFigmaMcpServer } from "../src/mcp/figmaGuard.js"
+import { addMcpServer, loadMcpConfig } from "../src/mcp/config.js"
 
 test("leaves MCP results within the context cap unchanged", () => {
 	assert.equal(truncateMcpResult("small result"), "small result")
@@ -35,4 +41,53 @@ test("caps text returned by an MCP tool before handing it to the agent", async (
 
 	assert.equal(result.text.length, MAX_MCP_RESULT_CHARS)
 	assert.match(result.text, /MCP tool result truncated by OrbCode/)
+})
+
+test("identifies Figma MCP servers by name, endpoint, package, or credential name", () => {
+	assert.equal(isFigmaMcpServer("figma", { type: "http", url: "https://example.com/mcp" }), true)
+	assert.equal(isFigmaMcpServer("design", { type: "http", url: "https://mcp.figma.com/mcp" }), true)
+	assert.equal(isFigmaMcpServer("design", { type: "http", url: "http://127.0.0.1:3845/mcp" }), true)
+	assert.equal(isFigmaMcpServer("design", { command: "npx", args: ["figma-developer-mcp"] }), true)
+	assert.equal(isFigmaMcpServer("design", { command: "node", env: { FIGMA_TOKEN: "secret" } }), true)
+	assert.equal(isFigmaMcpServer("design", { command: "node", env: { MCP_URL: "https://mcp.figma.com/mcp" } }), true)
+	assert.equal(isFigmaMcpServer("github", { type: "http", url: "https://api.github.com/mcp" }), false)
+})
+
+test("filters Figma MCPs from project config and rejects CLI additions", () => {
+	const project = fs.mkdtempSync(path.join(os.tmpdir(), "orbcode-figma-mcp-test-"))
+	try {
+		fs.writeFileSync(
+			path.join(project, ".mcp.json"),
+			JSON.stringify({
+				mcpServers: {
+					renamed_design_test: { type: "http", url: "http://127.0.0.1:3845/mcp" },
+					unrelated_test_server: { type: "http", url: "https://api.github.com/mcp" },
+				},
+			}),
+		)
+
+		const { servers } = loadMcpConfig(project)
+		assert.equal(servers.renamed_design_test, undefined)
+		assert.equal(servers.unrelated_test_server?.type, "http")
+		assert.throws(
+			() => addMcpServer(project, "figma", { type: "http", url: "https://mcp.figma.com/mcp" }, "project"),
+			/native figma_fetch/,
+		)
+	} finally {
+		fs.rmSync(project, { recursive: true, force: true })
+	}
+})
+
+test("does not expose Figma-specific tools from general MCP servers", async () => {
+	const client = {
+		listTools: async () => ({
+			tools: [
+				{ name: "get_design", description: "Read a Figma frame", inputSchema: { type: "object" } },
+				{ name: "search_issues", description: "Search issues", inputSchema: { type: "object" } },
+			],
+		}),
+	} as never
+
+	const tools = await listServerTools("general", client)
+	assert.deepEqual(tools.map((tool) => tool.originalName), ["search_issues"])
 })

--- a/test/skills.test.ts
+++ b/test/skills.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict"
+import * as fs from "node:fs"
+import * as os from "node:os"
+import * as path from "node:path"
+import test from "node:test"
+
+import { loadSkillFromPath } from "../src/skills/loader.js"
+import { useSkill } from "../src/tools/executors/skills.js"
+import type { ToolContext } from "../src/tools/types.js"
+
+function writeSkill(skillDir: string): string {
+	const skillFile = path.join(skillDir, "SKILL.md")
+	fs.mkdirSync(skillDir, { recursive: true })
+	fs.writeFileSync(
+		skillFile,
+		"---\nname: external-review\ndescription: Review external changes\n---\nRead ${SKILL_DIR}/rules.md.\n",
+	)
+	return skillFile
+}
+
+test("loads an external skill from a directory or SKILL.md path", () => {
+	const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "orbcode-skills-test-"))
+	try {
+		const skillDir = path.join(workspace, "shared-skills", "review")
+		const skillFile = writeSkill(skillDir)
+
+		assert.equal(loadSkillFromPath(skillDir, workspace)?.name, "external-review")
+		assert.equal(loadSkillFromPath(skillFile, workspace)?.dir, skillDir)
+		assert.equal(loadSkillFromPath(path.relative(workspace, skillDir), workspace)?.name, "external-review")
+	} finally {
+		fs.rmSync(workspace, { recursive: true, force: true })
+	}
+})
+
+test("use_skill accepts an explicit path outside the discovery catalog", async () => {
+	const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "orbcode-skills-test-"))
+	try {
+		const skillDir = path.join(workspace, "shared-skills", "review")
+		writeSkill(skillDir)
+
+		const result = await useSkill(
+			{ skill_name: path.relative(workspace, skillDir) },
+			{ cwd: workspace } as ToolContext,
+		)
+
+		assert.equal(result.isError, undefined)
+		assert.match(result.text, /# Skill: external-review/)
+		assert.match(result.text, new RegExp(`${skillDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/rules\\.md`))
+	} finally {
+		fs.rmSync(workspace, { recursive: true, force: true })
+	}
+})


### PR DESCRIPTION
## Summary

Release branch for v0.5.5. Four logical commits, typecheck passing.

### feat(skills): load skills from explicit directory or SKILL.md paths
- `use_skill` now accepts absolute, workspace-relative, and `~/` paths to a skill directory or its `SKILL.md` file, in addition to discovered names.
- Adds an `external` skill source and a `loadSkillFromPath` helper; falls back to path loading when a name is not in the catalog.
- Updates the schema/description and the project-skills path comment (`.orbcode` -> `.orb`).
- Tests: `test/skills.test.ts`.

### feat(mcp): block external Figma MCP servers in favor of native figma_fetch
- New `figmaGuard` module detects Figma MCPs by server name, endpoint (desktop dev server on `:3845`, hosted `mcp.figma.com`), package (`figma-developer-mcp`), env/headers, and tool name/description.
- Rejected on connect, config load, config addition, and migration (live + dry-run); Figma-specific tools are filtered from general servers' tool listings.
- Tests: `test/mcp-client.test.ts`.

### feat(commands): add /weekly-reset and /create-skill slash commands
- `/weekly-reset` — eligible paid users (Pro+) reset their weekly usage tier once per monthly billing cycle. New `resetWeeklyUsage` against `/axoncode/weekly-reset`, with `AxonCodeWeeklyResetAvailability` typing; refreshes tiered usage and reports next-available time.
- `/create-skill <description>` — turns a plain-language request into a repo-local skill under `.orb/skills/<skill-name>/`, keeping scripts/references/assets in that directory and forbidding edits outside it. New `buildCreateSkillPrompt` builder.
- Tests: `test/create-skill.test.ts`.

### chore(release): bump version to 0.5.5-dev and document new features
- `package.json` 0.5.4 -> 0.5.5-dev.
- CHANGELOG and README updated for the new commands and external skill path loading.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `node --test` suites for skills, mcp-client, create-skill pass locally