### PR TITLE
release: v0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2026-07-21
+
+### Added
+
+- **Paste files copied in the host file manager as attachments.** Copying a
+  file in Finder/Explorer (or a `text/uri-list` copy on Linux/Wayland) and pasting
+  into the composer now attaches the file, instead of pasting a meaningless path
+  string. OrbCode reads the native file-list clipboard flavor — `public.file-url`
+  on macOS via JXA, `FileDropList` on Windows via PowerShell, and `text/uri-list`
+  on Linux via `wl-paste`/`xclip` — resolves each entry to a real path, filters to
+  supported attachment types, and queues them exactly like drag-and-drop. When
+  the clipboard holds no files (a plain text copy), the paste falls back to
+  inserting the text as before. `useInput` exposes an optional `onPaste` hook so
+  callers can consume a paste before it reaches the key handler.
+
 ## [0.5.6] - 2026-07-21
 
 ### Fixed
@@ -742,7 +757,8 @@ non-interactive mode.
 - Cross-platform shell detection and path handling in
   `execute_command` (Windows vs POSIX, `cmd` vs `bash`, etc.).
 
-[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.5...HEAD
+[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.7...HEAD
+[0.5.7]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.1...v0.5.5
 [0.5.0]: https://github.com/MatterAIOrg/OrbCode/compare/v0.4.8...v0.5.0

--- a/README.md
+++ b/README.md
@@ -274,8 +274,9 @@ MatterAI gateway untouched.
   as a compact Tasks panel (`□` pending / `◧` in progress / `■` done).
 - **@-references**: type `@` in the input to fuzzy-search workspace files;
   ↑/↓ to choose, enter/tab inserts the top/selected match into the prompt.
-- **Attachments**: use `/attach` or `ctrl+f` to open the native file picker, or
-  drag files onto the input box (the terminal pastes their paths). CSV, XLSX,
+- **Attachments**: use `/attach` or `ctrl+f` to open the native file picker,
+  copy and paste a file from the system file manager, or drag files onto the
+  input box (the terminal pastes their paths). CSV, XLSX,
   DOCX, PDF, plain-text, JSON, Markdown, PNG, JPEG, and WebP are supported.
   Documents are extracted to bounded text before the model call;
   attached filenames stay visible in the composer, queue, transcript, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -165,6 +165,61 @@ export function isSupportedAttachmentPath(filePath: string): boolean {
 }
 
 /**
+ * Read file objects copied by the host file manager. Terminals generally expose
+ * only the clipboard's text flavor, so Finder/Explorer copies need to be read
+ * from the native file-list flavor instead.
+ */
+export async function clipboardAttachmentPaths(cwd: string): Promise<string[]> {
+	let output: string | undefined
+	if (process.platform === "darwin") {
+		const script = [
+			'ObjC.import("AppKit")',
+			"const pasteboard = $.NSPasteboard.generalPasteboard",
+			"const items = pasteboard.pasteboardItems",
+			"const urls = []",
+			"for (let index = 0; index < items.count; index++) {",
+			"  const value = items.objectAtIndex(index).stringForType(\"public.file-url\")",
+			"  if (value) urls.push(ObjC.unwrap(value))",
+			"}",
+			"urls.join(\"\\n\")",
+		].join("\n")
+		output = await runClipboardCommand("osascript", ["-l", "JavaScript", "-e", script], cwd)
+	} else if (process.platform === "win32") {
+		const script = [
+			"$ErrorActionPreference = 'SilentlyContinue'",
+			"Get-Clipboard -Format FileDropList | ForEach-Object { $_.FullName }",
+		].join("; ")
+		output = await runClipboardCommand(
+			"powershell.exe",
+			["-NoProfile", "-NonInteractive", "-Command", script],
+			cwd,
+		)
+	} else if (process.platform === "linux") {
+		output = await runClipboardCommand("wl-paste", ["--no-newline", "--type", "text/uri-list"], cwd)
+		if (output === undefined) {
+			output = await runClipboardCommand("xclip", ["-selection", "clipboard", "-t", "text/uri-list", "-o"], cwd)
+		}
+	}
+
+	return clipboardAttachmentPathsFromText(output ?? "", cwd)
+}
+
+export function clipboardAttachmentPathsFromText(input: string, cwd: string): string[] {
+	const paths: string[] = []
+	for (const line of input.split(/\r?\n/)) {
+		const token = line.trim()
+		if (!token || token.startsWith("#")) continue
+		const filePath = resolvePathToken(token, cwd)
+		try {
+			if (isSupportedAttachmentPath(filePath) && fs.statSync(filePath).isFile()) paths.push(filePath)
+		} catch {
+			// Clipboard entries can disappear if a file is moved after it was copied.
+		}
+	}
+	return [...new Set(paths)]
+}
+
+/**
  * Terminal emulators implement file drag-and-drop by pasting one or more paths.
  * Only consume the input when every pasted token is an existing supported file,
  * so ordinary pasted prose remains ordinary prompt text.
@@ -411,5 +466,30 @@ function runPickerCommand(command: string, args: string[], cwd: string): Promise
 			else if (code === 1) resolve(null)
 			else reject(new Error(stderr.trim() || `File picker exited with code ${code ?? "unknown"}`))
 		})
+	})
+}
+
+/** `undefined` means the executable or requested clipboard format is unavailable. */
+function runClipboardCommand(command: string, args: string[], cwd: string): Promise<string | undefined> {
+	return new Promise((resolve) => {
+		const child = spawn(command, args, { cwd, stdio: ["ignore", "pipe", "ignore"] })
+		let stdout = ""
+		let settled = false
+		const finish = (value: string | undefined) => {
+			if (settled) return
+			settled = true
+			clearTimeout(timeout)
+			resolve(value)
+		}
+		const timeout = setTimeout(() => {
+			child.kill()
+			finish(undefined)
+		}, 1_500)
+		child.stdout.setEncoding("utf8")
+		child.stdout.on("data", (chunk: string) => {
+			if (stdout.length < 1024 * 1024) stdout += chunk
+		})
+		child.on("error", () => finish(undefined))
+		child.on("close", (code) => finish(code === 0 ? stdout : undefined))
 	})
 }

--- a/src/ui/components/InputBox.tsx
+++ b/src/ui/components/InputBox.tsx
@@ -4,7 +4,9 @@ import { Box, Text, useInput } from "../primitives.js"
 import {
 	type Attachment,
 	type SubmittedPrompt,
+	clipboardAttachmentPaths,
 	droppedAttachmentPaths,
+	isSupportedAttachmentPath,
 	parseAttachments,
 	partitionAttachmentsByImageSupport,
 	pickAttachmentPaths,
@@ -260,6 +262,39 @@ export function InputBox({ active, width, slashCommands, onSubmit, supportsImage
 		setEditor(next, atToken.start + file.length + 2)
 	}
 
+	const insertPastedText = (input: string) => {
+		const currentValue = valueRef.current
+		const currentCursor = cursorRef.current
+		const clean = input.replace(/\r\n?/g, "\n")
+		const next = currentValue.slice(0, currentCursor) + clean + currentValue.slice(currentCursor)
+		setHistoryIndex(-1)
+		setEditor(next, currentCursor + clean.length)
+	}
+
+	const handlePaste = (input: string, kind?: "text" | "binary" | "unknown") => {
+		const droppedPaths = droppedAttachmentPaths(input, process.cwd())
+		if (droppedPaths.length > 0) {
+			addDroppedAttachments(droppedPaths)
+			return true
+		}
+
+		const trimmed = input.trim()
+		const mayBeCopiedFile = kind === "binary" || !trimmed || isSupportedAttachmentPath(trimmed)
+		if (!mayBeCopiedFile) return false
+
+		const generation = composerGenerationRef.current
+		void clipboardAttachmentPaths(process.cwd())
+			.then((filePaths) => {
+				if (generation !== composerGenerationRef.current) return
+				if (filePaths.length > 0) addDroppedAttachments(filePaths)
+				else insertPastedText(input)
+			})
+			.catch(() => {
+				if (generation === composerGenerationRef.current) insertPastedText(input)
+			})
+		return true
+	}
+
 	useInput(
 		(input, key) => {
 			const currentValue = valueRef.current
@@ -393,13 +428,13 @@ export function InputBox({ active, width, slashCommands, onSubmit, supportsImage
 				// Multi-char chunks (paste) are inserted as-is. Newlines inside
 				// the chunk are literal newlines, not a submit signal — press
 				// Enter when you're ready to send.
-				const clean = input.replace(/\r\n?/g, "\n")
-				const next = currentValue.slice(0, currentCursor) + clean + currentValue.slice(currentCursor)
-				setHistoryIndex(-1)
-				setEditor(next, currentCursor + clean.length)
+				insertPastedText(input)
 			}
 		},
-		{ isActive: active },
+		{
+			isActive: active,
+			onPaste: (input, metadata) => handlePaste(input, metadata?.kind),
+		},
 	)
 
 	const plainDisplay = active

--- a/src/ui/primitives.tsx
+++ b/src/ui/primitives.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext } from "react"
-import { createTextAttributes, type KeyEvent } from "@opentui/core"
+import { createTextAttributes, type KeyEvent, type PasteMetadata } from "@opentui/core"
 import {
 	useKeyboard,
 	usePaste,
@@ -156,7 +156,11 @@ function inputText(event: KeyEvent): string {
 
 export function useInput(
 	handler: (input: string, key: InputKey) => void,
-	options: { isActive?: boolean } = {},
+	options: {
+		isActive?: boolean
+		/** Return true when the caller consumed the paste. */
+		onPaste?: (input: string, metadata?: PasteMetadata) => boolean
+	} = {},
 ) {
 	const active = options.isActive ?? true
 	useKeyboard((event) => {
@@ -165,7 +169,9 @@ export function useInput(
 	})
 	usePaste((event) => {
 		if (!active) return
-		handler(new TextDecoder().decode(event.bytes), {
+		const input = new TextDecoder().decode(event.bytes)
+		if (options.onPaste?.(input, event.metadata)) return
+		handler(input, {
 			upArrow: false,
 			downArrow: false,
 			leftArrow: false,

--- a/test/attachments.test.ts
+++ b/test/attachments.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict"
 import * as fs from "node:fs/promises"
 import * as os from "node:os"
 import * as path from "node:path"
+import { pathToFileURL } from "node:url"
 import { afterEach, test } from "node:test"
 
 import {
+	clipboardAttachmentPathsFromText,
 	droppedAttachmentPaths,
 	formatAttachmentContext,
 	parseAttachments,
@@ -33,6 +35,22 @@ test("recognizes quoted and shell-escaped dropped file paths without consuming p
 	assert.deepEqual(droppedAttachmentPaths(`'${first}' '${second}'`, directory), [first, second])
 	assert.deepEqual(droppedAttachmentPaths(first.replace(/([\\\s()])/g, "\\$1"), directory), [first])
 	assert.deepEqual(droppedAttachmentPaths("please review this report", directory), [])
+})
+
+test("resolves copied file-manager URLs as attachments", async () => {
+	const directory = await temporaryDirectory()
+	const image = path.join(directory, "design mock.png")
+	const unsupported = path.join(directory, "archive.zip")
+	await fs.writeFile(image, Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+	await fs.writeFile(unsupported, "zip")
+
+	assert.deepEqual(
+		clipboardAttachmentPathsFromText(
+			[`# file-manager clipboard`, pathToFileURL(image).href, pathToFileURL(unsupported).href].join("\n"),
+			directory,
+		),
+		[image],
+	)
 })
 
 test("extracts text documents and validates image contents", async () => {


### PR DESCRIPTION
## Release v0.5.7

Bumps version to `0.5.7` and ships the clipboard-paste attachment feature that
has been staged on `main`.

### Added

- **Paste files copied in the host file manager as attachments.** Copying a
  file in Finder/Explorer (or a `text/uri-list` copy on Linux/Wayland) and
  pasting into the composer now attaches the file instead of pasting a
  meaningless path string. OrbCode reads the native file-list clipboard
  flavor (`public.file-url` on macOS via JXA, `FileDropList` on Windows via
  PowerShell, `text/uri-list` on Linux via `wl-paste`/`xclip`), resolves each
  entry to a real path, filters to supported attachment types, and queues
  them like drag-and-drop. Plain-text copies fall back to inserting the text.
  `useInput` exposes an optional `onPaste` hook so callers can consume a
  paste before it reaches the key handler.

### Verification

- `npm run typecheck` passes
- `npm run test:attachments` passes (4/4)