### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-07-22
+
+### Changed
+
+- **`search_files` rewritten on FFF with ripgrep fallback and pagination.** The
+  native `search_files` tool now runs through the FFF (`@ff-labs/fff-node`)
+  engine first — a persistent, watched file finder that keeps an in-memory index
+  of the workspace — and falls back to the bundled `@vscode/ripgrep` binary (or
+  system `rg`) when FFF is unavailable or a continuation fails. Results are
+  compact (at most three matches per file), capped at 100 per page, and paginated
+  via an opaque `cursor` string that is fingerprint-bound to the originating
+  path, regex, and `file_pattern`; passing the literal word `none` is rejected
+  with a clear error so the model can't continue a completed search. A rare FFF
+  continuation failure restarts from page one with ripgrep and is flagged with
+  `Restarted: yes` so repeated matches can be accounted for.
+- **New `search_files` parameters.** `cursor` (opaque continuation token or
+  null), `max_results` (1–100, default 50), and `context_lines` (0–2, default 0)
+  replace the old fixed 300-match dump. `file_pattern` now accepts `null` for all
+  files (the schema's `type` widened from `string` to `string|null`), and the
+  system prompt's verbose quoting rules were replaced with concise pagination
+  guidance. The tool description, schema, executor, and summary formatter were
+  updated together.
+- **Search results are cleaned for the TUI.** Pagination metadata (`Engine`,
+  `Matches`, `Next cursor`, `Restarted`, `Warning`) is stripped from result
+  previews and the restored display transcript so the visible rows show only
+  file paths and matched lines.
+- **Search engines are disposed cleanly on exit.** A `disposeSearchFiles` hook
+  drains in-flight FFF and ripgrep operations, destroys persistent finders, and
+  tears down child processes (SIGKILL escalation after 250ms) so the CLI never
+  leaves a `rg` process or FFF library behind.
+- **README tool table updated.** `search_files` now reads "FFF-first Rust-regex
+  search, compact pagination, and bundled/system ripgrep fallback".
+
+### Added
+
+- **`test/search-files.test.ts`** — 11 tests covering FFF default selection,
+  native pagination continuity, literal handling of route-directory
+  metacharacters, opaque-cursor binding, fractional-limit rejection, ripgrep
+  ignore/normalization consistency, adjacent-match preservation across pages,
+  completed-search disambiguation, FFF continuation fallback during cleanup,
+  and post-cleanup FFF re-initialization. Exposed via `npm run test:search`.
+
 ## [0.5.10] - 2026-07-22
 
 ### Changed
@@ -795,7 +837,9 @@ non-interactive mode.
 - Cross-platform shell detection and path handling in
   `execute_command` (Windows vs POSIX, `cmd` vs `bash`, etc.).
 
-[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.8...HEAD
+[Unreleased]: https://github.com/MatterAIOrg/OrbCode/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.10...v0.6.0
+[0.5.10]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.8...v0.5.10
 [0.5.8]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.6...v0.5.7
 [0.5.6]: https://github.com/MatterAIOrg/OrbCode/compare/v0.5.5...v0.5.6

--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ can run `/weekly-reset` once per monthly billing cycle.
 
 ## Tools
 
-Active in the CLI (schemas byte-identical to the extension's `native-tools`):
+Active in the CLI (aligned with the extension's native tools, with CLI-specific limits where noted):
 
 | tool                       | executor notes                                                                               |
 | -------------------------- | -------------------------------------------------------------------------------------------- |
@@ -960,7 +960,7 @@ Active in the CLI (schemas byte-identical to the extension's `native-tools`):
 | `multi_file_edit`          | batched edits grouped per file, per-edit OK/FAILED results                                   |
 | `file_write`               | creates parent dirs, full-content writes                                                     |
 | `list_files`               | optional recursive, ignores node_modules/.git/build dirs, 800-entry cap                      |
-| `search_files`             | JS regex search with glob `file_pattern` (picomatch), 300-match cap, binary skip             |
+| `search_files`             | FFF-first Rust-regex search, compact pagination, and bundled/system ripgrep fallback          |
 | `execute_command`          | user's shell, 120s timeout, 30k output cap, optional cwd                                     |
 | `web_search` / `web_fetch` | proxied through the MatterAI backend with your token                                         |
 | `update_todo_list`         | drives the TUI todo panel                                                                    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.10",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matterailab/orbcode",
-      "version": "0.5.10",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.85",
@@ -20,7 +20,7 @@
         "open": "^10.1.0",
         "openai": "^4.78.0",
         "pdf-parse": "^2.4.5",
-        "picomatch": "^4.0.4",
+        "picomatch": "4.0.4",
         "react": "^19.2.0",
         "read-excel-file": "^9.2.0"
       },
@@ -29,13 +29,17 @@
       },
       "devDependencies": {
         "@types/node": "^20.17.0",
-        "@types/picomatch": "^3.0.1",
+        "@types/picomatch": "3.0.2",
         "@types/react": "^19.2.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2"
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@ff-labs/fff-node": "0.10.1",
+        "@vscode/ripgrep": "1.18.0"
       }
     },
     "node_modules/@ai-sdk/anthropic": {
@@ -556,6 +560,169 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ff-labs/fff-bin-android-arm64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-android-arm64/-/fff-bin-android-arm64-0.10.1.tgz",
+      "integrity": "sha512-6Bsaa6yKEd2HV1M2WtqSYhoZucKYffIUms6GYoPN48QHP8hZgO8GXJ85/JDxKlkCJsN2hw1ROiwQK0+xUHYhFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@ff-labs/fff-bin-darwin-arm64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-darwin-arm64/-/fff-bin-darwin-arm64-0.10.1.tgz",
+      "integrity": "sha512-7yUP+56sG3UTrLg7eepOD16yM2dgiD7g6Ase2XWQB7oXwLV7mBMylPKIli2pP3kHzfw9K+BS3WAwHKHJ2QhxYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ff-labs/fff-bin-darwin-x64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-darwin-x64/-/fff-bin-darwin-x64-0.10.1.tgz",
+      "integrity": "sha512-9zb+P1xtyqu/jVklm5RKF2zm9doRRsBNbkF/a8S4aSqSJoNlQR8ZF7C129fzOLfffVAjjgcO2l8oJgxOzHYiwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ff-labs/fff-bin-linux-arm64-gnu": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-linux-arm64-gnu/-/fff-bin-linux-arm64-gnu-0.10.1.tgz",
+      "integrity": "sha512-KTwr9CUfCJv0vtG2xG+nMxDae/2NJY2/oVmtgSvTnH9baI6JprqsFGphbukx7mdW/QMPwBiYtoO8ZGoC7i92jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ff-labs/fff-bin-linux-arm64-musl": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-linux-arm64-musl/-/fff-bin-linux-arm64-musl-0.10.1.tgz",
+      "integrity": "sha512-oznmSpV+zjiAPiwqbA4y+SAsMaYvDhGllHiT9L4ebdQnSOfcQzlUwvo45OhBPwHBt47tIois4bkF/MITlDk54A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ff-labs/fff-bin-linux-x64-gnu": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-linux-x64-gnu/-/fff-bin-linux-x64-gnu-0.10.1.tgz",
+      "integrity": "sha512-KDpl8lwSEOauP/6FSJIvnARzE+ILm2rVIRQAio9dc5nn56EvlsryBWry0c5V0Tbw1PV0lNrZ+bzcIiPuTacvzw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ff-labs/fff-bin-linux-x64-musl": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-linux-x64-musl/-/fff-bin-linux-x64-musl-0.10.1.tgz",
+      "integrity": "sha512-mZCpojVtGNDr/wdCUEAHdfrl6qORvKHv3Pw35TaOdshnG4wocoA5bBKTGj/zmAU11o0GMK4V+wUhdNrgqoE10w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ff-labs/fff-bin-win32-arm64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-win32-arm64/-/fff-bin-win32-arm64-0.10.1.tgz",
+      "integrity": "sha512-SbT76ETXC5AgV9J8sVDozKG8wzrrxsOn8lbBprlOtx+O5V5EYmS1W7BlsatTHy6ddQ3uU5oOYO04PWZBuP6wXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ff-labs/fff-bin-win32-x64": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-bin-win32-x64/-/fff-bin-win32-x64-0.10.1.tgz",
+      "integrity": "sha512-dcpHUCBEZoXKQCdKa3bADfgcNyeyfM8tatXrILqIFYi9GL8E4GnzKx1rGkgP5ukVtuj0WuoJyyqSvGjpJPIT8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ff-labs/fff-node": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@ff-labs/fff-node/-/fff-node-0.10.1.tgz",
+      "integrity": "sha512-I2TIWHkey4wpLCncUQymBz/yWrjp/TE91yjrPvSLaPMUMRf3wXwEmelGNnZ5ynxy3cUauYg5b5hsUwhOK4skfA==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "android"
+      ],
+      "dependencies": {
+        "ffi-rs": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@ff-labs/fff-bin-android-arm64": "0.10.1",
+        "@ff-labs/fff-bin-darwin-arm64": "0.10.1",
+        "@ff-labs/fff-bin-darwin-x64": "0.10.1",
+        "@ff-labs/fff-bin-linux-arm64-gnu": "0.10.1",
+        "@ff-labs/fff-bin-linux-arm64-musl": "0.10.1",
+        "@ff-labs/fff-bin-linux-x64-gnu": "0.10.1",
+        "@ff-labs/fff-bin-linux-x64-musl": "0.10.1",
+        "@ff-labs/fff-bin-win32-arm64": "0.10.1",
+        "@ff-labs/fff-bin-win32-x64": "0.10.1"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1243,6 +1410,183 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -1250,6 +1594,195 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-android-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-android-arm64/-/ffi-rs-android-arm64-1.3.2.tgz",
+      "integrity": "sha512-eDYLT0kVBkp7e2BwdRDmt6N1rkeDPUHDefk3ZX0/nok+GLsqfy1WBoSL3Yg7HVXN1EyW8OBVc2uK8Zq8HbmaSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-arm64/-/ffi-rs-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-kRdgPaOM6TfuC5wHUwstlatk4HNie2lwSLJWQL2LiAUIJ7+96CoiWUNVhwBcFrhdfxhnWenYS6F668CV0vit8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-darwin-x64/-/ffi-rs-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-O3AlVgre8FQcZRJe44Xs7A6iDLumoPXqbw40+eJCa2gyXaXyLPdHoWrS1W9rBCa1QZRRnG7zRulPVFw8C5uo8g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-arm-gnueabihf": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm-gnueabihf/-/ffi-rs-linux-arm-gnueabihf-1.3.2.tgz",
+      "integrity": "sha512-IXiNdTbIcTCPny5eeElijFWYeKSJjQWSjt9ZyJNdLHYiB1Np+XD6K7wNZS6EOMgMelhW1kQE62T654skGkVDIA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-arm64-gnu": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-gnu/-/ffi-rs-linux-arm64-gnu-1.3.2.tgz",
+      "integrity": "sha512-gWFO6xufUK9lPYUqDvKa6IR243dPqdetgl9Q7HrZWaDu7wLo06QQrosw8QTzndafQnOcBKm6LoLujmGCfTgJOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-arm64-musl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-arm64-musl/-/ffi-rs-linux-arm64-musl-1.3.2.tgz",
+      "integrity": "sha512-lejvOSqypPziQH5rzfkDlJ6e92qhWbDutE9ttOO6z5I2k83zoh9iZhZWhaXSU5VqgQpcshRkrbtXb9gy1ft5dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-x64-gnu": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-gnu/-/ffi-rs-linux-x64-gnu-1.3.2.tgz",
+      "integrity": "sha512-s8VCFazaJKmgY2hgMTpWk4TtBY/zy5ovbaGgwyY0FvBD0YvyhcET4IrMsDJpHhFVTPCYfKZ1dN45clD/YiFp6g==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-linux-x64-musl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-linux-x64-musl/-/ffi-rs-linux-x64-musl-1.3.2.tgz",
+      "integrity": "sha512-Ahr5chfKZKWUik20bEZRug+be57LZ2yYrtolyjSRoo7A4ZniBUHBZUNWm6TD6i0CJayqyxWeVk/XiaABD8bY0w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-arm64-msvc": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-arm64-msvc/-/ffi-rs-win32-arm64-msvc-1.3.2.tgz",
+      "integrity": "sha512-yhpLcj0qel5VNlpzxPZfNmi7+rEX8444QHjUP6WWLxdRfqPllROu/Cp3OpkBpw3BLdxfcDhWkjWMD5QsJN0Pvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-ia32-msvc": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-ia32-msvc/-/ffi-rs-win32-ia32-msvc-1.3.2.tgz",
+      "integrity": "sha512-BFVSbdtg/7mJBw5kQFOPKFiA+SF7z3240HpzHN81Umm4Bp4dWkyx0msYn8+Q7/BBJiLQ4F6bi3Nftk58YA9r9w==",
+      "cpu": [
+        "x64",
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@yuuang/ffi-rs-win32-x64-msvc": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@yuuang/ffi-rs-win32-x64-msvc/-/ffi-rs-win32-x64-msvc-1.3.2.tgz",
+      "integrity": "sha512-ZL5MJ76n2rjwGo26kCWW7wK6QT/cee00Rx8pfW79pz6vM6jqfhoE7zTnwFiw4aOQUes9+HUc5DeeJ3z+Vb9oLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/abort-controller": {
@@ -2026,6 +2559,26 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ffi-rs": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/ffi-rs/-/ffi-rs-1.3.2.tgz",
+      "integrity": "sha512-4s8dX9VbBw/jd5NOuE3EJRqXaIVdjMyiumeeDzrOhtjQRwp6Bz2za7iksWXTnvTQKV/tTdm1s1w7mObe92zPjQ==",
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "@yuuang/ffi-rs-android-arm64": "1.3.2",
+        "@yuuang/ffi-rs-darwin-arm64": "1.3.2",
+        "@yuuang/ffi-rs-darwin-x64": "1.3.2",
+        "@yuuang/ffi-rs-linux-arm-gnueabihf": "1.3.2",
+        "@yuuang/ffi-rs-linux-arm64-gnu": "1.3.2",
+        "@yuuang/ffi-rs-linux-arm64-musl": "1.3.2",
+        "@yuuang/ffi-rs-linux-x64-gnu": "1.3.2",
+        "@yuuang/ffi-rs-linux-x64-musl": "1.3.2",
+        "@yuuang/ffi-rs-win32-arm64-msvc": "1.3.2",
+        "@yuuang/ffi-rs-win32-ia32-msvc": "1.3.2",
+        "@yuuang/ffi-rs-win32-x64-msvc": "1.3.2"
+      }
     },
     "node_modules/fflate": {
       "version": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matterailab/orbcode",
-  "version": "0.5.10",
+  "version": "0.6.0",
   "description": "OrbCode CLI — agentic coding in your terminal, powered by Axon models by MatterAI",
   "type": "module",
   "bin": {
@@ -36,6 +36,7 @@
     "test:attachments": "node --import tsx --test test/attachments.test.ts",
     "test:mcp": "node --import tsx --test test/mcp-client.test.ts",
     "test:plugins": "node --import tsx --test test/plugins.test.ts",
+    "test:search": "node --import tsx --test test/search-files.test.ts",
     "test:ui": "bun test test/ui-viewport.test.tsx",
     "prepublishOnly": "npm run typecheck && npm run build"
   },
@@ -51,16 +52,20 @@
     "open": "^10.1.0",
     "openai": "^4.78.0",
     "pdf-parse": "^2.4.5",
-    "picomatch": "^4.0.4",
+    "picomatch": "4.0.4",
     "react": "^19.2.0",
     "read-excel-file": "^9.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.17.0",
-    "@types/picomatch": "^3.0.1",
+    "@types/picomatch": "3.0.2",
     "@types/react": "^19.2.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"
+  },
+  "optionalDependencies": {
+    "@ff-labs/fff-node": "0.10.1",
+    "@vscode/ripgrep": "1.18.0"
   },
   "keywords": [
     "orbcode",

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -14,6 +14,7 @@ import { createLLMClient } from "../api/provider.js"
 import { buildSystemPrompt } from "../prompts/system.js"
 import {
 	describeToolCall,
+	disposeSearchFiles,
 	executeTool,
 	getActiveTools,
 	getApprovalKind,
@@ -22,6 +23,7 @@ import {
 import { walkFiles } from "../tools/executors/listFiles.js"
 import { previewFileChange } from "../tools/executors/files.js"
 import { extractFigmaUrls, figmaFetch } from "../tools/executors/figma.js"
+import { stripSearchPageMetadataForDisplay } from "../tools/executors/searchFiles/format.js"
 import type { AgentCallbacks, AgentEvent, ApprovalDecision } from "./events.js"
 import {
 	getSessionFilePath,
@@ -168,8 +170,10 @@ function contentToText(content: unknown): string {
 		.join("")
 }
 
-function resultPreview(text: string): string {
-	const lines = text.split("\n")
+function formatResultPreview(toolName: string, text: string): string {
+	const visibleText = toolName === "search_files" ? stripSearchPageMetadataForDisplay(text) : text
+	if (!visibleText) return ""
+	const lines = visibleText.split("\n")
 	return (
 		lines.slice(0, RESULT_PREVIEW_LINES).join("\n") +
 		(lines.length > RESULT_PREVIEW_LINES ? `\n… (${lines.length} lines)` : "")
@@ -291,7 +295,7 @@ function legacyTranscript(messages: OpenAI.Chat.ChatCompletionMessageParam[]): S
 				kind: "tool",
 				name: tool.name,
 				summary: tool.summary,
-				resultPreview: resultPreview(text),
+				resultPreview: formatResultPreview(tool.name, text),
 				isError,
 				diff: isError ? undefined : tool.diff,
 			})
@@ -419,7 +423,11 @@ export class Agent {
 
 	/** Visible history restored by the TUI, including reasoning and tools. */
 	get displayTranscript(): SessionTranscriptEntry[] {
-		return this.transcript.map((entry) => ({ ...entry }))
+		return this.transcript.map((entry) =>
+			entry.kind === "tool" && entry.name === "search_files"
+				? { ...entry, resultPreview: stripSearchPageMetadataForDisplay(entry.resultPreview) }
+				: { ...entry },
+		)
 	}
 
 	private recordTranscriptEvent(event: AgentEvent): void {
@@ -812,6 +820,11 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 			await this.mcp?.stop()
 		} catch {
 			// best-effort
+		}
+		try {
+			await disposeSearchFiles()
+		} catch {
+			// Search cleanup must not prevent the CLI from exiting.
 		}
 	}
 
@@ -1257,10 +1270,7 @@ User time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 			}
 		}
 
-		const previewLines = resultText.split("\n")
-		const resultPreview =
-			previewLines.slice(0, RESULT_PREVIEW_LINES).join("\n") +
-			(previewLines.length > RESULT_PREVIEW_LINES ? `\n… (${previewLines.length} lines)` : "")
+		const resultPreview = formatResultPreview(toolCall.name, resultText)
 
 		onEvent({
 			type: "tool-end",

--- a/src/prompts/system.ts
+++ b/src/prompts/system.ts
@@ -185,51 +185,25 @@ Command validity rules: a command is never empty, never just \`:\`, never a bare
 
 ## search_files
 
-The \`search_files\` tool allows you to search for patterns across files in a directory using regex.
+Search file contents using a Rust-compatible regex. Results are compact, limited to three matches per file, and paginated.
 
 ### Parameters
 
 1. **path** (string, required): Directory to search recursively, relative to workspace
 2. **regex** (string, required): Rust-compatible regular expression pattern
 3. **file_pattern** (string or null, required): Glob pattern to filter files OR null
+4. **cursor** (string or null, required): Copy the opaque cursor from the same search exactly, or pass JSON null without quotes for the first page
+5. **max_results** (integer or null, required): Target 1-100 results; null defaults to 50
+6. **context_lines** (integer or null, required): 0-2 surrounding lines; null defaults to 0
 
-### CRITICAL: file_pattern Must Be a String or null
-
-**The \`file_pattern\` parameter MUST ALWAYS be:**
-- A properly quoted string: \`"*.js"\`, \`"*.tsx"\`, \`"**/*.json"\`
-- OR explicitly \`null\` if you want to search all files
-
-**NEVER provide an unquoted value like \`*.js\` - this will cause a JSON parsing error.**
-
-### Correct Examples
-\`\`\`json
-// Search for "import" in all TypeScript files
-{
-  "path": "src",
-  "regex": "import.*from",
-  "file_pattern": "*.ts"
-}
-
-// Search for "TODO" in all files (no filter)
-{
-  "path": "src",
-  "regex": "TODO:",
-  "file_pattern": null
-}
-
-\`\`\`
-
-The regex uses Rust syntax (similar to PCRE); escape special characters like \`\\.\` and \`\\(\`. \`file_pattern\` uses glob syntax: \`"*.ts"\`, \`"*.{jsx,tsx}"\`, \`"**/*.json"\`. When in doubt, use \`null\` to search all files.
+Use zero context for discovery, then read the relevant file region. Reuse a cursor only with the same path, regex, and file pattern; never invent or edit one.
+If \`Next cursor\` is \`none\`, the search is complete: stop and never pass the word \`none\`. If a result says \`Restarted: yes\`, the FFF continuation failed and ripgrep restarted at page one, so account for repeated matches and continue only with the new cursor.
 
 ### Search Hygiene
 
 - Exclude test, spec, and mock paths from discovery searches by default (\`__tests__\`, \`*.spec.*\`, \`*.test.*\`, \`__mocks__\`) unless the task itself is about tests. They pollute results and bury the implementation you are looking for.
 - Scope \`path\` to the narrowest plausible directory instead of searching from the repository root.
 - If a search returns hundreds of hits, tighten the regex or \`file_pattern\` and search again. Do not scan through the dump.
-
-### Remember
-
-**Always quote the file_pattern value or use null. Never use bare/unquoted glob patterns.**
 
 ## Verifying tool results and avoiding loops
 

--- a/src/tools/executors/searchFiles.ts
+++ b/src/tools/executors/searchFiles.ts
@@ -1,108 +1,137 @@
 import * as fs from "node:fs"
-import * as path from "node:path"
-import picomatch from "picomatch"
 
 import { type ToolContext, type ToolResult, resolveWorkspacePath } from "../types.js"
+import { searchFilesWithFff, disposeFffSearch } from "./searchFiles/fff.js"
+import { formatSearchPage } from "./searchFiles/format.js"
+import { disposeRipgrepSearch, searchFilesWithRipgrep } from "./searchFiles/ripgrep.js"
+import {
+	createSearchFingerprint,
+	normalizeSearchFilePattern,
+	parseSearchOptions,
+	type SearchPage,
+} from "./searchFiles/types.js"
 
-const IGNORED_DIRS = new Set([
-	"node_modules",
-	".git",
-	"dist",
-	"build",
-	"out",
-	".next",
-	".turbo",
-	"__pycache__",
-	".venv",
-	"venv",
-])
+let disposalPromise: Promise<void> | undefined
+let activeSearches = 0
+let idlePromise: Promise<void> | undefined
+let resolveIdle: (() => void) | undefined
 
-const MAX_RESULTS = 300
-const MAX_FILE_SIZE = 2 * 1024 * 1024 // skip files over 2MB
-const MAX_LINE_LENGTH = 500
+async function acquireSearchOperation(): Promise<void> {
+	while (disposalPromise) {
+		try {
+			await disposalPromise
+		} catch {
+			// Cleanup errors are reported to the disposer; later sessions may retry.
+		}
+	}
+	activeSearches++
+}
+
+function releaseSearchOperation(): void {
+	activeSearches--
+	if (activeSearches === 0) {
+		resolveIdle?.()
+		resolveIdle = undefined
+		idlePromise = undefined
+	}
+}
+
+function waitForSearchOperations(): Promise<void> {
+	if (activeSearches === 0) return Promise.resolve()
+	if (!idlePromise) {
+		idlePromise = new Promise<void>((resolve) => {
+			resolveIdle = resolve
+		})
+	}
+	return idlePromise
+}
 
 export async function searchFiles(args: Record<string, unknown>, context: ToolContext): Promise<ToolResult> {
-	const dirPath = resolveWorkspacePath(context.cwd, String(args.path ?? "."))
-	const regexSource = String(args.regex ?? "")
-	const filePattern = args.file_pattern == null || args.file_pattern === "" ? null : String(args.file_pattern)
-
-	let regex: RegExp
+	await acquireSearchOperation()
 	try {
-		regex = new RegExp(regexSource)
+		const directoryPath = resolveWorkspacePath(context.cwd, String(args.path ?? "."))
+		if (typeof args.regex !== "string" || args.regex.length === 0) {
+			throw new Error("regex must be a non-empty string")
+		}
+		const regex = args.regex
+		const filePattern = normalizeSearchFilePattern(args.file_pattern)
+		if (!fs.existsSync(directoryPath) || !fs.statSync(directoryPath).isDirectory()) {
+			return { text: `Directory not found: ${directoryPath}`, isError: true }
+		}
+
+		const fingerprint = createSearchFingerprint(directoryPath, regex, filePattern)
+		const options = parseSearchOptions(args, fingerprint)
+		let page: SearchPage
+
+		if (options.cursor?.engine === "ripgrep") {
+			page = await searchFilesWithRipgrep(context.cwd, directoryPath, regex, filePattern, options)
+		} else {
+			try {
+				page = await searchFilesWithFff(context.cwd, directoryPath, regex, filePattern, options)
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error)
+				const restarted = options.cursor?.engine === "fff"
+				page = await searchFilesWithRipgrep(context.cwd, directoryPath, regex, filePattern, {
+					...options,
+					cursor: null,
+				})
+				page.warning = restarted
+					? `FFF continuation failed; ripgrep fallback restarted from the first page and may repeat earlier results (${message})`
+					: `FFF failed; used ripgrep fallback (${message})`
+				page.restarted = restarted
+			}
+		}
+
+		return { text: formatSearchPage(page) }
 	} catch (error) {
-		return { text: `Invalid regex: ${(error as Error).message}`, isError: true }
+		return { text: `Error searching files:\n${error instanceof Error ? error.message : String(error)}`, isError: true }
+	} finally {
+		releaseSearchOperation()
 	}
-
-	if (!fs.existsSync(dirPath)) {
-		return { text: `Directory not found: ${dirPath}`, isError: true }
-	}
-
-	// A bare pattern like "*.ts" should match at any depth, like ripgrep -g.
-	const isMatch = filePattern
-		? picomatch(filePattern.includes("/") ? filePattern : `**/${filePattern}`, { dot: true })
-		: () => true
-
-	const results: string[] = []
-	let matchCount = 0
-
-	const walk = (dir: string): void => {
-		if (matchCount >= MAX_RESULTS) return
-		let dirents: fs.Dirent[]
-		try {
-			dirents = fs.readdirSync(dir, { withFileTypes: true })
-		} catch {
-			return
-		}
-		for (const dirent of dirents) {
-			if (matchCount >= MAX_RESULTS) return
-			const full = path.join(dir, dirent.name)
-			if (dirent.isDirectory()) {
-				if (!IGNORED_DIRS.has(dirent.name) && !dirent.name.startsWith(".")) walk(full)
-				continue
-			}
-			// picomatch only understands forward slashes, so normalize Windows paths.
-			const rel = path.relative(dirPath, full).split(path.sep).join("/")
-			if (!isMatch(rel)) continue
-			let stat: fs.Stats
-			try {
-				stat = fs.statSync(full)
-			} catch {
-				continue
-			}
-			if (stat.size > MAX_FILE_SIZE) continue
-
-			let content: string
-			try {
-				content = fs.readFileSync(full, "utf8")
-			} catch {
-				continue
-			}
-			if (content.includes("\u0000")) continue // binary
-
-			const lines = content.split("\n")
-			const fileMatches: string[] = []
-			for (let i = 0; i < lines.length && matchCount < MAX_RESULTS; i++) {
-				if (regex.test(lines[i])) {
-					matchCount++
-					const lineText = lines[i].length > MAX_LINE_LENGTH ? lines[i].slice(0, MAX_LINE_LENGTH) + "…" : lines[i]
-					fileMatches.push(`  ${i + 1}: ${lineText}`)
-				}
-			}
-			if (fileMatches.length > 0) {
-				results.push(`${rel}\n${fileMatches.join("\n")}`)
-			}
-		}
-	}
-
-	walk(dirPath)
-
-	if (results.length === 0) {
-		return { text: `No matches found for "${regexSource}" in ${dirPath}.` }
-	}
-
-	let text = `Found ${matchCount} match${matchCount === 1 ? "" : "es"}:\n\n${results.join("\n\n")}`
-	if (matchCount >= MAX_RESULTS) {
-		text += `\n\n(Truncated at ${MAX_RESULTS} matches. Narrow your regex or file_pattern.)`
-	}
-	return { text }
 }
+
+export function disposeSearchFiles(): Promise<void> {
+	if (disposalPromise) return disposalPromise
+
+	let resolveDisposal!: () => void
+	let rejectDisposal!: (error: unknown) => void
+	const disposing = new Promise<void>((resolve, reject) => {
+		resolveDisposal = resolve
+		rejectDisposal = reject
+	})
+	disposalPromise = disposing
+	void (async () => {
+		await waitForSearchOperations()
+		const errors: unknown[] = []
+		try {
+			await disposeFffSearch()
+		} catch (error) {
+			errors.push(error)
+		}
+		try {
+			await disposeRipgrepSearch()
+		} catch (error) {
+			errors.push(error)
+		}
+		if (errors.length > 0) throw new AggregateError(errors, "Search cleanup failed")
+	})().then(resolveDisposal, rejectDisposal)
+	void disposing.then(
+		() => {
+			if (disposalPromise === disposing) disposalPromise = undefined
+		},
+		() => {
+			if (disposalPromise === disposing) disposalPromise = undefined
+		},
+	)
+	return disposing
+}
+
+export { formatSearchPage, stripSearchPageMetadataForDisplay } from "./searchFiles/format.js"
+export {
+	createSearchFingerprint,
+	normalizeNullableString,
+	normalizeSearchFilePattern,
+	parseSearchCursor,
+	parseSearchOptions,
+	serializeSearchCursor,
+} from "./searchFiles/types.js"

--- a/src/tools/executors/searchFiles/fff.ts
+++ b/src/tools/executors/searchFiles/fff.ts
@@ -1,0 +1,321 @@
+import * as path from "node:path"
+
+import type { FileFinder, GrepCursor, GrepMatch } from "@ff-labs/fff-node"
+
+import {
+	MAX_MATCHES_PER_FILE,
+	SEARCH_EXCLUDED_DIRECTORY_NAMES,
+	SEARCH_EXCLUDED_GLOBS,
+	type SearchContextLine,
+	type SearchMatch,
+	type SearchOptions,
+	type SearchPage,
+} from "./types.js"
+
+type FffModule = typeof import("@ff-labs/fff-node")
+
+const FINDER_INIT_TIMEOUT_MS = 10_000
+const FINDER_FAILURE_COOLDOWN_MS = 30_000
+
+const persistentFinders = new Map<string, Promise<FileFinder>>()
+const finderFailures = new Map<string, { retryAfter: number; message: string }>()
+const liveFinders = new Set<FileFinder>()
+let fffModulePromise: Promise<FffModule> | undefined
+let disposalPromise: Promise<void> | undefined
+let activeOperations = 0
+let idlePromise: Promise<void> | undefined
+let resolveIdle: (() => void) | undefined
+
+async function acquireFffOperation(): Promise<void> {
+	while (disposalPromise) {
+		try {
+			await disposalPromise
+		} catch {
+			// Cleanup failures are reported to the disposer. A later search may retry.
+		}
+	}
+	activeOperations++
+}
+
+function releaseFffOperation(): void {
+	activeOperations--
+	if (activeOperations === 0) {
+		resolveIdle?.()
+		resolveIdle = undefined
+		idlePromise = undefined
+	}
+}
+
+function waitForFffOperations(): Promise<void> {
+	if (activeOperations === 0) return Promise.resolve()
+	if (!idlePromise) {
+		idlePromise = new Promise<void>((resolve) => {
+			resolveIdle = resolve
+		})
+	}
+	return idlePromise
+}
+
+async function loadFffModule(): Promise<FffModule> {
+	if (!fffModulePromise) {
+		const loading = import("@ff-labs/fff-node")
+		fffModulePromise = loading
+		loading.catch(() => {
+			if (fffModulePromise === loading) fffModulePromise = undefined
+		})
+	}
+	return fffModulePromise
+}
+
+function destroyFinder(finder: FileFinder): void {
+	if (!finder.isDestroyed) finder.destroy()
+	liveFinders.delete(finder)
+}
+
+async function createFinder(basePath: string, watch: boolean): Promise<FileFinder> {
+	const { FileFinder } = await loadFffModule()
+	const created = FileFinder.create({
+		basePath,
+		aiMode: true,
+		disableWatch: !watch,
+		followSymlinks: false,
+	})
+	if (!created.ok) throw new Error(created.error)
+
+	const finder = created.value
+	liveFinders.add(finder)
+	try {
+		const ready = await finder.waitForScan(FINDER_INIT_TIMEOUT_MS)
+		if (!ready.ok || !ready.value) {
+			throw new Error(ready.ok ? `FFF initial scan timed out after ${FINDER_INIT_TIMEOUT_MS}ms` : ready.error)
+		}
+		return finder
+	} catch (error) {
+		try {
+			destroyFinder(finder)
+		} catch (cleanupError) {
+			throw new AggregateError([error, cleanupError], "FFF initialization and cleanup both failed")
+		}
+		throw error
+	}
+}
+
+async function getPersistentFinder(basePath: string): Promise<FileFinder> {
+	const normalized = path.resolve(basePath)
+	const failure = finderFailures.get(normalized)
+	if (failure && failure.retryAfter > Date.now()) throw new Error(failure.message)
+	if (failure) finderFailures.delete(normalized)
+
+	const cached = persistentFinders.get(normalized)
+	if (cached) return cached
+
+	const creating = createFinder(normalized, true)
+	persistentFinders.set(normalized, creating)
+	try {
+		const finder = await creating
+		finderFailures.delete(normalized)
+		return finder
+	} catch (error) {
+		if (persistentFinders.get(normalized) === creating) persistentFinders.delete(normalized)
+		const message = error instanceof Error ? error.message : String(error)
+		finderFailures.set(normalized, { retryAfter: Date.now() + FINDER_FAILURE_COOLDOWN_MS, message })
+		throw error
+	}
+}
+
+function isInsidePath(parent: string, child: string): boolean {
+	const relative = path.relative(parent, child)
+	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+}
+
+function isUnsafeFffPathConstraint(relativePath: string): boolean {
+	return /[\s*?[\]{}!]/.test(relativePath)
+}
+
+function isInsideExcludedDirectory(relativePath: string): boolean {
+	const excluded = new Set<string>(SEARCH_EXCLUDED_DIRECTORY_NAMES)
+	return relativePath.split("/").some((segment) => excluded.has(segment))
+}
+
+/** Protect regex tokens from FFF's inline path/glob constraint parser. */
+export function encodeRegexForFffQuery(regex: string): string {
+	let encoded = regex
+		.replace(/\\\//g, "\\x2F")
+		.replace(/\//g, "\\x2F")
+		.replace(/\r/g, "\\x0D")
+		.replace(/\n/g, "\\x0A")
+		.replace(/\t/g, "\\x09")
+		.replace(/\f/g, "\\x0C")
+		.replace(/\v/g, "\\x0B")
+		.replace(/ /g, "\\x20")
+	if (encoded.startsWith("!")) encoded = `\\x21${encoded.slice(1)}`
+	return encoded
+}
+
+function buildFffQuery(cwd: string, directoryPath: string, regex: string, filePattern?: string) {
+	const workspace = path.resolve(cwd)
+	const directory = path.resolve(directoryPath)
+	const workspaceRelative = path.relative(workspace, directory).split(path.sep).join("/")
+	const persistent =
+		isInsidePath(workspace, directory) &&
+		!isUnsafeFffPathConstraint(workspaceRelative) &&
+		!isInsideExcludedDirectory(workspaceRelative)
+	const basePath = persistent ? workspace : directory
+	const constraints: string[] = []
+
+	if (filePattern && /\s/.test(filePattern)) {
+		throw new Error("FFF cannot safely encode a whitespace-containing file pattern")
+	}
+	if (persistent && workspaceRelative) {
+		constraints.push(`${workspaceRelative}/**`)
+		if (filePattern?.startsWith("!")) {
+			const pattern = filePattern.slice(1)
+			constraints.push(pattern.includes("/") ? `!${workspaceRelative}/${pattern}` : filePattern)
+		} else if (filePattern?.includes("/")) constraints.push(`${workspaceRelative}/${filePattern}`)
+		else if (filePattern) constraints.push(filePattern)
+	} else if (filePattern) {
+		constraints.push(filePattern)
+	}
+	constraints.push(...SEARCH_EXCLUDED_GLOBS.map((glob) => `!${glob}`))
+
+	constraints.push(encodeRegexForFffQuery(regex))
+	return { basePath, directory, persistent, query: constraints.join(" ") }
+}
+
+function contextLines(lines: string[] | undefined, firstLine: number): SearchContextLine[] | undefined {
+	return lines?.length ? lines.map((text, index) => ({ line: firstLine + index, text })) : undefined
+}
+
+function toSearchMatch(cwd: string, basePath: string, match: GrepMatch): SearchMatch {
+	const before = match.contextBefore ?? []
+	return {
+		file: path.relative(cwd, path.join(basePath, match.relativePath)),
+		line: match.lineNumber,
+		column: match.col + 1,
+		text: match.lineContent,
+		isDefinition: match.isDefinition,
+		contextBefore: contextLines(before, match.lineNumber - before.length),
+		contextAfter: contextLines(match.contextAfter, match.lineNumber + 1),
+	}
+}
+
+function nativeCursor(offset: number): GrepCursor {
+	return { __brand: "GrepCursor", _offset: offset }
+}
+
+export async function searchFilesWithFff(
+	cwd: string,
+	directoryPath: string,
+	regex: string,
+	filePattern: string | undefined,
+	options: SearchOptions,
+): Promise<SearchPage> {
+	await acquireFffOperation()
+	let finder: FileFinder | undefined
+	let persistent = false
+
+	try {
+		if (options.cursor?.engine === "ripgrep") throw new Error("A ripgrep cursor cannot be continued by FFF")
+
+		const request = buildFffQuery(cwd, directoryPath, regex, filePattern)
+		persistent = request.persistent
+		finder = persistent ? await getPersistentFinder(request.basePath) : await createFinder(request.basePath, false)
+		let cursor = options.cursor ? nativeCursor(options.cursor.offset) : null
+		let nextCursor: GrepCursor | null = null
+		const matches: SearchMatch[] = []
+
+		for (let page = 0; page < 100 && matches.length < options.maxResults; page++) {
+			const result = finder.grep(request.query, {
+				mode: "regex",
+				cursor,
+				pageSize: options.maxResults - matches.length,
+				maxMatchesPerFile: MAX_MATCHES_PER_FILE,
+				beforeContext: options.contextLines,
+				afterContext: options.contextLines,
+				classifyDefinitions: true,
+				smartCase: false,
+			})
+			if (!result.ok) throw new Error(result.error)
+			if (result.value.regexFallbackError) throw new Error(result.value.regexFallbackError)
+
+			for (const match of result.value.items) {
+				const absolute = path.join(request.basePath, match.relativePath)
+				if (isInsidePath(request.directory, absolute)) matches.push(toSearchMatch(cwd, request.basePath, match))
+			}
+
+			nextCursor = result.value.nextCursor
+			if (!nextCursor || matches.length >= options.maxResults) break
+			cursor = nextCursor
+		}
+
+		return {
+			engine: "fff",
+			matches,
+			nextCursor: nextCursor
+				? { engine: "fff", offset: nextCursor._offset, fingerprint: options.fingerprint }
+				: null,
+		}
+	} finally {
+		try {
+			if (finder && !persistent) destroyFinder(finder)
+		} finally {
+			releaseFffOperation()
+		}
+	}
+}
+
+export function disposeFffSearch(): Promise<void> {
+	if (disposalPromise) return disposalPromise
+
+	let resolveDisposal!: () => void
+	let rejectDisposal!: (error: unknown) => void
+	const disposing = new Promise<void>((resolve, reject) => {
+		resolveDisposal = resolve
+		rejectDisposal = reject
+	})
+	disposalPromise = disposing
+
+	void (async () => {
+		await waitForFffOperations()
+		const cached = [...persistentFinders.values()]
+		persistentFinders.clear()
+		finderFailures.clear()
+		const errors: unknown[] = []
+
+		for (const finderPromise of cached) {
+			try {
+				destroyFinder(await finderPromise)
+			} catch (error) {
+				errors.push(error)
+			}
+		}
+		for (const finder of [...liveFinders]) {
+			try {
+				destroyFinder(finder)
+			} catch (error) {
+				errors.push(error)
+			}
+		}
+
+		if (liveFinders.size === 0 && fffModulePromise) {
+			try {
+				const fff = await fffModulePromise
+				fff.closeLibrary()
+				fffModulePromise = undefined
+			} catch (error) {
+				errors.push(error)
+			}
+		}
+		if (errors.length > 0) throw new AggregateError(errors, "FFF cleanup failed")
+	})().then(resolveDisposal, rejectDisposal)
+
+	void disposing.then(
+		() => {
+			if (disposalPromise === disposing) disposalPromise = undefined
+		},
+		() => {
+			if (disposalPromise === disposing) disposalPromise = undefined
+		},
+	)
+	return disposing
+}

--- a/src/tools/executors/searchFiles/format.ts
+++ b/src/tools/executors/searchFiles/format.ts
@@ -1,0 +1,66 @@
+import * as path from "node:path"
+
+import {
+	MAX_SEARCH_LINE_LENGTH,
+	type SearchContextLine,
+	type SearchMatch,
+	type SearchPage,
+	serializeSearchCursor,
+} from "./types.js"
+
+export function truncateSearchLine(line: string, maxLength = MAX_SEARCH_LINE_LENGTH): string {
+	const normalized = line.replace(/[\r\n]+$/g, "")
+	return normalized.length > maxLength ? `${normalized.slice(0, maxLength)} [truncated]` : normalized
+}
+
+function addContextLine(lines: Map<number, string>, contextLine: SearchContextLine): void {
+	if (!lines.has(contextLine.line)) {
+		lines.set(contextLine.line, `  ${contextLine.line} | ${truncateSearchLine(contextLine.text)}`)
+	}
+}
+
+/** Remove model-only pagination metadata before rendering a search result in the TUI. */
+export function stripSearchPageMetadataForDisplay(text: string): string {
+	const lines = text.split("\n")
+	let firstVisibleLine = 0
+	while (
+		firstVisibleLine < lines.length &&
+		/^(?:Engine|Matches|Next cursor|Restarted|Warning):/.test(lines[firstVisibleLine])
+	) {
+		firstVisibleLine++
+	}
+	while (firstVisibleLine < lines.length && lines[firstVisibleLine].trim() === "") firstVisibleLine++
+	return lines.slice(firstVisibleLine).join("\n")
+}
+
+export function formatSearchPage(page: SearchPage): string {
+	const cursor = serializeSearchCursor(page.nextCursor)
+	const nextCursor = cursor ?? "none (search complete; do not continue)"
+	const header = [`Engine: ${page.engine}`, `Matches: ${page.matches.length}`, `Next cursor: ${nextCursor}`]
+	if (page.restarted) header.push("Restarted: yes")
+	if (page.warning) header.push(`Warning: ${page.warning}`)
+	if (page.matches.length === 0) return header.join("\n")
+
+	const byFile = new Map<string, SearchMatch[]>()
+	for (const match of page.matches) {
+		const file = match.file.split(path.sep).join("/")
+		const existing = byFile.get(file)
+		if (existing) existing.push(match)
+		else byFile.set(file, [match])
+	}
+
+	const body: string[] = []
+	for (const [file, matches] of byFile) {
+		body.push(`# ${file}`)
+		const lines = new Map<number, string>()
+		for (const match of matches) {
+			for (const line of match.contextBefore ?? []) addContextLine(lines, line)
+			const definition = match.isDefinition ? " def" : ""
+			lines.set(match.line, `> ${match.line}:${match.column}${definition} | ${truncateSearchLine(match.text)}`)
+			for (const line of match.contextAfter ?? []) addContextLine(lines, line)
+		}
+		body.push(...[...lines.entries()].sort(([a], [b]) => a - b).map(([, value]) => value), "")
+	}
+
+	return `${header.join("\n")}\n\n${body.join("\n").trimEnd()}`
+}

--- a/src/tools/executors/searchFiles/ripgrep.ts
+++ b/src/tools/executors/searchFiles/ripgrep.ts
@@ -1,0 +1,303 @@
+import * as childProcess from "node:child_process"
+import { constants as fsConstants } from "node:fs"
+import * as fs from "node:fs/promises"
+import * as path from "node:path"
+import * as readline from "node:readline"
+
+import picomatch from "picomatch"
+
+import {
+	MAX_MATCHES_PER_FILE,
+	SEARCH_EXCLUDED_GLOBS,
+	type SearchContextLine,
+	type SearchMatch,
+	type SearchOptions,
+	type SearchPage,
+} from "./types.js"
+
+const activeProcesses = new Set<childProcess.ChildProcessWithoutNullStreams>()
+const cancelledProcesses = new WeakSet<childProcess.ChildProcessWithoutNullStreams>()
+let disposalPromise: Promise<void> | undefined
+let disposalEpoch = 0
+let activeOperations = 0
+let idlePromise: Promise<void> | undefined
+let resolveIdle: (() => void) | undefined
+
+function pathText(value: { text?: string } | undefined): string | undefined {
+	return value?.text
+}
+
+async function resolveRipgrepExecutables(): Promise<string[]> {
+	const executables: string[] = []
+	try {
+		const { rgPath } = await import("@vscode/ripgrep")
+		await fs.access(rgPath, fsConstants.X_OK)
+		executables.push(rgPath)
+	} catch {
+		// The optional bundled binary may be absent or unsupported on this host.
+	}
+	if (!executables.includes("rg")) executables.push("rg")
+	return executables
+}
+
+async function acquireRipgrepOperation(): Promise<number> {
+	while (disposalPromise) await disposalPromise
+	activeOperations++
+	return disposalEpoch
+}
+
+function releaseRipgrepOperation(): void {
+	activeOperations--
+	if (activeOperations === 0) {
+		resolveIdle?.()
+		resolveIdle = undefined
+		idlePromise = undefined
+	}
+}
+
+function waitForRipgrepOperations(): Promise<void> {
+	if (activeOperations === 0) return Promise.resolve()
+	if (!idlePromise) {
+		idlePromise = new Promise<void>((resolve) => {
+			resolveIdle = resolve
+		})
+	}
+	return idlePromise
+}
+
+function runRipgrep(
+	executable: string,
+	cwd: string,
+	directoryPath: string,
+	regex: string,
+	filePattern: string | undefined,
+	options: SearchOptions,
+): Promise<SearchPage> {
+	const offset = options.cursor?.engine === "ripgrep" ? options.cursor.offset : 0
+	const args = ["--json", "--no-messages", "--max-filesize", "10M", "--context", String(options.contextLines)]
+	if (filePattern && !filePattern.startsWith("!")) {
+		const basenamePattern = path.posix.basename(filePattern)
+		args.push("--type-add", `orbcode:${basenamePattern}`, "--type", "orbcode")
+	}
+	args.push(...SEARCH_EXCLUDED_GLOBS.flatMap((glob) => ["--glob", `!${glob}`]), "-e", regex, ".")
+	const negated = filePattern?.startsWith("!") ?? false
+	const patternBody = negated ? filePattern!.slice(1) : filePattern
+	const expandedPattern = patternBody?.includes("/") ? patternBody : patternBody ? `**/${patternBody}` : undefined
+	const matchesFile = expandedPattern ? picomatch(negated ? `!${expandedPattern}` : expandedPattern, { dot: true }) : () => true
+
+	return new Promise<SearchPage>((resolve, reject) => {
+		const rgProcess = childProcess.spawn(executable, args, { cwd: directoryPath, windowsHide: true })
+		activeProcesses.add(rgProcess)
+		const lines = readline.createInterface({ input: rgProcess.stdout, crlfDelay: Infinity })
+		const matches: SearchMatch[] = []
+		let currentFile: string | undefined
+		let currentFileMatches = false
+		let matchesSeenInFile = 0
+		let recentContext: SearchContextLine[] = []
+		let lastMatch: SearchMatch | undefined
+		let rawMatchesSeen = 0
+		let pageFull = false
+		let intentionallyKilled = false
+		let settled = false
+		let stderr = ""
+
+		const stop = () => {
+			if (intentionallyKilled) return
+			intentionallyKilled = true
+			lines.close()
+			rgProcess.kill()
+		}
+
+		rgProcess.stderr.on("data", (data) => {
+			stderr += data.toString()
+		})
+
+		lines.on("line", (rawLine) => {
+			if (!rawLine || intentionallyKilled) return
+			let parsed: any
+			try {
+				parsed = JSON.parse(rawLine)
+			} catch {
+				return
+			}
+
+			if (parsed.type === "begin") {
+				currentFile = pathText(parsed.data?.path)
+				const absoluteFile = currentFile
+					? path.isAbsolute(currentFile)
+						? currentFile
+						: path.resolve(directoryPath, currentFile)
+					: undefined
+				const relativeFile = absoluteFile
+					? path.relative(directoryPath, absoluteFile).split(path.sep).join("/")
+					: ""
+				currentFileMatches = Boolean(currentFile && matchesFile(relativeFile))
+				matchesSeenInFile = 0
+				recentContext = []
+				lastMatch = undefined
+				return
+			}
+			if (parsed.type === "end") {
+				if (pageFull) stop()
+				currentFile = undefined
+				currentFileMatches = false
+				matchesSeenInFile = 0
+				recentContext = []
+				lastMatch = undefined
+				return
+			}
+			if (!currentFile || !currentFileMatches || (parsed.type !== "match" && parsed.type !== "context")) return
+
+			const line = Number(parsed.data?.line_number)
+			const text = String(parsed.data?.lines?.text ?? "").replace(/[\r\n]+$/g, "")
+			if (!Number.isFinite(line)) return
+
+			if (parsed.type === "context") {
+				const context = { line, text }
+				if (lastMatch && line > lastMatch.line && line <= lastMatch.line + options.contextLines) {
+					lastMatch.contextAfter ??= []
+					if (lastMatch.contextAfter.length < options.contextLines) lastMatch.contextAfter.push(context)
+				}
+				recentContext.push(context)
+				if (recentContext.length > options.contextLines) recentContext.shift()
+				if (pageFull && (!lastMatch || (lastMatch.contextAfter?.length ?? 0) >= options.contextLines)) stop()
+				return
+			}
+
+			// Do not advance the raw cursor for a match that was not returned. This
+			// preserves an adjacent match when the previous page is collecting context.
+			if (pageFull || matches.length >= options.maxResults) {
+				stop()
+				return
+			}
+
+			rawMatchesSeen++
+			matchesSeenInFile++
+			if (rawMatchesSeen <= offset || matchesSeenInFile > MAX_MATCHES_PER_FILE) return
+
+			const absoluteFile = path.isAbsolute(currentFile) ? currentFile : path.resolve(directoryPath, currentFile)
+			const match: SearchMatch = {
+				file: path.relative(cwd, absoluteFile),
+				line,
+				column: Number(parsed.data?.submatches?.[0]?.start ?? 0) + 1,
+				text,
+				contextBefore: recentContext.filter(
+					(context) => context.line >= line - options.contextLines && context.line < line,
+				),
+			}
+			matches.push(match)
+			lastMatch = match
+			if (matches.length >= options.maxResults) {
+				pageFull = true
+				if (options.contextLines === 0) stop()
+			}
+		})
+
+		rgProcess.on("error", (error) => {
+			activeProcesses.delete(rgProcess)
+			if (settled) return
+			settled = true
+			reject(new Error(`ripgrep process error: ${error.message}`))
+		})
+		rgProcess.on("close", (code) => {
+			activeProcesses.delete(rgProcess)
+			if (settled) return
+			settled = true
+			if (cancelledProcesses.has(rgProcess)) {
+				reject(new Error("ripgrep search was cancelled during shutdown"))
+				return
+			}
+			if (!intentionallyKilled && code !== 0 && code !== 1) {
+				reject(new Error(`ripgrep process error: ${stderr.trim() || `exit code ${code}`}`))
+				return
+			}
+			resolve({
+				engine: "ripgrep",
+				matches,
+				nextCursor: pageFull
+					? { engine: "ripgrep", offset: rawMatchesSeen, fingerprint: options.fingerprint }
+					: null,
+			})
+		})
+	})
+}
+
+export async function searchFilesWithRipgrep(
+	cwd: string,
+	directoryPath: string,
+	regex: string,
+	filePattern: string | undefined,
+	options: SearchOptions,
+): Promise<SearchPage> {
+	const epoch = await acquireRipgrepOperation()
+	try {
+		const executables = await resolveRipgrepExecutables()
+		if (epoch !== disposalEpoch) throw new Error("ripgrep search was cancelled during shutdown")
+
+		let lastError: unknown
+		for (const executable of executables) {
+			try {
+				return await runRipgrep(executable, cwd, directoryPath, regex, filePattern, options)
+			} catch (error) {
+				lastError = error
+				if (epoch !== disposalEpoch) throw error
+			}
+		}
+		throw lastError ?? new Error("No ripgrep executable is available")
+	} finally {
+		releaseRipgrepOperation()
+	}
+}
+
+function terminateRipgrep(rgProcess: childProcess.ChildProcessWithoutNullStreams): Promise<void> {
+	if (rgProcess.exitCode !== null) return Promise.resolve()
+	cancelledProcesses.add(rgProcess)
+	return new Promise<void>((resolve) => {
+		let forceTimer: ReturnType<typeof setTimeout> | undefined
+		let capTimer: ReturnType<typeof setTimeout> | undefined
+		let finished = false
+		const done = () => {
+			if (finished) return
+			finished = true
+			if (forceTimer) clearTimeout(forceTimer)
+			if (capTimer) clearTimeout(capTimer)
+			resolve()
+		}
+		rgProcess.once("close", done)
+		rgProcess.once("error", done)
+		try {
+			rgProcess.kill()
+			forceTimer = setTimeout(() => {
+				try {
+					rgProcess.kill("SIGKILL")
+				} catch {
+					// The process may have exited between the timer firing and kill().
+				}
+			}, 250)
+			forceTimer.unref?.()
+			capTimer = setTimeout(done, 1000)
+			capTimer.unref?.()
+		} catch {
+			done()
+		}
+	})
+}
+
+export function disposeRipgrepSearch(): Promise<void> {
+	if (disposalPromise) return disposalPromise
+
+	let resolveDisposal!: () => void
+	const disposing = new Promise<void>((resolve) => {
+		resolveDisposal = resolve
+	})
+	disposalPromise = disposing
+	disposalEpoch++
+	void (async () => {
+		await Promise.all([...activeProcesses].map(terminateRipgrep))
+		await waitForRipgrepOperations()
+	})().then(resolveDisposal, resolveDisposal)
+	void disposing.then(() => {
+		if (disposalPromise === disposing) disposalPromise = undefined
+	})
+	return disposing
+}

--- a/src/tools/executors/searchFiles/types.ts
+++ b/src/tools/executors/searchFiles/types.ts
@@ -1,0 +1,129 @@
+import { createHash } from "node:crypto"
+import * as path from "node:path"
+
+export const DEFAULT_SEARCH_RESULTS = 50
+export const MAX_SEARCH_RESULTS = 100
+export const MAX_MATCHES_PER_FILE = 3
+export const MAX_SEARCH_CONTEXT_LINES = 2
+export const MAX_SEARCH_LINE_LENGTH = 300
+export const SEARCH_EXCLUDED_DIRECTORY_NAMES = [
+	"node_modules",
+	".git",
+	"dist",
+	"build",
+	"out",
+	".next",
+	".turbo",
+	"__pycache__",
+	".venv",
+	"venv",
+] as const
+export const SEARCH_EXCLUDED_GLOBS = SEARCH_EXCLUDED_DIRECTORY_NAMES.map((name) => `**/${name}/**`)
+
+export type SearchEngine = "fff" | "ripgrep"
+
+export interface SearchCursor {
+	engine: SearchEngine
+	offset: number
+	fingerprint: string
+}
+
+export interface SearchContextLine {
+	line: number
+	text: string
+}
+
+export interface SearchMatch {
+	file: string
+	line: number
+	column: number
+	text: string
+	isDefinition?: boolean
+	contextBefore?: SearchContextLine[]
+	contextAfter?: SearchContextLine[]
+}
+
+export interface SearchPage {
+	engine: SearchEngine
+	matches: SearchMatch[]
+	nextCursor: SearchCursor | null
+	warning?: string
+	restarted?: boolean
+}
+
+export interface SearchOptions {
+	cursor: SearchCursor | null
+	maxResults: number
+	contextLines: number
+	fingerprint: string
+}
+
+export function normalizeNullableString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined
+	const normalized = value.trim()
+	return normalized === "" || normalized.toLowerCase() === "null" ? undefined : normalized
+}
+
+export function normalizeSearchFilePattern(value: unknown): string | undefined {
+	const pattern = normalizeNullableString(value)
+	if (!pattern || pattern === "*") return undefined
+	return pattern.startsWith(".") && !pattern.includes("*") ? `*${pattern}` : pattern
+}
+
+function boundedInteger(value: unknown, name: string, fallback: number, min: number, max: number): number {
+	if (value == null || value === "" || (typeof value === "string" && value.trim().toLowerCase() === "null")) {
+		return fallback
+	}
+
+	const parsed = typeof value === "number" ? value : Number(value)
+	if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+		throw new Error(`${name} must be an integer from ${min} to ${max}, or null`)
+	}
+	return parsed
+}
+
+export function createSearchFingerprint(directoryPath: string, regex: string, filePattern?: string): string {
+	return createHash("sha256")
+		.update(JSON.stringify([path.resolve(directoryPath), regex, filePattern ?? null]))
+		.digest("hex")
+		.slice(0, 16)
+}
+
+export function parseSearchCursor(value: unknown, expectedFingerprint: string): SearchCursor | null {
+	if (value == null) return null
+	if (typeof value !== "string") {
+		throw new Error("search_files cursor must be the string returned by a previous search, or null")
+	}
+
+	const normalized = value.trim()
+	if (normalized === "" || normalized.toLowerCase() === "null") return null
+	if (normalized.toLowerCase() === "none") {
+		throw new Error("search_files reported no next cursor because the search is complete; do not continue it")
+	}
+
+	const match = /^(fff|ripgrep):(\d+):([a-f0-9]{16})$/.exec(normalized)
+	if (!match) {
+		throw new Error("search_files cursor is invalid; copy it exactly from a previous identical search")
+	}
+
+	const offset = Number(match[2])
+	if (!Number.isSafeInteger(offset)) throw new Error("search_files cursor offset is too large")
+	if (match[3] !== expectedFingerprint) {
+		throw new Error("search_files cursor belongs to a different path, regex, or file_pattern")
+	}
+
+	return { engine: match[1] as SearchEngine, offset, fingerprint: match[3] }
+}
+
+export function serializeSearchCursor(cursor: SearchCursor | null): string | null {
+	return cursor ? `${cursor.engine}:${cursor.offset}:${cursor.fingerprint}` : null
+}
+
+export function parseSearchOptions(args: Record<string, unknown>, fingerprint: string): SearchOptions {
+	return {
+		cursor: parseSearchCursor(args.cursor, fingerprint),
+		maxResults: boundedInteger(args.max_results, "max_results", DEFAULT_SEARCH_RESULTS, 1, MAX_SEARCH_RESULTS),
+		contextLines: boundedInteger(args.context_lines, "context_lines", 0, 0, MAX_SEARCH_CONTEXT_LINES),
+		fingerprint,
+	}
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,7 +4,7 @@ import { nativeTools } from "./schemas/index.js"
 import type { ToolContext, ToolResult } from "./types.js"
 import { fileEdit, fileWrite, multiFileEdit, readFile } from "./executors/files.js"
 import { listFiles } from "./executors/listFiles.js"
-import { searchFiles } from "./executors/searchFiles.js"
+import { disposeSearchFiles, normalizeSearchFilePattern, searchFiles } from "./executors/searchFiles.js"
 import { executeCommand } from "./executors/executeCommand.js"
 import { useSkill } from "./executors/skills.js"
 import { webFetch, webSearch } from "./executors/web.js"
@@ -13,6 +13,7 @@ import type { McpManager } from "../mcp/manager.js"
 
 export { nativeTools }
 export type { ToolContext, ToolResult }
+export { disposeSearchFiles }
 
 export type ApprovalKind = "none" | "edit" | "command"
 
@@ -57,8 +58,10 @@ export function describeToolCall(toolName: string, args: Record<string, unknown>
 			return String(args.command ?? "")
 		case "list_files":
 			return `${args.path ?? "."}${args.recursive ? " (recursive)" : ""}`
-		case "search_files":
-			return `/${args.regex ?? ""}/ in ${args.path ?? "."}${args.file_pattern ? ` (${args.file_pattern})` : ""}`
+		case "search_files": {
+			const pattern = normalizeSearchFilePattern(args.file_pattern)
+			return `/${args.regex ?? ""}/ in ${args.path ?? "."}${pattern ? ` · ${pattern}` : ""}`
+		}
 		case "web_search":
 			return String(args.query ?? "")
 		case "web_fetch":

--- a/src/tools/schemas/search_files.ts
+++ b/src/tools/schemas/search_files.ts
@@ -4,7 +4,8 @@ export default {
 	type: "function",
 	function: {
 		name: "search_files",
-		description: "Run a regex search across files under a directory, returning matches with surrounding context.",
+		description:
+			"Search file contents recursively under a directory using a Rust-compatible regex and optional file glob. Returns a compact, paginated page with at most three matches per file; use context_lines 0 for discovery, then read the relevant file. Continue only with the opaque cursor returned by the same path, regex, and file_pattern; pass JSON null without quotes for the first page. If Next cursor is none, the search is complete: stop and never pass the word none. A rare FFF continuation failure may restart with ripgrep and is marked Restarted: yes.",
 		strict: true,
 		parameters: {
 			type: "object",
@@ -15,14 +16,32 @@ export default {
 				},
 				regex: {
 					type: "string",
+					minLength: 1,
 					description: "Rust-compatible regular expression pattern to match",
 				},
 				file_pattern: {
-					type: ["string"],
-					description: "String glob to limit which files are searched (e.g., '*.ts')",
+					type: ["string", "null"],
+					description: "Glob limiting searched files (e.g. '*.ts'), or null for all files",
+				},
+				cursor: {
+					type: ["string", "null"],
+					description:
+						"Opaque continuation cursor copied exactly from a previous identical search, or JSON null for the first page",
+				},
+				max_results: {
+					type: ["integer", "null"],
+					minimum: 1,
+					maximum: 100,
+					description: "Target results for this page; null uses 50",
+				},
+				context_lines: {
+					type: ["integer", "null"],
+					minimum: 0,
+					maximum: 2,
+					description: "Context lines before and after each match; null uses 0",
 				},
 			},
-			required: ["path", "regex", "file_pattern"],
+			required: ["path", "regex", "file_pattern", "cursor", "max_results", "context_lines"],
 			additionalProperties: false,
 		},
 	},

--- a/test/search-files.test.ts
+++ b/test/search-files.test.ts
@@ -1,0 +1,365 @@
+import assert from "node:assert/strict"
+import { after, test } from "node:test"
+import * as fs from "node:fs/promises"
+import * as os from "node:os"
+import * as path from "node:path"
+
+import {
+	createSearchFingerprint,
+	disposeSearchFiles,
+	formatSearchPage,
+	parseSearchCursor,
+	searchFiles,
+	stripSearchPageMetadataForDisplay,
+} from "../src/tools/executors/searchFiles.js"
+import { describeToolCall } from "../src/tools/index.js"
+
+const roots: string[] = []
+
+async function fixture(): Promise<string> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), "orbcode-search-"))
+	roots.push(root)
+	await fs.mkdir(path.join(root, "src"))
+	await fs.writeFile(path.join(root, "src", "alpha.ts"), "const needle = 1\nneedle += 1\n")
+	await fs.writeFile(path.join(root, "src", "notes.md"), "needle in markdown\n")
+	await fs.writeFile(path.join(root, "outside.ts"), "needle outside scope\n")
+	return root
+}
+
+after(async () => {
+	await disposeSearchFiles().catch(() => {})
+	await Promise.all(roots.map((root) => fs.rm(root, { recursive: true, force: true })))
+})
+
+test("uses FFF by default with compact file filtering", async () => {
+	const cwd = await fixture()
+	const result = await searchFiles(
+		{ path: "src", regex: "needle", file_pattern: "*.ts", cursor: "null", max_results: 50, context_lines: 0 },
+		{ cwd, token: "", getTodos: () => "", setTodos: () => {} },
+	)
+
+	assert.equal(result.isError, undefined)
+	assert.match(result.text, /^Engine: fff/m)
+	assert.match(result.text, /# src\/alpha\.ts/)
+	assert.doesNotMatch(result.text, /notes\.md/)
+	assert.doesNotMatch(result.text, /outside\.ts/)
+})
+
+test("continues native FFF pagination without dropping matches", async () => {
+	const cwd = await fixture()
+	await fs.writeFile(path.join(cwd, "src", "beta.ts"), "const needle = 2\n")
+	const context = { cwd, token: "", getTodos: () => "", setTodos: () => {} }
+	const args = {
+		path: "src",
+		regex: "needle",
+		file_pattern: "*.ts",
+		cursor: null as string | null,
+		max_results: 1,
+		context_lines: 0,
+	}
+	const first = await searchFiles(args, context)
+	assert.match(first.text, /^Engine: fff/m)
+	const cursor = /^Next cursor: (fff:\S+)$/m.exec(first.text)?.[1]
+	assert.ok(cursor)
+
+	const second = await searchFiles({ ...args, cursor }, context)
+	assert.match(second.text, /^Engine: fff/m)
+	assert.match(`${first.text}\n${second.text}`, /src\/alpha\.ts/)
+	assert.match(`${first.text}\n${second.text}`, /src\/beta\.ts/)
+})
+
+test("treats route-directory metacharacters literally and anchors nested globs to path", async () => {
+	const cwd = await fixture()
+	await fs.mkdir(path.join(cwd, "src", "components"))
+	await fs.writeFile(path.join(cwd, "src", "components", "plain.ts"), "const routeNeedle = true\n")
+	const context = { cwd, token: "", getTodos: () => "", setTodos: () => {} }
+	const normal = await searchFiles(
+		{
+			path: "src",
+			regex: "routeNeedle",
+			file_pattern: "components/*.ts",
+			cursor: null,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+	assert.match(normal.text, /components\/plain\.ts/)
+
+	const route = path.join(cwd, "src", "routes", "[id]")
+	await fs.mkdir(path.join(route, "components"), { recursive: true })
+	await fs.writeFile(path.join(route, "components", "view.ts"), "const routeNeedle = true\n")
+	await fs.writeFile(path.join(route, "other.ts"), "const routeNeedle = false\n")
+
+	const result = await searchFiles(
+		{
+			path: "src/routes/[id]",
+			regex: "routeNeedle",
+			file_pattern: "components/*.ts",
+			cursor: null,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+
+	assert.equal(result.isError, undefined)
+	assert.match(result.text, /^Engine: fff/m)
+	assert.match(result.text, /components\/view\.ts/)
+	assert.doesNotMatch(result.text, /other\.ts/)
+})
+
+test("binds opaque cursors to the originating search", () => {
+	const fingerprint = createSearchFingerprint("/workspace/src", "needle", "*.ts")
+	const cursor = `fff:42:${fingerprint}`
+	assert.deepEqual(parseSearchCursor(cursor, fingerprint), { engine: "fff", offset: 42, fingerprint })
+	assert.throws(
+		() => parseSearchCursor(cursor, createSearchFingerprint("/workspace/src", "different", "*.ts")),
+		/different path, regex, or file_pattern/,
+	)
+	assert.equal(parseSearchCursor(" NULL ", fingerprint), null)
+	assert.throws(() => parseSearchCursor("none", fingerprint), /search is complete/)
+})
+
+test("rejects fractional result and context limits", async () => {
+	const cwd = await fixture()
+	const result = await searchFiles(
+		{ path: "src", regex: "needle", file_pattern: "*.ts", cursor: null, max_results: 1.5, context_lines: 0 },
+		{ cwd, token: "", getTodos: () => "", setTodos: () => {} },
+	)
+	assert.equal(result.isError, true)
+	assert.match(result.text, /max_results must be an integer/)
+})
+
+test("ripgrep preserves ignores, normalized patterns, and path-relative nested globs", async () => {
+	const cwd = await fixture()
+	await fs.mkdir(path.join(cwd, ".git"))
+	await fs.mkdir(path.join(cwd, "node_modules", "dep"), { recursive: true })
+	await fs.mkdir(path.join(cwd, "components"))
+	await fs.writeFile(path.join(cwd, ".gitignore"), "ignored.ts\n")
+	await fs.writeFile(path.join(cwd, "ignored.ts"), "needle ignored\n")
+	await fs.writeFile(path.join(cwd, "node_modules", "dep", "index.ts"), "needle dependency\n")
+	await fs.writeFile(path.join(cwd, "components", "view.ts"), "needle component\n")
+	const context = { cwd, token: "", getTodos: () => "", setTodos: () => {} }
+
+	const allFingerprint = createSearchFingerprint(cwd, "needle", undefined)
+	const all = await searchFiles(
+		{
+			path: ".",
+			regex: "needle",
+			file_pattern: null,
+			cursor: `ripgrep:0:${allFingerprint}`,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+	assert.equal(all.isError, undefined)
+	assert.match(all.text, /^Engine: ripgrep/m)
+	assert.match(all.text, /components\/view\.ts/)
+	assert.doesNotMatch(all.text, /ignored\.ts|node_modules/)
+
+	const nestedPattern = "components/*.ts"
+	const nestedFingerprint = createSearchFingerprint(cwd, "needle", nestedPattern)
+	const nested = await searchFiles(
+		{
+			path: ".",
+			regex: "needle",
+			file_pattern: nestedPattern,
+			cursor: `ripgrep:0:${nestedFingerprint}`,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+	assert.equal(nested.isError, undefined)
+	assert.match(nested.text, /components\/view\.ts/)
+	assert.doesNotMatch(nested.text, /src\/alpha\.ts/)
+
+	const extensionPattern = "*.ts"
+	const extensionFingerprint = createSearchFingerprint(cwd, "needle", extensionPattern)
+	const extension = await searchFiles(
+		{
+			path: ".",
+			regex: "needle",
+			file_pattern: ".ts",
+			cursor: `ripgrep:0:${extensionFingerprint}`,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+	assert.equal(extension.isError, undefined)
+	assert.match(extension.text, /components\/view\.ts/)
+	assert.doesNotMatch(extension.text, /ignored\.ts|notes\.md|node_modules/)
+})
+
+test("keeps generated-directory exclusions and negative globs consistent across engines", async () => {
+	const cwd = await fixture()
+	for (const directory of ["dist", "build", "out"]) {
+		await fs.mkdir(path.join(cwd, directory))
+		await fs.writeFile(path.join(cwd, directory, "generated.ts"), "excludedNeedle generated\n")
+	}
+	await fs.mkdir(path.join(cwd, "src", "components"))
+	await fs.writeFile(path.join(cwd, "src", "keep.ts"), "excludedNeedle keep\nnegativeNeedle keep\n")
+	await fs.writeFile(path.join(cwd, "src", "components", "skip.ts"), "negativeNeedle component\n")
+	await fs.writeFile(path.join(cwd, "src", "negative.md"), "negativeNeedle markdown\n")
+	const context = { cwd, token: "", getTodos: () => "", setTodos: () => {} }
+
+	const fff = await searchFiles(
+		{ path: ".", regex: "excludedNeedle", file_pattern: "*.ts", cursor: null, max_results: 50, context_lines: 0 },
+		context,
+	)
+	assert.match(fff.text, /^Engine: fff/m)
+	assert.match(fff.text, /src\/keep\.ts/)
+	assert.doesNotMatch(fff.text, /dist|build|out/)
+
+	const rgFingerprint = createSearchFingerprint(cwd, "excludedNeedle", "*.ts")
+	const rg = await searchFiles(
+		{
+			path: ".",
+			regex: "excludedNeedle",
+			file_pattern: "*.ts",
+			cursor: `ripgrep:0:${rgFingerprint}`,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+	assert.match(rg.text, /src\/keep\.ts/)
+	assert.doesNotMatch(rg.text, /dist|build|out/)
+
+	const explicitDist = await searchFiles(
+		{ path: "dist", regex: "excludedNeedle", file_pattern: "*.ts", cursor: null, max_results: 50, context_lines: 0 },
+		context,
+	)
+	assert.match(explicitDist.text, /^Engine: fff/m)
+	assert.match(explicitDist.text, /dist\/generated\.ts/)
+	const explicitDistFingerprint = createSearchFingerprint(path.join(cwd, "dist"), "excludedNeedle", "*.ts")
+	const explicitDistRg = await searchFiles(
+		{
+			path: "dist",
+			regex: "excludedNeedle",
+			file_pattern: "*.ts",
+			cursor: `ripgrep:0:${explicitDistFingerprint}`,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+	assert.match(explicitDistRg.text, /dist\/generated\.ts/)
+
+	const pathNegation = await searchFiles(
+		{
+			path: "src",
+			regex: "negativeNeedle",
+			file_pattern: "!components/**",
+			cursor: null,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+	assert.match(pathNegation.text, /^Engine: fff/m)
+	assert.match(pathNegation.text, /src\/keep\.ts/)
+	assert.doesNotMatch(pathNegation.text, /components\/skip\.ts/)
+
+	const extensionNegation = "!*.md"
+	const negationFingerprint = createSearchFingerprint(path.join(cwd, "src"), "negativeNeedle", extensionNegation)
+	const rgNegation = await searchFiles(
+		{
+			path: "src",
+			regex: "negativeNeedle",
+			file_pattern: extensionNegation,
+			cursor: `ripgrep:0:${negationFingerprint}`,
+			max_results: 50,
+			context_lines: 0,
+		},
+		context,
+	)
+	assert.match(rgNegation.text, /src\/keep\.ts/)
+	assert.doesNotMatch(rgNegation.text, /negative\.md/)
+})
+
+test("ripgrep pagination preserves an adjacent match on the next page", async () => {
+	const cwd = await fixture()
+	const directory = path.join(cwd, "paging")
+	await fs.mkdir(directory)
+	await fs.writeFile(path.join(directory, "adjacent.ts"), "needle one\nneedle two\nend\n")
+	const context = { cwd, token: "", getTodos: () => "", setTodos: () => {} }
+	const fingerprint = createSearchFingerprint(directory, "needle", "*.ts")
+	const args = {
+		path: "paging",
+		regex: "needle",
+		file_pattern: "*.ts",
+		cursor: `ripgrep:0:${fingerprint}` as string | null,
+		max_results: 1,
+		context_lines: 1,
+	}
+
+	const first = await searchFiles(args, context)
+	assert.equal(first.isError, undefined)
+	assert.match(first.text, /^Engine: ripgrep/m)
+	assert.match(first.text, /> 1:1 /)
+	const cursor = /^Next cursor: (\S+)$/m.exec(first.text)?.[1]
+	assert.ok(cursor)
+
+	const second = await searchFiles({ ...args, cursor }, context)
+	assert.equal(second.isError, undefined)
+	assert.match(second.text, /> 2:1 /)
+})
+
+test("makes completed searches and tool summaries unambiguous", () => {
+	const completed = formatSearchPage({ engine: "fff", matches: [], nextCursor: null })
+	assert.match(completed, /Next cursor: none \(search complete; do not continue\)/)
+	assert.equal(stripSearchPageMetadataForDisplay(completed), "")
+	const page = formatSearchPage({
+		engine: "fff",
+		matches: [{ file: "src/a.ts", line: 4, column: 2, text: "needle" }],
+		nextCursor: { engine: "fff", offset: 2, fingerprint: "0123456789abcdef" },
+	})
+	const visiblePage = stripSearchPageMetadataForDisplay(page)
+	assert.doesNotMatch(visiblePage, /Engine:|Matches:|Next cursor:/)
+	assert.match(visiblePage, /# src\/a\.ts\n> 4:2 \| needle/)
+	assert.equal(
+		describeToolCall("search_files", { path: "src", regex: "eido", file_pattern: "*.ts" }),
+		"/eido/ in src · *.ts",
+	)
+	assert.equal(describeToolCall("search_files", { path: "src", regex: "eido", file_pattern: "null" }), "/eido/ in src")
+})
+
+test("marks and safely drains an FFF continuation fallback during cleanup", async () => {
+	const cwd = await fixture()
+	await fs.writeFile(path.join(cwd, "space file.ts"), "needle spaced\n")
+	const filePattern = "space *.ts"
+	const fingerprint = createSearchFingerprint(cwd, "needle", filePattern)
+	const pending = searchFiles(
+		{
+			path: ".",
+			regex: "needle",
+			file_pattern: filePattern,
+			cursor: `fff:1:${fingerprint}`,
+			max_results: 50,
+			context_lines: 0,
+		},
+		{ cwd, token: "", getTodos: () => "", setTodos: () => {} },
+	)
+	const disposing = disposeSearchFiles()
+	const result = await pending
+	await disposing
+	assert.equal(result.isError, undefined)
+	assert.match(result.text, /^Engine: ripgrep/m)
+	assert.match(result.text, /^Restarted: yes$/m)
+	assert.match(result.text, /space file\.ts/)
+})
+
+test("can initialize FFF again after session cleanup", async () => {
+	const cwd = await fixture()
+	const args = { path: "src", regex: "needle", file_pattern: "*.ts", cursor: null, max_results: 50, context_lines: 0 }
+	const context = { cwd, token: "", getTodos: () => "", setTodos: () => {} }
+	const first = await searchFiles(args, context)
+	assert.match(first.text, /^Engine: fff/m)
+	await disposeSearchFiles()
+	const second = await searchFiles(args, context)
+	assert.match(second.text, /^Engine: fff/m)
+})


### PR DESCRIPTION
## Release v0.6.0

`search_files` rewrite: FFF-first engine with ripgrep fallback, compact paginated results, and clean shutdown.

### Highlights

- **FFF-first `search_files` with ripgrep fallback.** The native tool now runs through FFF (`@ff-labs/fff-node`), a persistent watched file finder with an in-memory workspace index, and falls back to the bundled `@vscode/ripgrep` binary (or system `rg`) when FFF is unavailable or a continuation fails. A rare FFF continuation failure restarts from page one with ripgrep and is flagged `Restarted: yes` so repeated matches can be accounted for.
- **Compact, paginated results.** At most three matches per file, capped at 100 per page, paginated via an opaque `cursor` fingerprint-bound to the originating path/regex/`file_pattern`. Passing the literal word `none` is rejected so a completed search can't be continued.
- **New parameters.** `cursor` (opaque token or null), `max_results` (1–100, default 50), `context_lines` (0–2, default 0) replace the old fixed 300-match dump. `file_pattern` now accepts `null` for all files.
- **Clean shutdown.** `disposeSearchFiles` drains in-flight FFF/ripgrep operations, destroys persistent finders, and tears down child processes (SIGKILL escalation) so no `rg` process or FFF library leaks.
- **TUI cleanup.** Pagination metadata is stripped from result previews and the restored display transcript.
- **Tests.** `test/search-files.test.ts` (11 tests) covers FFF selection, pagination continuity, cursor binding, ripgrep consistency, fallback during cleanup, and post-cleanup re-init. Exposed via `npm run test:search`.

### Versioning

Minor bump (new tool parameters and behavior).

### Pre-release checklist

- [x] `npm run typecheck` passes
- [x] `npm run test:search` passes (11/11)
- [x] `package.json` version bumped to `0.6.0`
- [x] `CHANGELOG.md` entry added
- [x] `0.6.0` not yet published to npm (latest is `0.5.10`)

### After merge

Per `RELEASE.md`, tag the merge commit on `main` and push the tag to trigger the publish workflow:

```bash
git checkout main && git pull
git tag v0.6.0
git push origin v0.6.0
```