### PR TITLE
Release v0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.10] - 2026-07-22
+
+### Changed
+
+- **Batched `read_file` tool support.** Updated the native `read_file` tool to accept a `files` array (1-10 file regions) for batching independent reads in a single tool call. Clamps line limits to 200-1000 lines for region requests and formats returned regions with range and total file line labels when multiple regions are returned. Updated tool schema, executor, system prompt guidelines, and summary descriptions.
+
 ## [0.5.8] - 2026-07-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.5",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matterailab/orbcode",
-      "version": "0.5.5",
+      "version": "0.5.10",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {

--- a/src/prompts/system.ts
+++ b/src/prompts/system.ts
@@ -134,36 +134,38 @@ Common tool calls and explanations
 
 ## read_file Tool Usage
 
-The \`read_file\` tool reads file contents with optional offset and limit. Use it to examine code before making changes or to discuss specific sections.
+The \`read_file\` tool reads one or more file regions in one operation. Batch all independent reads that are already known at the current step instead of issuing one call per file or walking through adjacent offsets.
 
 ### Parameters
 
-- \`file_path\` (required): Absolute path to the file (e.g., /Users/username/project/src/file.ts)
-- \`offset\` (optional): Starting line number (1-indexed). Defaults to 1.
-- \`limit\` (optional): Maximum number of lines to read. If not specified, reads the complete file. Default and maximum limit is 1000 lines.
+- \`files\` (required): Array containing 1-10 file-region requests.
+- \`files[].file_path\` (required): Absolute path to the file (e.g., /Users/username/project/src/file.ts).
+- \`files[].offset\` (optional): Starting line number (1-indexed). Defaults to 1.
+- \`files[].limit\` (optional): Number of lines to read. Use 200-1000; each region is capped at 1000 lines.
 
 ### Example
 
-**Read lines 100-150:**
+**Read several relevant regions together:**
 \`\`\`json
 {
-  "file_path": "/Users/username/project/src/App.tsx",
-  "offset": 100,
-  "limit": 50
+  "files": [
+    {"file_path": "/Users/username/project/src/App.tsx", "offset": 1, "limit": 1000},
+    {"file_path": "/Users/username/project/src/utils.ts", "offset": 400, "limit": 500}
+  ]
 }
 \`\`\`
 
-Parameter rules: \`file_path\` must be an absolute path; \`offset\` and \`limit\` must be >= 1 if specified; omit \`limit\` to read from \`offset\` to the end. Call the tool multiple times to read multiple files.
-
-CRITICAL: \`offset\` is what targets a region — \`limit\` alone reads the TOP of the file. To inspect line N (e.g. from search results), you MUST pass \`offset\` ≈ N-20 together with \`limit\`. Before sending the call, confirm \`offset\` is present whenever you are aiming at a specific line.
+Parameter rules: \`file_path\` must be absolute. \`offset\` must be >= 1 and \`limit\` must be between 200 and 1000 when specified. Omitting both reads from the top up to the 1000-line cap. To inspect line N in a large file, use an offset that includes enough context for the complete surrounding function or logical region.
 
 When you don't know line numbers: use \`search_files\` to locate the code, note the line number from the results, then \`read_file\` that region with surrounding context.
 
 ### Reading Strategy
 
-- When investigating a bug, read whole functions or logical regions in ONE call rather than small slivers. Prefer one 150-line read over five 30-line reads — fragmented reads lose context and waste calls.
+- For files up to 1000 lines, read the whole file once. For larger files, prefer 500-1000-line logical regions. Do not request fewer than 200 lines merely to save context.
+- Put every independent file or region you already know you need into the same \`files\` array. Use another call only when the first result reveals a genuinely new dependency.
 - Budget your re-reads: if you have already read a region and have not edited it since, work from what you have instead of fetching it again. Re-read only when the file has changed or you genuinely lack the detail.
 - After every read, verify the output matches the parameters you sent. If you meant to read around line N but the result starts at line 1, you omitted \`offset\` — re-issue the call with \`offset\` set. NEVER re-read the top of the file expecting a different result.
+- For code reviews, first use a compact change inventory such as \`git status --short\`, \`git diff --stat\`, and \`git diff --unified=20\`. Do not dump an unbounded repository diff and then request the same per-file diffs again.
 
 
 # execute_command

--- a/src/tools/executors/files.ts
+++ b/src/tools/executors/files.ts
@@ -5,37 +5,119 @@ import { type ToolContext, type ToolResult, resolveWorkspacePath } from "../type
 import { unifiedDiff } from "../../utils/diff.js"
 
 const MAX_READ_LINES = 1000
+const MIN_READ_LINES = 200
 
 /** Format file content as right-aligned `LINE_NUMBER|LINE_CONTENT` (6-char padding). */
 function withLineNumbers(lines: string[], startLine: number): string {
 	return lines.map((line, i) => `${String(startLine + i).padStart(6, " ")}|${line}`).join("\n")
 }
 
+interface FileReadSpec {
+	file_path: string
+	offset?: number
+	limit?: number
+}
+
+function parseFileEntries(args: Record<string, unknown>): FileReadSpec[] {
+	if (Array.isArray(args.files) && args.files.length > 0) {
+		return args.files.map((item: Record<string, unknown>) => {
+			const offset = item.offset != null ? Math.max(1, Number(item.offset) || 1) : undefined
+			let limit: number | undefined
+			if (item.limit != null) {
+				const rawLimit = Number(item.limit)
+				if (!isNaN(rawLimit)) {
+					limit = Math.min(MAX_READ_LINES, Math.max(MIN_READ_LINES, rawLimit))
+				}
+			}
+			return {
+				file_path: String(item.file_path ?? ""),
+				offset,
+				limit,
+			}
+		})
+	} else if (args.file_path) {
+		const offset = args.offset != null ? Math.max(1, Number(args.offset) || 1) : undefined
+		let limit: number | undefined
+		if (args.limit != null) {
+			const rawLimit = Number(args.limit)
+			if (!isNaN(rawLimit)) {
+				limit = Math.min(MAX_READ_LINES, Math.max(1, rawLimit))
+			}
+		}
+		return [
+			{
+				file_path: String(args.file_path),
+				offset,
+				limit,
+			},
+		]
+	}
+	return []
+}
+
 export async function readFile(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
-	const filePath = resolveWorkspacePath(context.cwd, String(args.file_path ?? ""))
-	const offset = Math.max(1, Number(args.offset ?? 1) || 1)
-	const limitArg = args.limit === null || args.limit === undefined ? MAX_READ_LINES : Number(args.limit)
-	const limit = Math.min(Math.max(1, limitArg || MAX_READ_LINES), MAX_READ_LINES)
-
-	let content: string
-	try {
-		content = fs.readFileSync(filePath, "utf8")
-	} catch (error) {
-		return { text: `Error reading file ${filePath}: ${(error as Error).message}`, isError: true }
+	const entries = parseFileEntries(args)
+	if (entries.length === 0) {
+		return { text: "No files specified to read.", isError: true }
 	}
 
-	const allLines = content.split("\n")
-	const slice = allLines.slice(offset - 1, offset - 1 + limit)
-	if (slice.length === 0) {
-		return { text: `File ${filePath} has ${allLines.length} lines; offset ${offset} is beyond the end.`, isError: true }
+	const results: { text: string; isError?: boolean }[] = []
+
+	for (const entry of entries) {
+		const relPath = entry.file_path
+		const filePath = resolveWorkspacePath(context.cwd, relPath)
+		const offset = entry.offset ?? 1
+		const limit = entry.limit ?? MAX_READ_LINES
+
+		let content: string
+		try {
+			content = fs.readFileSync(filePath, "utf8")
+		} catch (error) {
+			results.push({
+				text: `Error reading file ${relPath}: ${(error as Error).message}`,
+				isError: true,
+			})
+			continue
+		}
+
+		const allLines = content.split("\n")
+		const totalLines = allLines.length
+		const slice = allLines.slice(offset - 1, offset - 1 + limit)
+
+		if (slice.length === 0 && totalLines > 0) {
+			results.push({
+				text: `File ${relPath} has ${totalLines} lines; offset ${offset} is beyond the end.`,
+				isError: true,
+			})
+			continue
+		}
+
+		const formattedContent = withLineNumbers(slice, offset)
+		const lastLineShown = offset - 1 + slice.length
+
+		if (entries.length === 1) {
+			let output = formattedContent
+			if (lastLineShown < totalLines) {
+				output += `\n\n(Showing lines ${offset}-${lastLineShown} of ${totalLines}. Use offset/limit to read more.)`
+			}
+			results.push({ text: output })
+		} else {
+			const rangeLabel = totalLines > 0 ? ` (lines ${offset}-${lastLineShown} of ${totalLines})` : ""
+			let output = `--- ${relPath}${rangeLabel} ---\n${formattedContent}`
+			if (lastLineShown < totalLines) {
+				output += `\n(Showing lines ${offset}-${lastLineShown} of ${totalLines}. Use offset/limit to read more.)`
+			}
+			results.push({ text: output })
+		}
 	}
 
-	let result = withLineNumbers(slice, offset)
-	const lastLineShown = offset - 1 + slice.length
-	if (lastLineShown < allLines.length) {
-		result += `\n\n(Showing lines ${offset}-${lastLineShown} of ${allLines.length}. Use offset/limit to read more.)`
+	const combinedText = results.map((r) => r.text).join("\n\n")
+	const allFailed = results.length > 0 && results.every((r) => r.isError)
+
+	return {
+		text: combinedText,
+		isError: allFailed,
 	}
-	return { text: result }
 }
 
 export async function fileWrite(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -33,8 +33,17 @@ export function getApprovalKind(toolName: string, args: Record<string, unknown>)
 /** One-line human summary of a tool call, shown in the UI. */
 export function describeToolCall(toolName: string, args: Record<string, unknown>): string {
 	switch (toolName) {
-		case "read_file":
+		case "read_file": {
+			if (Array.isArray(args.files) && args.files.length > 0) {
+				const paths = args.files.map((f: { file_path?: string }) => f.file_path ?? "").filter(Boolean)
+				const uniqueFiles = [...new Set(paths)]
+				if (args.files.length === 1) {
+					return uniqueFiles[0] || String(args.files[0]?.file_path ?? "")
+				}
+				return `${args.files.length} regions across ${uniqueFiles.length} file${uniqueFiles.length === 1 ? "" : "s"}`
+			}
 			return String(args.file_path ?? "")
+		}
 		case "file_write":
 			return String(args.file_path ?? "")
 		case "file_edit":

--- a/src/tools/schemas/index.ts
+++ b/src/tools/schemas/index.ts
@@ -7,7 +7,7 @@ import askFollowupQuestion from "./ask_followup_question.js"
 import attemptCompletion from "./attempt_completion.js"
 import executeCommand from "./execute_command.js"
 import listFiles from "./list_files.js"
-import { read_file_single } from "./read_file.js"
+import read_file from "./read_file.js"
 import searchFiles from "./search_files.js"
 import updateTodoList from "./update_todo_list.js"
 import useSkill from "./use_skill.js"
@@ -27,7 +27,7 @@ export const nativeTools = [
 	attemptCompletion,
 	executeCommand,
 	listFiles,
-	read_file_single,
+	read_file,
 	searchFiles,
 	updateTodoList,
 	useSkill,

--- a/src/tools/schemas/read_file.ts
+++ b/src/tools/schemas/read_file.ts
@@ -1,31 +1,54 @@
 import type OpenAI from "openai"
 
-export const read_file_single = {
+export const read_file = {
 	type: "function",
 	function: {
 		name: "read_file",
 		description:
-			"Read a file and return its contents with line numbers. Use offset and limit to read specific portions efficiently. Default and maximum limit is 1000 lines to prevent context overflow.",
+			"Read one or more files and return line-numbered contents. Batch every independent file or region needed for the current investigation into this single call. Prefer 200-1000 lines per source-code region; for files up to 1000 lines, omit offset and limit to read the file once. Do not walk adjacent regions through many small calls. Each requested region is capped at 1000 lines.",
 		strict: true,
 		parameters: {
 			type: "object",
 			properties: {
-				file_path: {
-					type: "string",
-					description: "Absolute path to the file to read (e.g., /Users/username/project/src/file.ts)",
-				},
-				offset: {
-					type: ["number", "null"],
-					description: "Starting line number (1-indexed). Defaults to 1 if not specified.",
-				},
-				limit: {
-					type: ["number", "null"],
+				files: {
+					type: "array",
+					minItems: 1,
+					maxItems: 10,
 					description:
-						"Maximum number of lines to read from offset. Default and maximum limit is 1000 lines.",
+						"File regions to read together. Include all independent reads already known at this step. The same file may appear more than once for distant regions.",
+					items: {
+						type: "object",
+						properties: {
+							file_path: {
+								type: "string",
+								description: "Absolute path to the file (e.g., /Users/username/project/src/file.ts).",
+							},
+							offset: {
+								type: ["number", "null"],
+								minimum: 1,
+								description:
+									"Starting line number (1-indexed). Use it only when targeting a region in a file longer than 1000 lines; otherwise use null.",
+							},
+							limit: {
+								type: ["number", "null"],
+								minimum: 200,
+								maximum: 1000,
+								description:
+									"Lines to read from offset. Prefer 500-1000. Use null to read from offset up to the 1000-line cap.",
+							},
+						},
+						required: ["file_path"],
+						additionalProperties: false,
+					},
 				},
 			},
-			required: ["file_path"],
+			required: ["files"],
 			additionalProperties: false,
 		},
 	},
 } satisfies OpenAI.Chat.ChatCompletionTool
+
+export const read_file_single = read_file
+
+export default read_file
+

--- a/test/files.test.ts
+++ b/test/files.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import * as os from "node:os"
+
+import { readFile } from "../src/tools/executors/files.js"
+import read_file_schema from "../src/tools/schemas/read_file.js"
+import { describeToolCall } from "../src/tools/index.js"
+
+test("read_file schema accepts batched files array", () => {
+	assert.equal(read_file_schema.function.name, "read_file")
+	assert.deepEqual(read_file_schema.function.parameters.required, ["files"])
+})
+
+test("readFile executes single file and batched file region reads", async () => {
+	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "orbcode-test-"))
+	const file1 = path.join(tmpDir, "file1.txt")
+	const file2 = path.join(tmpDir, "file2.txt")
+
+	const lines1 = Array.from({ length: 300 }, (_, i) => `line ${i + 1}`).join("\n")
+	const lines2 = Array.from({ length: 50 }, (_, i) => `content ${i + 1}`).join("\n")
+
+	fs.writeFileSync(file1, lines1)
+	fs.writeFileSync(file2, lines2)
+
+	const context = { cwd: tmpDir, setTodos: () => {} }
+
+	// Single region via args.files
+	const res1 = await readFile(
+		{
+			files: [{ file_path: "file2.txt" }],
+		},
+		context,
+	)
+	assert.equal(res1.isError, false)
+	assert.match(res1.text, /content 1/)
+	assert.match(res1.text, /content 50/)
+
+	// Batched multi-region call
+	const res2 = await readFile(
+		{
+			files: [
+				{ file_path: "file1.txt", offset: 1, limit: 250 },
+				{ file_path: "file2.txt", offset: 10, limit: 200 },
+			],
+		},
+		context,
+	)
+	assert.equal(res2.isError, false)
+	assert.match(res2.text, /--- file1.txt \(lines 1-250 of 300\) ---/)
+	assert.match(res2.text, /--- file2.txt \(lines 10-50 of 50\) ---/)
+
+	// Backward-compatible single file_path argument
+	const res3 = await readFile(
+		{
+			file_path: "file2.txt",
+			offset: 1,
+			limit: 10,
+		},
+		context,
+	)
+	assert.equal(res3.isError, false)
+	assert.match(res3.text, /content 1/)
+
+	// Test describeToolCall summary for single and batched files
+	assert.equal(
+		describeToolCall("read_file", { files: [{ file_path: "src/index.ts" }] }),
+		"src/index.ts",
+	)
+	assert.equal(
+		describeToolCall("read_file", {
+			files: [{ file_path: "src/index.ts" }, { file_path: "src/utils.ts" }],
+		}),
+		"2 regions across 2 files",
+	)
+
+	fs.rmSync(tmpDir, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Changes in v0.5.10

- **Batched `read_file` tool support**: Updated the native `read_file` tool to accept a `files` array (1-10 file regions) for batching independent reads in a single tool call. Clamps line limits to 200-1000 lines for region requests and formats returned regions with range and total file line labels when multiple regions are returned. Updated tool schema, executor, system prompt guidelines, summary descriptions, and added unit tests.