### PR TITLE
release: v0.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.8] - 2026-07-21
+
+### Added
+
+- **Axon Eido 3 Pro and Mini now expose 200k and 400k context-window options.**
+  Each model ships as two local entries — `axon-eido-3-code-{pro,mini}-200k`
+  and `axon-eido-3-code-{pro,mini}-400k` — that share the same underlying base
+  model on the MatterAI gateway. A new `gatewayModelId` field on `AxonModel`
+  lets a local context-window option map to a different base model ID sent to
+  the gateway, so the suffix only affects OrbCode's local context window.
+- **400k context is gated to Pro Plus and Ultra plans.** A new
+  `canUse400kContext(plan)` helper normalizes the plan name and unlocks the
+  400k options only for `proplus` / `ultra`. The model picker renders the 400k
+  rows dimmed with a "Only available in Pro Plus and Ultra plans" hint, skips
+  them when navigating with ↑/↓/Tab, and refuses to select them via Enter or
+  number keys. Selecting a 400k model from `/model` or the picker on an
+  ineligible plan emits an error row and leaves the current model unchanged.
+  Headless mode (`-p`) fetches `/axoncode/profile` and exits with a clear
+  message if the requested 400k model isn't allowed. If a user without 400k
+  access loads the app with a 400k model already in settings, OrbCode
+  auto-falls back to the matching `-200k` variant.
+
+### Changed
+
+- **Default model is now `axon-eido-3-code-mini-200k`.** The previous default
+  (`axon-eido-3-code-mini`, 400k) is preserved as the `-400k` option for
+  eligible plans.
+- **`/model pro` and `/model mini` short suffixes prefer the 200k variant.**
+  The suffix matcher now also accepts `-<arg>-` infixes (so `pro` matches
+  `axon-eido-3-code-pro-200k`) and sorts 200k matches ahead of 400k ones,
+  keeping the short form usable on every plan.
+
 ## [0.5.7] - 2026-07-21
 
 ### Added
@@ -757,7 +789,8 @@ non-interactive mode.
 - Cross-platform shell detection and path handling in
   `execute_command` (Windows vs POSIX, `cmd` vs `bash`, etc.).
 
