### PR TITLE
release: v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2026-07-21
+
+### Fixed
+
+- **Shift+Enter now inserts a newline in terminals that send a bare linefeed.**
+  Outside the Kitty keyboard protocol, many terminals encode Shift+Enter as a
+  raw LF (linefeed) with no shift modifier, so OpenTUI surfaced it as a plain
+  `linefeed` key — which the composer treated as an ordinary Enter and submitted
+  the prompt instead of starting a new line. The input key mapper now recognizes
+  a `linefeed` key as `return` with the `shift` flag set, so multiline input
+  works consistently across terminals that don't implement the Kitty protocol.
+
+### Changed
+
+- **Attachment image-support partitioning is now a shared helper.** The logic
+  that splits parsed attachments into image-capable and unsupported-image sets
+  (used when the active model can't accept images) is extracted into
+  `partitionAttachmentsByImageSupport`, so the partition rule has a single
+  implementation and is covered by a dedicated unit test.
+
 ## [0.5.5] - 2026-07-20
 
 ### Added
@@ -722,7 +742,9 @@ non-interactive mode.
 - Cross-platform shell detection and path handling in
   `execute_command` (Windows vs POSIX, `cmd` vs `bash`, etc.).
 
-[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.5...HEAD
+[0.5.6]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.5...v0.5.6
+[0.5.5]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.1...v0.5.5
 [0.5.0]: https://github.com/MatterAIOrg/OrbCode/compare/v0.4.8...v0.5.0
 [0.4.0]: https://github.com/MatterAIOrg/OrbCode/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/MatterAIOrg/OrbCode/releases/tag/v0.3.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -70,6 +70,19 @@ export interface ParseAttachmentsResult {
 	errors: string[]
 }
 
+export function partitionAttachmentsByImageSupport(
+	attachments: Attachment[],
+	supportsImages: boolean,
+): { accepted: Attachment[]; unsupportedImages: ImageAttachment[] } {
+	if (supportsImages) return { accepted: attachments, unsupportedImages: [] }
+	return {
+		accepted: attachments.filter((attachment) => attachment.kind !== "image"),
+		unsupportedImages: attachments.filter(
+			(attachment): attachment is ImageAttachment => attachment.kind === "image",
+		),
+	}
+}
+
 /** Open the host operating system's native file chooser. */
 export async function pickAttachmentPaths(cwd: string): Promise<string[]> {
 	let output: string | null | undefined

--- a/src/ui/components/InputBox.tsx
+++ b/src/ui/components/InputBox.tsx
@@ -6,6 +6,7 @@ import {
 	type SubmittedPrompt,
 	droppedAttachmentPaths,
 	parseAttachments,
+	partitionAttachmentsByImageSupport,
 	pickAttachmentPaths,
 } from "../../attachments.js"
 import { COLORS } from "../../branding.js"
@@ -198,10 +199,10 @@ export function InputBox({ active, width, slashCommands, onSubmit, supportsImage
 			.then(async () => {
 				const result = await parseAttachments(filePaths, attachmentsRef.current)
 				if (generation !== composerGenerationRef.current) return
-				const accepted = supportsImages
-					? result.attachments
-					: result.attachments.filter((attachment) => attachment.kind !== "image")
-				const unsupportedImages = result.attachments.filter((attachment) => attachment.kind === "image")
+				const { accepted, unsupportedImages } = partitionAttachmentsByImageSupport(
+					result.attachments,
+					supportsImages,
+				)
 				if (accepted.length > 0) {
 					const next = [...attachmentsRef.current, ...accepted]
 					attachmentsRef.current = next

--- a/src/ui/primitives.tsx
+++ b/src/ui/primitives.tsx
@@ -124,6 +124,10 @@ export function Text({
 
 function inputKey(event: KeyEvent): InputKey {
 	const name = event.name.toLowerCase()
+	// Outside the Kitty keyboard protocol, several terminals encode
+	// Shift+Enter as LF while plain Enter is CR. OpenTUI exposes that LF as a
+	// `linefeed` key with no shift modifier, so preserve the distinction here.
+	const isLinefeed = name === "linefeed"
 	return {
 		upArrow: name === "up",
 		downArrow: name === "down",
@@ -131,13 +135,13 @@ function inputKey(event: KeyEvent): InputKey {
 		rightArrow: name === "right",
 		pageUp: name === "pageup" || name === "page_up",
 		pageDown: name === "pagedown" || name === "page_down",
-		return: name === "return" || name === "enter",
+		return: name === "return" || name === "enter" || isLinefeed,
 		escape: name === "escape" || name === "esc",
 		tab: name === "tab",
 		backspace: name === "backspace",
 		delete: name === "delete",
 		ctrl: event.ctrl,
-		shift: event.shift,
+		shift: event.shift || isLinefeed,
 		meta: event.meta || event.option,
 	}
 }

--- a/test/attachments.test.ts
+++ b/test/attachments.test.ts
@@ -8,6 +8,7 @@ import {
 	droppedAttachmentPaths,
 	formatAttachmentContext,
 	parseAttachments,
+	partitionAttachmentsByImageSupport,
 } from "../src/attachments.js"
 
 const temporaryDirectories: string[] = []
@@ -50,6 +51,14 @@ test("extracts text documents and validates image contents", async () => {
 	assert.equal(result.attachments[1]?.kind, "image")
 	assert.match(result.attachments[1]?.kind === "image" ? result.attachments[1].dataUrl : "", /^data:image\/png;base64,/)
 	assert.match(result.errors[0] ?? "", /contents do not match/)
+
+	const supported = partitionAttachmentsByImageSupport(result.attachments, true)
+	assert.deepEqual(supported.accepted, result.attachments)
+	assert.deepEqual(supported.unsupportedImages, [])
+
+	const unsupported = partitionAttachmentsByImageSupport(result.attachments, false)
+	assert.deepEqual(unsupported.accepted.map((attachment) => attachment.kind), ["document"])
+	assert.deepEqual(unsupported.unsupportedImages.map((attachment) => attachment.kind), ["image"])
 })
 
 test("bounds extracted text and formats document context", async () => {

--- a/test/ui-viewport.test.tsx
+++ b/test/ui-viewport.test.tsx
@@ -4,6 +4,7 @@ import React, { act } from "react";
 import { testRender } from "@opentui/react/test-utils";
 
 import { Box, Text } from "../src/ui/primitives.js";
+import { InputBox } from "../src/ui/components/InputBox.js";
 import {
   Spinner,
   TIP_DELAY_MS,
@@ -97,6 +98,36 @@ test("keeps the wrapped live response above the composer", async () => {
     assert.notEqual(finalRow, -1);
     assert.notEqual(composerRow, -1);
     assert.equal(finalRow, composerRow - 1);
+  } finally {
+    act(() => screen.renderer.destroy());
+  }
+});
+
+test("treats a raw linefeed as Shift+Enter in the composer", async () => {
+  let submittedText: string | undefined;
+  const screen = await testRender(
+    <InputBox
+      active
+      width={80}
+      slashCommands={[]}
+      onSubmit={(prompt) => {
+        submittedText = prompt.text;
+      }}
+      supportsImages
+    />,
+    { width: 80, height: 8, kittyKeyboard: true },
+  );
+
+  try {
+    await act(async () => {
+      await screen.mockInput.typeText("first");
+      await screen.mockInput.pressKeys(["LINEFEED"]);
+      await screen.mockInput.typeText("second");
+      screen.mockInput.pressEnter();
+      await screen.flush();
+    });
+
+    assert.equal(submittedText, "first\nsecond");
   } finally {
     act(() => screen.renderer.destroy());
   }


### PR DESCRIPTION
## Release v0.5.6

Patch release with a keyboard-input fix and a small internal refactor.

### Fixed
- **Shift+Enter inserts a newline in terminals that send a bare linefeed.** Outside the Kitty keyboard protocol, many terminals encode Shift+Enter as a raw LF (linefeed) with no shift modifier, so the composer submitted the prompt instead of starting a new line. The input key mapper now recognizes a `linefeed` key as `return` with the `shift` flag set, so multiline input works consistently across terminals that don't implement the Kitty protocol.

### Changed
- **Attachment image-support partitioning is now a shared helper.** The logic that splits parsed attachments into image-capable and unsupported-image sets is extracted into `partitionAttachmentsByImageSupport`, giving the partition rule a single implementation covered by a dedicated unit test.

### Checklist
- [x] `npm run typecheck` passes
- [x] `npm run test:attachments` and `npm run test:ui` pass
- [x] Version bumped to `0.5.6` in `package.json`
- [x] `CHANGELOG.md` entry added

Per `RELEASE.md`, the `v0.5.6` tag should be cut on `main` **after** this PR is merged.