-[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.7...HEAD
+[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.8...HEAD
+[0.5.8]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.1...v0.5.5

--- a/README.md
+++ b/README.md
@@ -182,14 +182,19 @@ picker (`/model <id>` still selects directly). Additional models can be
 declared via `customModels` in settings.json. The choice persists across
 sessions.
 
-| id                        | context | max output | pricing                |
-| ------------------------- | ------- | ---------- | ---------------------- |
-| `axon-eido-3-code-pro`    | 400k    | 64k        | $3/M in · $9/M out     |
-| `axon-eido-3-code-mini`   | 400k    | 64k        | $1.5/M in · $4.5/M out |
-| `axon-eido-3-flash`       | 200k    | 64k        | free                   |
+| id                             | context | max output | pricing                |
+| ------------------------------ | ------- | ---------- | ---------------------- |
+| `axon-eido-3-code-pro-200k`    | 200k    | 64k        | $3/M in · $9/M out     |
+| `axon-eido-3-code-pro-400k`    | 400k    | 64k        | $3/M in · $9/M out     |
+| `axon-eido-3-code-mini-200k`   | 200k    | 64k        | $1.5/M in · $4.5/M out |
+| `axon-eido-3-code-mini-400k`   | 400k    | 64k        | $1.5/M in · $4.5/M out |
+| `axon-eido-3-flash`            | 200k    | 64k        | free                   |
 
-`axon-eido-3-code-mini` is the default. All three support native JSON tool calls
-and image input. Cost comes from the API's usage chunks (`is_byok`-aware) and is
+`axon-eido-3-code-mini-200k` is the default. The context suffix controls
+OrbCode's local context window; requests still send the underlying base model ID
+to the MatterAI gateway. The 400k options require a Pro Plus or Ultra plan and
+are unavailable on Free and Pro. All five options support native JSON tool calls and
+image input. Cost comes from the API's usage chunks (`is_byok`-aware) and is
 shown in the status bar.
 
 ### Other providers (Anthropic, OpenAI-compatible)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -8,7 +8,7 @@ import {
   X_ORGANIZATIONID,
 } from "./headers.js";
 import { stripReasoningDetails, type LLMClient } from "./llmClient.js";
-import { getModel } from "./models.js";
+import { getGatewayModelId, getModel } from "./models.js";
 import type { ApiStreamChunk } from "./stream.js";
 
 interface CompletionUsage {
@@ -71,7 +71,7 @@ export class AxonClient implements LLMClient {
 
     const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming =
       {
-        model: model.id,
+        model: getGatewayModelId(model),
         temperature: 0.2,
         messages: [
           { role: "system", content: systemPrompt },

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -8,6 +8,8 @@ export type ModelEffort = "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface AxonModel {
   id: string;
+  /** Model ID sent to the MatterAI gateway when it differs from the local selection ID. */
+  gatewayModelId?: string;
   name: string;
   description: string;
   contextWindow: number;
@@ -151,9 +153,23 @@ export const BUILTIN_AXON_MODELS: Record<string, AxonModel> = {
     outputPrice: 0.0,
     free: true,
   },
-  "axon-eido-3-code-pro": {
-    id: "axon-eido-3-code-pro",
-    name: "Axon Eido 3 Pro",
+  "axon-eido-3-code-pro-200k": {
+    id: "axon-eido-3-code-pro-200k",
+    gatewayModelId: "axon-eido-3-code-pro",
+    name: "Axon Eido 3 Pro (200K context)",
+    description:
+      "Axon Eido 3 Pro is the frontier Axon Code model for coding tasks, long running agents and general intelligence, fine-tuned on open source models.",
+    contextWindow: 200000,
+    maxOutputTokens: 64000,
+    supportsImages: true,
+    inputPrice: 0.000003,
+    outputPrice: 0.000009,
+    free: false,
+  },
+  "axon-eido-3-code-pro-400k": {
+    id: "axon-eido-3-code-pro-400k",
+    gatewayModelId: "axon-eido-3-code-pro",
+    name: "Axon Eido 3 Pro (400K context)",
     description:
       "Axon Eido 3 Pro is the frontier Axon Code model for coding tasks, long running agents and general intelligence, fine-tuned on open source models.",
     contextWindow: 400000,
@@ -163,9 +179,23 @@ export const BUILTIN_AXON_MODELS: Record<string, AxonModel> = {
     outputPrice: 0.000009,
     free: false,
   },
-  "axon-eido-3-code-mini": {
-    id: "axon-eido-3-code-mini",
-    name: "Axon Eido 3 Mini",
+  "axon-eido-3-code-mini-200k": {
+    id: "axon-eido-3-code-mini-200k",
+    gatewayModelId: "axon-eido-3-code-mini",
+    name: "Axon Eido 3 Mini (200K context)",
+    description:
+      "Axon Eido 3 Mini is a general purpose super intelligent LLM coding model for high-effort day-to-day tasks",
+    contextWindow: 200000,
+    maxOutputTokens: 64000,
+    supportsImages: true,
+    inputPrice: 0.0000015,
+    outputPrice: 0.0000045,
+    free: false,
+  },
+  "axon-eido-3-code-mini-400k": {
+    id: "axon-eido-3-code-mini-400k",
+    gatewayModelId: "axon-eido-3-code-mini",
+    name: "Axon Eido 3 Mini (400K context)",
     description:
       "Axon Eido 3 Mini is a general purpose super intelligent LLM coding model for high-effort day-to-day tasks",
     contextWindow: 400000,
@@ -188,7 +218,25 @@ export const AXON_MODELS: Record<string, AxonModel> = {
   ...ANTHROPIC_MODELS,
 };
 
-export const DEFAULT_MODEL_ID = "axon-eido-3-code-mini";
+export const DEFAULT_MODEL_ID = "axon-eido-3-code-mini-200k";
+
+const EXTENDED_CONTEXT_PLANS = new Set(["proplus", "ultra"]);
+
+/** Whether an account plan includes Axon's 400k context options. */
+export function canUse400kContext(plan?: string): boolean {
+  const normalizedPlan = plan?.toLowerCase().replace(/[^a-z0-9]/g, "") ?? "";
+  return EXTENDED_CONTEXT_PLANS.has(normalizedPlan);
+}
+
+export function is400kAxonModel(modelId: string): boolean {
+  return (
+    modelId.startsWith("axon-eido-3-code-") && modelId.endsWith("-400k")
+  );
+}
+
+export function get200kAxonFallback(modelId: string): string {
+  return modelId.replace(/-400k$/, "-200k");
+}
 
 /** A model declared in settings.json; everything except the id is optional. */
 export interface CustomModelConfig {
@@ -243,4 +291,9 @@ export function isValidAxonModel(modelId: string): boolean {
 
 export function getModel(modelId: string): AxonModel {
   return AXON_MODELS[modelId] ?? AXON_MODELS[DEFAULT_MODEL_ID];
+}
+
+/** Resolve a local context-window option to the model ID understood by the gateway. */
+export function getGatewayModelId(model: AxonModel): string {
+  return model.gatewayModelId ?? model.id;
 }

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,4 +1,11 @@
-import { getModel, isValidAxonModel, usesAiSdk } from "./api/models.js"
+import {
+	canUse400kContext,
+	getModel,
+	is400kAxonModel,
+	isValidAxonModel,
+	usesAiSdk,
+} from "./api/models.js"
+import { fetchProfile } from "./auth/auth.js"
 import { getAuthToken, getPendingProjectHooks, loadSettings } from "./config/settings.js"
 import { Agent } from "./core/agent.js"
 import type { AgentEvent } from "./core/events.js"
@@ -31,6 +38,15 @@ export async function runHeadless(
 	if (!token && !usesAiSdk(getModel(settings.model))) {
 		console.error("Not signed in. Run `orbcode login`, set MATTERAI_TOKEN, or put an apiKey in settings.json.")
 		process.exit(1)
+	}
+
+	if (token && is400kAxonModel(settings.model)) {
+		const profile = await fetchProfile(token)
+		const plan = profile.plan ?? profile.tieredUsage?.plan
+		if (!canUse400kContext(plan)) {
+			console.error("400k context is only available on Pro Plus and Ultra plans. Use the matching -200k model.")
+			process.exit(1)
+		}
 	}
 
 	// There's no interactive trust prompt in headless mode, so untrusted project

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -25,7 +25,10 @@ import {
 } from "../branding.js";
 import {
   BUILTIN_AXON_MODELS,
+  canUse400kContext,
+  get200kAxonFallback,
   getModel,
+  is400kAxonModel,
   isValidAxonModel,
 } from "../api/models.js";
 import { LoginView } from "./LoginView.js";
@@ -448,6 +451,8 @@ export function App({
     usagePercentage?: number;
     tieredUsage?: import("../auth/auth.js").AxonCodeTieredUsage;
   } | null>(null);
+  const activePlan = usage?.plan ?? usage?.tieredUsage?.plan;
+  const has400kAccess = canUse400kContext(activePlan);
 
   // Refresh plan/usage from /axoncode/profile (shown below the chat box).
   const refreshUsage = useCallback(() => {
@@ -818,6 +823,13 @@ export function App({
 
   const switchModel = useCallback(
     (modelId: string) => {
+      if (is400kAxonModel(modelId) && !has400kAccess) {
+        pushRow({
+          kind: "error",
+          text: "400k context is only available on Pro Plus and Ultra plans.",
+        });
+        return;
+      }
       const updated = { ...loadSettings(), model: modelId };
       setSettings(updated);
       saveSettings(updated);
@@ -827,8 +839,16 @@ export function App({
         text: `Model switched to ${getModel(modelId).name}`,
       });
     },
-    [pushRow],
+    [has400kAccess, pushRow],
   );
+
+  useEffect(() => {
+    if (!activePlan || has400kAccess || !is400kAxonModel(settings.model)) {
+      return;
+    }
+
+    switchModel(get200kAxonFallback(settings.model));
+  }, [activePlan, has400kAccess, settings.model, switchModel]);
 
   const switchTheme = useCallback(
     (mode: OrbCodeThemeMode) => {
@@ -903,13 +923,18 @@ export function App({
               text: `Model "${arg}" is only available in non-interactive mode. Run: orbcode -p "..." --model ${arg}`,
             });
           } else if (arg) {
-            // Allow short suffixes like "pro" or "mini" to resolve to the
-            // latest matching registered id, so /model pro keeps working
-            // as new model generations are added.
+            // Allow short suffixes like "pro" or "mini" to resolve to a
+            // matching registered id, preferring the default 200k context.
             const matches = pickerIds
-              .filter((id) => id.endsWith(`-${arg}`))
-              .sort()
-              .reverse();
+              .filter(
+                (id) => id.endsWith(`-${arg}`) || id.includes(`-${arg}-`),
+              )
+              .sort((a, b) => {
+                const aIs200k = a.endsWith("-200k");
+                const bIs200k = b.endsWith("-200k");
+                if (aIs200k !== bIs200k) return aIs200k ? -1 : 1;
+                return b.localeCompare(a);
+              });
             if (matches.length > 0) {
               switchModel(matches[0]);
             } else {
@@ -2003,6 +2028,7 @@ export function App({
             {modelPickerOpen && (
               <ModelPicker
                 currentId={settings.model}
+                canUse400k={has400kAccess}
                 onSelect={(modelId) => {
                   setModelPickerOpen(false);
                   switchModel(modelId);

--- a/src/ui/components/ModelPicker.tsx
+++ b/src/ui/components/ModelPicker.tsx
@@ -6,9 +6,11 @@ import { BUILTIN_AXON_MODELS, type AxonModel } from "../../api/models.js"
 import { PopoverBox } from "./PopoverBox.js"
 
 const VISIBLE_ROWS = 6
+const CONTEXT_WINDOW_ORDER = [200000, 400000]
 
 interface ModelPickerProps {
 	currentId: string
+	canUse400k: boolean
 	onSelect: (modelId: string) => void
 	onCancel: () => void
 }
@@ -19,24 +21,37 @@ function formatPrice(model: AxonModel): string {
 	return `${perMillion(model.inputPrice)} in / ${perMillion(model.outputPrice)} out per 1M tokens`
 }
 
-export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps) {
-	const models = Object.values(BUILTIN_AXON_MODELS)
+export function ModelPicker({ currentId, canUse400k, onSelect, onCancel }: ModelPickerProps) {
+	const models = Object.values(BUILTIN_AXON_MODELS).sort((a, b) => {
+		const aIndex = CONTEXT_WINDOW_ORDER.indexOf(a.contextWindow)
+		const bIndex = CONTEXT_WINDOW_ORDER.indexOf(b.contextWindow)
+		return (aIndex === -1 ? CONTEXT_WINDOW_ORDER.length : aIndex) -
+			(bIndex === -1 ? CONTEXT_WINDOW_ORDER.length : bIndex)
+	})
+	const isLocked = (model: AxonModel) => model.contextWindow === 400000 && !canUse400k
+	const nextSelectableIndex = (from: number, direction: 1 | -1) => {
+		for (let offset = 1; offset <= models.length; offset += 1) {
+			const candidate = (from + direction * offset + models.length) % models.length
+			if (!isLocked(models[candidate])) return candidate
+		}
+		return from
+	}
 	const [selected, setSelected] = useState(() => {
 		const index = models.findIndex((m) => m.id === currentId)
-		return index === -1 ? 0 : index
+		return index === -1 || isLocked(models[index]) ? models.findIndex((model) => !isLocked(model)) : index
 	})
 
 	useInput((input, key) => {
 		if (key.upArrow) {
-			setSelected((s) => (s - 1 + models.length) % models.length)
+			setSelected((s) => nextSelectableIndex(s, -1))
 			return
 		}
 		if (key.downArrow || key.tab) {
-			setSelected((s) => (s + 1) % models.length)
+			setSelected((s) => nextSelectableIndex(s, 1))
 			return
 		}
 		if (key.return) {
-			onSelect(models[selected].id)
+			if (!isLocked(models[selected])) onSelect(models[selected].id)
 			return
 		}
 		if (key.escape) {
@@ -45,7 +60,7 @@ export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps)
 		}
 		if (/^[1-9]$/.test(input)) {
 			const index = Number(input) - 1
-			if (index < models.length) onSelect(models[index].id)
+			if (index < models.length && !isLocked(models[index])) onSelect(models[index].id)
 		}
 	})
 
@@ -63,22 +78,38 @@ export function ModelPicker({ currentId, onSelect, onCancel }: ModelPickerProps)
 				const index = windowStart + i
 				const isSelected = index === selected
 				const isCurrent = model.id === currentId
+				const locked = isLocked(model)
+				const showContextHeader = i === 0 || visible[i - 1].contextWindow !== model.contextWindow
+				const contextLabel = `Context: ${model.contextWindow / 1000}k`
+				const contextAccessLabel =
+					model.contextWindow === 400000 && !canUse400k
+						? `${contextLabel} · Only available in Pro Plus and Ultra plans`
+						: contextLabel
 				return (
-					<Box key={model.id} flexDirection="column">
-						<Text color={isSelected ? COLORS.accent : undefined}>
-							{isSelected ? "❯ " : "  "}
-							{index + 1}. {model.name}
-							{isCurrent && <Text color={COLORS.success}> ✓ current</Text>}
-							<Text color={COLORS.dim}> · {formatPrice(model)}</Text>
-						</Text>
-						{isSelected && (
-							<Box paddingLeft={5}>
-								<Text color={COLORS.dim} wrap="wrap">
-									{model.description}
+					<React.Fragment key={model.id}>
+						{showContextHeader && (
+							<Box marginTop={i === 0 ? 0 : 1}>
+								<Text bold color={locked ? COLORS.dim : COLORS.primary}>
+									{contextAccessLabel}
 								</Text>
 							</Box>
 						)}
-					</Box>
+						<Box flexDirection="column">
+							<Text color={locked ? COLORS.dim : isSelected ? COLORS.accent : undefined}>
+								{isSelected ? "❯ " : "  "}
+								{index + 1}. {model.name}
+								{isCurrent && <Text color={COLORS.success}> ✓ current</Text>}
+								<Text color={COLORS.dim}> · {formatPrice(model)}</Text>
+							</Text>
+							{isSelected && (
+								<Box paddingLeft={5}>
+									<Text color={COLORS.dim} wrap="wrap">
+										{model.description}
+									</Text>
+								</Box>
+							)}
+						</Box>
+					</React.Fragment>
 				)
 			})}
 			{windowStart + VISIBLE_ROWS < models.length && (

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BUILTIN_AXON_MODELS,
+  DEFAULT_MODEL_ID,
+  canUse400kContext,
+  get200kAxonFallback,
+  getGatewayModelId,
+  is400kAxonModel,
+} from "../src/api/models.js";
+
+for (const tier of ["pro", "mini"] as const) {
+  test(`Axon Eido 3 ${tier} exposes 200k and 400k local options`, () => {
+    const baseId = `axon-eido-3-code-${tier}`;
+    const model200k = BUILTIN_AXON_MODELS[`${baseId}-200k`];
+    const model400k = BUILTIN_AXON_MODELS[`${baseId}-400k`];
+
+    assert.equal(model200k.contextWindow, 200000);
+    assert.equal(model400k.contextWindow, 400000);
+    assert.equal(getGatewayModelId(model200k), baseId);
+    assert.equal(getGatewayModelId(model400k), baseId);
+
+    const sharedMetadata = ({
+      id: _id,
+      name: _name,
+      contextWindow: _contextWindow,
+      ...metadata
+    }: typeof model200k) => metadata;
+
+    assert.deepEqual(sharedMetadata(model200k), sharedMetadata(model400k));
+  });
+}
+
+test("the 200k Mini option is the default", () => {
+  assert.equal(DEFAULT_MODEL_ID, "axon-eido-3-code-mini-200k");
+});
+
+test("400k context is limited to Pro Plus and Ultra plans", () => {
+  for (const plan of ["Pro Plus", "pro_plus", "pro-plus", "ULTRA"]) {
+    assert.equal(canUse400kContext(plan), true);
+  }
+  for (const plan of [undefined, "free", "Pro", "Enterprise"]) {
+    assert.equal(canUse400kContext(plan), false);
+  }
+});
+
+test("restricted Axon models map to their 200k variants", () => {
+  assert.equal(is400kAxonModel("axon-eido-3-code-mini-400k"), true);
+  assert.equal(is400kAxonModel("third-party-model-400k"), false);
+  assert.equal(
+    get200kAxonFallback("axon-eido-3-code-pro-400k"),
+    "axon-eido-3-code-pro-200k",
+  );
+});


### PR DESCRIPTION
## Release v0.5.8

### Added

- **Axon Eido 3 Pro and Mini now expose 200k and 400k context-window options.** Each model ships as two local entries — `axon-eido-3-code-{pro,mini}-200k` and `axon-eido-3-code-{pro,mini}-400k` — that share the same underlying base model on the MatterAI gateway. A new `gatewayModelId` field on `AxonModel` lets a local context-window option map to a different base model ID sent to the gateway, so the suffix only affects OrbCode's local context window.
- **400k context is gated to Pro Plus and Ultra plans.** A new `canUse400kContext(plan)` helper normalizes the plan name and unlocks the 400k options only for `proplus` / `ultra`. The model picker renders the 400k rows dimmed with a "Only available in Pro Plus and Ultra plans" hint, skips them when navigating with ↑/↓/Tab, and refuses to select them via Enter or number keys. Selecting a 400k model from `/model` or the picker on an ineligible plan emits an error row and leaves the current model unchanged. Headless mode (`-p`) fetches `/axoncode/profile` and exits with a clear message if the requested 400k model isn't allowed. If a user without 400k access loads the app with a 400k model already in settings, OrbCode auto-falls back to the matching `-200k` variant.

### Changed

- **Default model is now `axon-eido-3-code-mini-200k`.** The previous default (`axon-eido-3-code-mini`, 400k) is preserved as the `-400k` option for eligible plans.
- **`/model pro` and `/model mini` short suffixes prefer the 200k variant.** The suffix matcher now also accepts `-<arg>-` infixes (so `pro` matches `axon-eido-3-code-pro-200k`) and sorts 200k matches ahead of 400k ones, keeping the short form usable on every plan.

### Verification

- `npm run typecheck` passes
- `test/models.test.ts` — 5/5 pass (200k/400k options, default, plan gating, fallback mapping)

After this PR is merged into `main`, tag the merge commit with `v0.5.8` and push the tag to trigger the npm publish workflow.